### PR TITLE
feat(localization): add backend i18n module with translations API and caching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,6 @@ report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json
 
 # Husky internal bootstrap directory (auto-generated, not hand-edited)
 .husky/_/
+
+# Local PR / commit message drafts (not tracked)
+pr.md

--- a/package-lock.json
+++ b/package-lock.json
@@ -335,7 +335,6 @@
       "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.27.3.tgz",
       "integrity": "sha512-IjLt0gd3L4jlOfilxVXTifn42FnVffMgDC04RJK1KDZpmkBWLv0XC92MVVmkxrFZNS/7l3xWgP/I3nqtX1sQHw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/node": "^18.11.18",
         "@types/node-fetch": "^2.6.4",
@@ -351,7 +350,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
       "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -360,8 +358,7 @@
       "version": "5.26.5",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
       "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@apollo/cache-control-types": {
       "version": "1.0.3",
@@ -2066,7 +2063,6 @@
       "integrity": "sha512-UvFa/vR+e19XookZF8RzFZBrw2EUkQWxiBW0yYQAhvk3C+QVGl0H3ouca8LDBlBfQKXwmW3huo/59H8rwb1wJw==",
       "license": "Apache-2.0",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "tslib": "^2.3.1"
       }
@@ -2143,6 +2139,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -2660,7 +2657,6 @@
       "resolved": "https://registry.npmjs.org/@browserbasehq/sdk/-/sdk-2.6.0.tgz",
       "integrity": "sha512-83iXP5D7xMm8Wyn66TUaUrgoByCmAJuoMoZQI3sGg3JAiMlTfnCIMqyVBoNSaItaPIkaCnrsj6LiusmXV2X9YA==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@types/node": "^18.11.18",
         "@types/node-fetch": "^2.6.4",
@@ -2676,7 +2672,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
       "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -2685,8 +2680,7 @@
       "version": "5.26.5",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
       "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@browserbasehq/stagehand": {
       "version": "1.14.0",
@@ -2722,8 +2716,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/@cfworker/json-schema/-/json-schema-4.1.1.tgz",
       "integrity": "sha512-gAmrUZSGtKc3AiBL71iNWxDsyUC5uMaKKGdvzYsBoTW/xi42JQHl7eKV2OYzCUqvc+D2RCcf7EXY2iCyFIk6og==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@colors/colors": {
       "version": "1.5.0",
@@ -3028,6 +3021,7 @@
       "resolved": "https://registry.npmjs.org/@elastic/elasticsearch/-/elasticsearch-8.19.1.tgz",
       "integrity": "sha512-+1j9NnQVOX+lbWB8LhCM7IkUmjU05Y4+BmSLfusq0msCsQb1Va+OUKFCoOXjCJqQrcgdRdQCjYYyolQ/npQALQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@elastic/transport": "^8.9.6",
         "apache-arrow": "18.x - 21.x",
@@ -3252,6 +3246,7 @@
       "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.8.0.tgz",
       "integrity": "sha512-rc1hOQtjIWGxcxpb9aHAfLpIctjEnsDehj0DAiVfBlmT84uvR0uUtN2hEi/ecvWVjXUGf5qPF4qEgiLOx1YIMQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "lodash.camelcase": "^4.3.0",
         "long": "^5.0.0",
@@ -3291,6 +3286,7 @@
       "resolved": "https://registry.npmjs.org/@huggingface/inference/-/inference-4.13.13.tgz",
       "integrity": "sha512-kxa3hkQEgD/B2x6QTZQBnu4Wx/Uc7pOAqmLS8T3VkTM4weshJzaeYH/nEDKGuChUKJza0IglytRViSCiT8KLjg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@huggingface/jinja": "^0.5.5",
         "@huggingface/tasks": "^0.19.85"
@@ -3388,7 +3384,6 @@
       "resolved": "https://registry.npmjs.org/@ibm-cloud/watsonx-ai/-/watsonx-ai-1.7.8.tgz",
       "integrity": "sha512-UpU/hTHRrCwzkqV1+H/CGbHIGRKty6SX1Aea2CBbyRonsEPIPQtFfhz8FHhs+o6Ca/TCupHNlcLAQUFektZmEQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@types/node": "^18.0.0",
         "extend": "3.0.2",
@@ -3404,7 +3399,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
       "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -3413,8 +3407,7 @@
       "version": "5.26.5",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
       "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@img/colour": {
       "version": "1.0.0",
@@ -5264,7 +5257,6 @@
         "https://github.com/sponsors/ctavan"
       ],
       "license": "MIT",
-      "peer": true,
       "bin": {
         "uuid": "dist/bin/uuid"
       }
@@ -5471,19 +5463,6 @@
         "ioredis": ">=5.0.0"
       }
     },
-    "node_modules/@nestjs-modules/ioredis/node_modules/@nestjs/axios": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/@nestjs/axios/-/axios-3.1.3.tgz",
-      "integrity": "sha512-RZ/63c1tMxGLqyG3iOCVt7A72oy4x1eM6QEhd4KzCYpaVWW0igq0WSREeRoEZhIxRcZfDfIIkvsOMiM7yfVGZQ==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "peerDependencies": {
-        "@nestjs/common": "^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0",
-        "axios": "^1.3.1",
-        "rxjs": "^6.0.0 || ^7.0.0"
-      }
-    },
     "node_modules/@nestjs-modules/ioredis/node_modules/@nestjs/terminus": {
       "version": "10.2.0",
       "resolved": "https://registry.npmjs.org/@nestjs/terminus/-/terminus-10.2.0.tgz",
@@ -5555,32 +5534,6 @@
         }
       }
     },
-    "node_modules/@nestjs-modules/ioredis/node_modules/@nestjs/typeorm": {
-      "version": "10.0.2",
-      "resolved": "https://registry.npmjs.org/@nestjs/typeorm/-/typeorm-10.0.2.tgz",
-      "integrity": "sha512-H738bJyydK4SQkRCTeh1aFBxoO1E9xdL/HaLGThwrqN95os5mEyAtK7BLADOS+vldP4jDZ2VQPLj4epWwRqCeQ==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "uuid": "9.0.1"
-      },
-      "peerDependencies": {
-        "@nestjs/common": "^8.0.0 || ^9.0.0 || ^10.0.0",
-        "@nestjs/core": "^8.0.0 || ^9.0.0 || ^10.0.0",
-        "reflect-metadata": "^0.1.13 || ^0.2.0",
-        "rxjs": "^7.2.0",
-        "typeorm": "^0.3.0"
-      }
-    },
-    "node_modules/@nestjs-modules/ioredis/node_modules/reflect-metadata": {
-      "version": "0.1.14",
-      "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.14.tgz",
-      "integrity": "sha512-ZhYeb6nRaXCfhnndflDK8qI6ZQ/YcWZCISRAWICW9XYqMUwjZM9Z0DveWX/ABN01oxSHwVxKQmxeYZSsm0jh5A==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true
-    },
     "node_modules/@nestjs-modules/ioredis/node_modules/uuid": {
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
@@ -5591,7 +5544,6 @@
       ],
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "bin": {
         "uuid": "dist/bin/uuid"
       }
@@ -5634,6 +5586,7 @@
       "resolved": "https://registry.npmjs.org/@nestjs/axios/-/axios-4.0.1.tgz",
       "integrity": "sha512-68pFJgu+/AZbWkGu65Z3r55bTsCPlgyKaV4BSG8yUAD72q1PPuyVRgUwFv6BxdnibTUHlyxm06FmYWNC+bjN7A==",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@nestjs/common": "^10.0.0 || ^11.0.0",
         "axios": "^1.3.1",
@@ -5890,6 +5843,7 @@
       "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-10.4.22.tgz",
       "integrity": "sha512-fxJ4v85nDHaqT1PmfNCQ37b/jcv2OojtXTaK1P2uAXhzLf9qq6WNUOFvxBrV4fhQek1EQoT1o9oj5xAZmv3NRw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "file-type": "20.4.1",
         "iterare": "1.2.1",
@@ -5948,6 +5902,7 @@
       "integrity": "sha512-6IX9+VwjiKtCjx+mXVPncpkQ5ZjKfmssOZPFexmT+6T9H9wZ3svpYACAo7+9e7Nr9DZSoRZw3pffkJP7Z0UjaA==",
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@nuxtjs/opencollective": "0.3.2",
         "fast-safe-stringify": "2.1.1",
@@ -6009,6 +5964,7 @@
       "resolved": "https://registry.npmjs.org/@nestjs/graphql/-/graphql-12.2.2.tgz",
       "integrity": "sha512-lUDy/1uqbRA1kBKpXcmY0aHhcPbfeG52Wg5+9Jzd1d57dwSjCAmuO+mWy5jz9ugopVCZeK0S/kdAMvA+r9fNdA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@graphql-tools/merge": "9.0.11",
         "@graphql-tools/schema": "10.0.10",
@@ -6218,6 +6174,7 @@
       "resolved": "https://registry.npmjs.org/@nestjs/platform-express/-/platform-express-10.4.22.tgz",
       "integrity": "sha512-ySSq7Py/DFozzZdNDH67m/vHoeVdphDniWBnl6q5QVoXldDdrZIHLXLRMPayTDh5A95nt7jjJzmD4qpTbNQ6tA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "body-parser": "1.20.4",
         "cors": "2.8.5",
@@ -6763,6 +6720,7 @@
       "resolved": "https://registry.npmjs.org/@nestjs/typeorm/-/typeorm-11.0.0.tgz",
       "integrity": "sha512-SOeUQl70Lb2OfhGkvnh4KXWlsd+zA08RuuQgT7kKbzivngxzSo1Oc7Usu5VxCxACQC9wc2l9esOHILSJeK7rJA==",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@nestjs/common": "^10.0.0 || ^11.0.0",
         "@nestjs/core": "^10.0.0 || ^11.0.0",
@@ -6776,6 +6734,7 @@
       "resolved": "https://registry.npmjs.org/@nestjs/websockets/-/websockets-10.4.22.tgz",
       "integrity": "sha512-OLd4i0Faq7vgdtB5vVUrJ54hWEtcXy9poJ6n7kbbh/5ms+KffUl+wwGsbe7uSXLrkoyI8xXU6fZPkFArI+XiRg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "iterare": "1.2.1",
         "object-hash": "3.0.0",
@@ -6896,6 +6855,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
       "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -7832,7 +7792,6 @@
       "resolved": "https://registry.npmjs.org/@redis/bloom/-/bloom-5.11.0.tgz",
       "integrity": "sha512-KYiVilAhAFN3057afUb/tfYJpsEyTkQB+tQcn5gVVA7DgcNOAj8lLxe4j8ov8BF6I9C1Fe/kwlbuAICcTMX8Lw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 18"
       },
@@ -7866,7 +7825,6 @@
       "resolved": "https://registry.npmjs.org/@redis/json/-/json-5.11.0.tgz",
       "integrity": "sha512-1iAy9kAtcD0quB21RbPTbUqqy+T2Uu2JxucwE+B4A+VaDbIRvpZR6DMqV8Iqaws2YxJYB3GC5JVNzPYio2ErUg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 18"
       },
@@ -7879,7 +7837,6 @@
       "resolved": "https://registry.npmjs.org/@redis/search/-/search-5.11.0.tgz",
       "integrity": "sha512-g1l7f3Rnyk/xI99oGHIgWHSKFl45Re5YTIcO8j/JE8olz389yUFyz2+A6nqVy/Zi031VgPDWscbbgOk8hlhZ3g==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 18"
       },
@@ -7892,7 +7849,6 @@
       "resolved": "https://registry.npmjs.org/@redis/time-series/-/time-series-5.11.0.tgz",
       "integrity": "sha512-TWFeOcU4xkj0DkndnOyhtxvX1KWD+78UHT3XX3x3XRBUGWeQrKo3jqzDsZwxbggUgf9yLJr/akFHXru66X5UQA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 18"
       },
@@ -8072,7 +8028,6 @@
       "integrity": "sha512-8janZoJw85nJmQZc4L8TuePp2pk1nxLgkxIR0TUjKJ5Dkj5oelB9WtiSSGXCQvNsJl0VSTvK/2ueMXxvpa9GVw==",
       "license": "Apache-2.0",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "@aws-crypto/crc32": "3.0.0",
         "@smithy/types": "^2.12.0",
@@ -8086,7 +8041,6 @@
       "integrity": "sha512-IzSgsrxUcsrejQbPVilIKy16kAT52EwB6zSaI+M3xxIhKh5+aldEyvI+z6erM7TCLB2BJsFrtHjp6/4/sr+3dA==",
       "license": "Apache-2.0",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "@aws-crypto/util": "^3.0.0",
         "@aws-sdk/types": "^3.222.0",
@@ -8098,8 +8052,7 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
       "license": "0BSD",
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/@smithy/eventstream-codec/node_modules/@aws-crypto/util": {
       "version": "3.0.0",
@@ -8107,7 +8060,6 @@
       "integrity": "sha512-2OJlpeJpCR48CC8r+uKVChzs9Iungj9wkZrl8Z041DWEWvyIHILYKCPNzJghKsivj+S3mLo6BVc7mBNzdxA46w==",
       "license": "Apache-2.0",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "@aws-sdk/types": "^3.222.0",
         "@aws-sdk/util-utf8-browser": "^3.0.0",
@@ -8119,8 +8071,7 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
       "license": "0BSD",
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/@smithy/eventstream-codec/node_modules/@smithy/types": {
       "version": "2.12.0",
@@ -8128,7 +8079,6 @@
       "integrity": "sha512-QwYgloJ0sVNBeBuBs65cIkTbfzV/Q6ZNPCJ99EICFEdJYG50nGIY/uYXp+TbsdJReIuPr0a0kXmCvren3MbRRw==",
       "license": "Apache-2.0",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "tslib": "^2.6.2"
       },
@@ -8142,7 +8092,6 @@
       "integrity": "sha512-7iKXR+/4TpLK194pVjKiasIyqMtTYJsgKgM242Y9uzt5dhHnUDvMNb+3xIhRJ9QhvqGii/5cRUt4fJn3dtXNHQ==",
       "license": "Apache-2.0",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "tslib": "^2.6.2"
       },
@@ -8553,7 +8502,6 @@
       "integrity": "sha512-Xy5XK1AFWW2nlY/biWZXu6/krgbaf2dg0q492D8M5qthsnU2H+UgFeZLbM76FnH7s6RO/xhQRkj+T6KBO3JzgQ==",
       "license": "Apache-2.0",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "@smithy/types": "^2.12.0",
         "tslib": "^2.6.2"
@@ -8568,7 +8516,6 @@
       "integrity": "sha512-QwYgloJ0sVNBeBuBs65cIkTbfzV/Q6ZNPCJ99EICFEdJYG50nGIY/uYXp+TbsdJReIuPr0a0kXmCvren3MbRRw==",
       "license": "Apache-2.0",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "tslib": "^2.6.2"
       },
@@ -8634,7 +8581,6 @@
       "integrity": "sha512-ui/NlpILU+6HAQBfJX8BBsDXuKSNrjTSuOYArRblcrErwKFutjrCNb/OExfVRyj9+26F9J+ZmfWT+fKWuDrH3Q==",
       "license": "Apache-2.0",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "@smithy/is-array-buffer": "^2.2.0",
         "@smithy/types": "^2.12.0",
@@ -8654,7 +8600,6 @@
       "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
       "license": "Apache-2.0",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "tslib": "^2.6.2"
       },
@@ -8668,7 +8613,6 @@
       "integrity": "sha512-QwYgloJ0sVNBeBuBs65cIkTbfzV/Q6ZNPCJ99EICFEdJYG50nGIY/uYXp+TbsdJReIuPr0a0kXmCvren3MbRRw==",
       "license": "Apache-2.0",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "tslib": "^2.6.2"
       },
@@ -8682,7 +8626,6 @@
       "integrity": "sha512-7iKXR+/4TpLK194pVjKiasIyqMtTYJsgKgM242Y9uzt5dhHnUDvMNb+3xIhRJ9QhvqGii/5cRUt4fJn3dtXNHQ==",
       "license": "Apache-2.0",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "tslib": "^2.6.2"
       },
@@ -8696,7 +8639,6 @@
       "integrity": "sha512-L1qpleXf9QD6LwLCJ5jddGkgWyuSvWBkJwWAZ6kFkdifdso+sk3L3O1HdmPvCdnCK3IS4qWyPxev01QMnfHSBw==",
       "license": "Apache-2.0",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "@smithy/types": "^2.12.0",
         "tslib": "^2.6.2"
@@ -8711,7 +8653,6 @@
       "integrity": "sha512-jtmJMyt1xMD/d8OtbVJ2gFZOSKc+ueYJZPW20ULW1GOp/q/YIM0wNh+u8ZFao9UaIGz4WoPW8hC64qlWLIfoDA==",
       "license": "Apache-2.0",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "tslib": "^2.6.2"
       },
@@ -9244,7 +9185,6 @@
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
       "integrity": "sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/ms": "*"
       }
@@ -9255,6 +9195,7 @@
       "integrity": "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "*",
         "@types/json-schema": "*"
@@ -9465,6 +9406,7 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.33.tgz",
       "integrity": "sha512-Rs1bVAIdBs5gbTIKza/tgpMuG1k3U/UMJLWecIMxNdJFDMzcM5LOiLVRYh3PilWEYDIeUDv7bpiHPLPsbydGcw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -9631,8 +9573,7 @@
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
       "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/uuid": {
       "version": "10.0.0",
@@ -9708,6 +9649,7 @@
       "integrity": "sha512-klQbnPAAiGYFyI02+znpBRLyjL4/BrBd0nyWkdC0s/6xFLkXYQ8OoRrSkqacS1ddVxf/LDyODIKbQ5TgKAf/Fg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.56.1",
         "@typescript-eslint/types": "8.56.1",
@@ -10145,7 +10087,6 @@
       "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
       "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "event-target-shim": "^5.0.0"
       },
@@ -10186,6 +10127,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -10208,7 +10150,6 @@
       "integrity": "sha512-wKmbr/DDiIXzEOiWrTTUcDm24kQ2vGfZQvM2fwg2vXqR5uW6aapr7ObPtj1th32b9u90/Pf4AItvdTh42fBmVQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10.13.0"
       },
@@ -10244,7 +10185,6 @@
       "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.6.0.tgz",
       "integrity": "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "humanize-ms": "^1.2.1"
       },
@@ -10258,6 +10198,7 @@
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -10576,6 +10517,7 @@
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz",
       "integrity": "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "follow-redirects": "^1.15.11",
         "form-data": "^4.0.5",
@@ -11122,6 +11064,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -11187,6 +11130,7 @@
       "resolved": "https://registry.npmjs.org/bull/-/bull-4.16.5.tgz",
       "integrity": "sha512-lDsx2BzkKe7gkCYiT5Acj02DpTwDznl/VNN7Psn7M3USPG7Vs/BaClZJJTAG+ufAR9++N1/NiUTdaFBWDIl5TQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cron-parser": "^4.9.0",
         "get-port": "^5.1.1",
@@ -11234,6 +11178,7 @@
       "resolved": "https://registry.npmjs.org/cache-manager/-/cache-manager-7.2.8.tgz",
       "integrity": "sha512-0HDaDLBBY/maa/LmUVAr70XUOwsiQD+jyzCBjmUErYZUKdMS9dT59PqW59PpVqfGM7ve6H0J6307JTpkCYefHQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@cacheable/utils": "^2.3.3",
         "keyv": "^5.5.5"
@@ -11280,6 +11225,7 @@
       "resolved": "https://registry.npmjs.org/@redis/client/-/client-1.6.1.tgz",
       "integrity": "sha512-/KCsg3xSlR+nCK8/8ZYSknYxvXHwubJrU82F3Lm1Fp6789VQ0/3RJKfsmRXjqfaTA++23CvC3hqmqe/2GEt6Kw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cluster-key-slot": "1.1.2",
         "generic-pool": "3.9.0",
@@ -11584,13 +11530,15 @@
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/class-transformer/-/class-transformer-0.5.1.tgz",
       "integrity": "sha512-SQa1Ws6hUbfC98vKGxZH3KFY0Y1lm5Zm0SY8XX9zbK7FJCyVEac3ATW0RIpwzW+oOfmHE5PMPufDG9hCfoEOMw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/class-validator": {
       "version": "0.14.3",
       "resolved": "https://registry.npmjs.org/class-validator/-/class-validator-0.14.3.tgz",
       "integrity": "sha512-rXXekcjofVN1LTOSw+u4u9WXVEUvNBVjORW154q/IdmYWy1nMbOU9aNtZB0t8m+FJQ9q91jlr2f9CwwUFdFMRA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/validator": "^13.15.3",
         "libphonenumber-js": "^1.11.1",
@@ -12108,6 +12056,7 @@
       "integrity": "sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "env-paths": "^2.2.1",
         "import-fresh": "^3.3.0",
@@ -12333,7 +12282,6 @@
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
       "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -12388,6 +12336,7 @@
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
       "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -12540,6 +12489,7 @@
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
       "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
       "license": "BSD-2-Clause",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -12804,8 +12754,7 @@
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
       "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
@@ -12869,6 +12818,7 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -12925,6 +12875,7 @@
       "integrity": "sha512-iI1f+D2ViGn+uvv5HuHVUamg8ll4tN+JRHGc6IJi4TP9Kl976C57fzPXgseXNs8v0iA8aSJpHsTWjDb9QJamGQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -13245,7 +13196,6 @@
       "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
       "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -13395,6 +13345,7 @@
       "resolved": "https://registry.npmjs.org/express-session/-/express-session-1.19.0.tgz",
       "integrity": "sha512-0csaMkGq+vaiZTmSMMGkfdCOabYv192VbytFypcvI0MANrp+4i/7yEkJ0sbAEhycQjntaKGzYfjfXQyVb7BHMA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cookie": "~0.7.2",
         "cookie-signature": "~1.0.7",
@@ -13516,8 +13467,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/external-editor": {
       "version": "3.1.0",
@@ -13630,6 +13580,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-xml-builder": "^1.0.0",
         "strnum": "^2.1.2"
@@ -14070,8 +14021,7 @@
       "version": "1.7.2",
       "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-1.7.2.tgz",
       "integrity": "sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/form-data/node_modules/mime-db": {
       "version": "1.52.0",
@@ -14099,7 +14049,6 @@
       "resolved": "https://registry.npmjs.org/formdata-node/-/formdata-node-4.4.1.tgz",
       "integrity": "sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "node-domexception": "1.0.0",
         "web-streams-polyfill": "4.0.0-beta.3"
@@ -14469,6 +14418,7 @@
       "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.13.0.tgz",
       "integrity": "sha512-uSisMYERbaB9bkA9M4/4dnqyktaEkf1kMHNKq/7DHyxVeWqHQ2mBmVqm5u6/FVHwF3iCNalKcg82Zfl+tffWoA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
       }
@@ -14536,6 +14486,7 @@
       "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
       "integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "minimist": "^1.2.5",
         "neo-async": "^2.6.2",
@@ -14700,7 +14651,6 @@
       "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
       "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ms": "^2.0.0"
       }
@@ -14726,7 +14676,6 @@
       "resolved": "https://registry.npmjs.org/ibm-cloud-sdk-core/-/ibm-cloud-sdk-core-5.4.8.tgz",
       "integrity": "sha512-tLMlZv13cV6S1UPj/bhv8XfV9Z1BDDs/4DxHKWnCw7QlJMzmGdHLPX386x9nrFMQMPZ48eAH+Thsa06tzUZkaA==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@types/debug": "^4.1.12",
         "@types/node": "^18.19.80",
@@ -14753,7 +14702,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
       "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -14763,7 +14711,6 @@
       "resolved": "https://registry.npmjs.org/file-type/-/file-type-16.5.4.tgz",
       "integrity": "sha512-/yFHK0aGjFEgDJjEKP0pWCplsPFPhwyfwevf/pVxiN0tmE4L9LmwWxWukdJSHdoCli4VgQLehjJtwQBnqmsKcw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "readable-web-to-node-stream": "^3.0.0",
         "strtok3": "^6.2.4",
@@ -14794,15 +14741,13 @@
           "url": "https://feross.org/support"
         }
       ],
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/ibm-cloud-sdk-core/node_modules/mime-db": {
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -14812,7 +14757,6 @@
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "mime-db": "1.52.0"
       },
@@ -14825,7 +14769,6 @@
       "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-6.3.0.tgz",
       "integrity": "sha512-fZtbhtvI9I48xDSywd/somNqgUHl2L2cstmXCCif0itOf96jeW18MBSyrLuNicYQVkvpOxkZtkzujiTJ9LW5Jw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@tokenizer/token": "^0.3.0",
         "peek-readable": "^4.1.0"
@@ -14843,7 +14786,6 @@
       "resolved": "https://registry.npmjs.org/token-types/-/token-types-4.2.1.tgz",
       "integrity": "sha512-6udB24Q737UD/SDsKAHI9FCRP7Bqc9D/MQUV02ORQg5iskjtLJlZJNdN4kKtcdtwCeWIwIHDGaUsTsCCAa8sFQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@tokenizer/token": "^0.3.0",
         "ieee754": "^1.2.1"
@@ -14860,8 +14802,7 @@
       "version": "5.26.5",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
       "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/iconv-lite": {
       "version": "0.4.24",
@@ -14887,6 +14828,7 @@
       "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 4"
       }
@@ -15079,6 +15021,7 @@
       "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.9.3.tgz",
       "integrity": "sha512-VI5tMCdeoxZWU5vjHWsiE/Su76JGhBvWF1MJnV9ZtGltHk9BmD48oDq8Tj8haZ85aceXZMxLNDQZRVo5QKNgXA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ioredis/commands": "1.5.0",
         "cluster-key-slot": "^1.1.0",
@@ -15366,8 +15309,7 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.2",
@@ -15486,6 +15428,7 @@
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -16878,6 +16821,7 @@
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
       "integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@keyv/serialize": "^1.1.1"
       }
@@ -17434,7 +17378,8 @@
       "version": "4.17.23",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
       "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/lodash.camelcase": {
       "version": "4.3.0",
@@ -18219,7 +18164,6 @@
       "resolved": "https://registry.npmjs.org/mustache/-/mustache-4.2.0.tgz",
       "integrity": "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "mustache": "bin/mustache"
       }
@@ -18344,7 +18288,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10.5.0"
       }
@@ -18644,7 +18587,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
       "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -18653,8 +18595,7 @@
       "version": "5.26.5",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
       "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/openapi-types": {
       "version": "12.1.3",
@@ -18935,6 +18876,7 @@
       "resolved": "https://registry.npmjs.org/passport/-/passport-0.7.0.tgz",
       "integrity": "sha512-cPLl+qZpSc+ireUvt+IzqbED1cHHkDoVYMo30jbJIdOOjQ1MQYZBPiNvmi8UM6lJuOpTPXJGZQk0DtC4y61MYQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "passport-strategy": "1.x.x",
         "pause": "0.0.1",
@@ -19049,6 +18991,7 @@
       "resolved": "https://registry.npmjs.org/pdf-parse/-/pdf-parse-1.1.1.tgz",
       "integrity": "sha512-v6ZJ/efsBpGrGGknjtq9J/oC8tZWq0KWL5vQrk2GlzLEQPUDB1ex+13Rmidl1neNN358Jn9EHZw5y07FFtaC7A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "debug": "^3.1.0",
         "node-ensure": "^0.0.0"
@@ -19071,7 +19014,6 @@
       "resolved": "https://registry.npmjs.org/peek-readable/-/peek-readable-4.1.0.tgz",
       "integrity": "sha512-ZI3LnwUv5nOGbQzD9c2iDG6toheuXSZP5esSHBjopsXH4dg19soufvpUGA3uohi5anFtGb2lhAVdHzH6R/Evvg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       },
@@ -19085,6 +19027,7 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.18.0.tgz",
       "integrity": "sha512-xqrUDL1b9MbkydY/s+VZ6v+xiMUmOUk7SS9d/1kpyQxoJ6U9AO1oIJyUWVZojbfe5Cc/oluutcgFG4L9RDP1iQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.11.0",
         "pg-pool": "^3.11.0",
@@ -19302,7 +19245,6 @@
       "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
       "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "playwright-core": "1.58.2"
       },
@@ -19321,7 +19263,6 @@
       "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
       "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "playwright-core": "cli.js"
       },
@@ -19339,7 +19280,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
@@ -19473,6 +19413,7 @@
       "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -19516,7 +19457,6 @@
       "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
       "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.6.0"
       }
@@ -19602,7 +19542,6 @@
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
       "integrity": "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "punycode": "^2.3.1"
       },
@@ -19674,8 +19613,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
       "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
@@ -19796,7 +19734,6 @@
       "resolved": "https://registry.npmjs.org/readable-web-to-node-stream/-/readable-web-to-node-stream-3.0.4.tgz",
       "integrity": "sha512-9nX56alTf5bwXQ3ZDipHJhusu9NTQJ/CVPtb/XHAJCXihZeitfJvIRS4GqQ/mfIoOE3IelHMrpayVrosdHBuLw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "readable-stream": "^4.7.0"
       },
@@ -19827,7 +19764,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.2.1"
@@ -19838,7 +19774,6 @@
       "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
       "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.8.x"
       }
@@ -19861,15 +19796,13 @@
           "url": "https://feross.org/support"
         }
       ],
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/readable-web-to-node-stream/node_modules/readable-stream": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
       "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "abort-controller": "^3.0.0",
         "buffer": "^6.0.3",
@@ -19998,8 +19931,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/resolve": {
       "version": "1.22.11",
@@ -20089,7 +20021,6 @@
       "resolved": "https://registry.npmjs.org/retry-axios/-/retry-axios-2.6.0.tgz",
       "integrity": "sha512-pOLi+Gdll3JekwuFjXO3fTq+L9lzMQGcSq7M5gIjExcl3Gu1hd4XXuf5o3+LuSBsaULQH7DiNbsqPd1chVpQGQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=10.7.0"
       },
@@ -20248,6 +20179,7 @@
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
       "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -20326,6 +20258,7 @@
       "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -21744,7 +21677,6 @@
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.4.tgz",
       "integrity": "sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "psl": "^1.1.33",
         "punycode": "^2.1.1",
@@ -21760,7 +21692,6 @@
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
       "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 4.0.0"
       }
@@ -21926,6 +21857,7 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -22150,6 +22082,7 @@
       "resolved": "https://registry.npmjs.org/typeorm/-/typeorm-0.3.28.tgz",
       "integrity": "sha512-6GH7wXhtfq2D33ZuRXYwIsl/qM5685WZcODZb7noOOcRMteM9KF2x2ap3H0EBjnSV0VO4gNAfJT5Ukp0PkOlvg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@sqltools/formatter": "^1.2.5",
         "ansis": "^4.2.0",
@@ -22333,6 +22266,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -22502,7 +22436,6 @@
       "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
       "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
@@ -22682,7 +22615,6 @@
       "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-4.0.0-beta.3.tgz",
       "integrity": "sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 14"
       }
@@ -22769,7 +22701,6 @@
       "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "esrecurse": "^4.3.0",
         "estraverse": "^4.1.1"
@@ -22784,7 +22715,6 @@
       "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "engines": {
         "node": ">=4.0"
       }
@@ -22795,7 +22725,6 @@
       "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.8.x"
       }
@@ -22806,7 +22735,6 @@
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -22817,7 +22745,6 @@
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "mime-db": "1.52.0"
       },
@@ -22831,7 +22758,6 @@
       "integrity": "sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/json-schema": "^7.0.9",
         "ajv": "^8.9.0",
@@ -23035,7 +22961,6 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
       "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -23190,6 +23115,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -23199,7 +23125,6 @@
       "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.1.tgz",
       "integrity": "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==",
       "license": "ISC",
-      "peer": true,
       "peerDependencies": {
         "zod": "^3.25 || ^4"
       }

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -49,6 +49,7 @@ import { TenancyModule } from './tenancy/tenancy.module';
 import { CdnModule } from './cdn/cdn.module';
 import { AuthModule } from './auth/auth.module';
 import { PaymentsModule } from './payments/payments.module';
+import { LocalizationModule } from './localization/localization.module';
 
 @Module({})
 export class AppModule {
@@ -353,6 +354,15 @@ export class AppModule {
       startupLogger.recordModuleLoaded('CDNModule', startTime);
     } else {
       startupLogger.recordModuleSkipped('CDNModule', 'ENABLE_CDN=false');
+    }
+
+    // Localization Module
+    if (flags.ENABLE_LOCALIZATION) {
+      const startTime = Date.now();
+      featureModules.push(LocalizationModule);
+      startupLogger.recordModuleLoaded('LocalizationModule', startTime);
+    } else {
+      startupLogger.recordModuleSkipped('LocalizationModule', 'ENABLE_LOCALIZATION=false');
     }
 
     // Queue Module (always loaded for Bull)

--- a/src/common/decorators/translate.decorator.ts
+++ b/src/common/decorators/translate.decorator.ts
@@ -1,0 +1,14 @@
+import { createParamDecorator, ExecutionContext } from '@nestjs/common';
+import { RequestWithLocale } from '../types/request-with-locale';
+
+/**
+ * Resolved request locale when LanguageMiddleware runs (Accept-Language / ?lang=).
+ * Falls back to I18N_DEFAULT_LOCALE or the decorator argument when unset.
+ */
+export const CurrentLocale = createParamDecorator(
+  (fallbackLocale: string | undefined, ctx: ExecutionContext): string => {
+    const req = ctx.switchToHttp().getRequest<RequestWithLocale>();
+    const envDefault = (process.env.I18N_DEFAULT_LOCALE || 'en').trim().toLowerCase();
+    return req.resolvedLocale ?? fallbackLocale ?? envDefault;
+  },
+);

--- a/src/common/types/request-with-locale.ts
+++ b/src/common/types/request-with-locale.ts
@@ -1,0 +1,3 @@
+import { Request } from 'express';
+
+export type RequestWithLocale = Request & { resolvedLocale?: string };

--- a/src/config/env.validation.ts
+++ b/src/config/env.validation.ts
@@ -110,6 +110,12 @@ export const envValidationSchema = Joi.object({
   ENABLE_SECURITY: Joi.boolean().default(true),
   ENABLE_TENANCY: Joi.boolean().default(true),
   ENABLE_CDN: Joi.boolean().default(true),
+  ENABLE_LOCALIZATION: Joi.boolean().default(true),
+
+  // i18n / localization
+  I18N_DEFAULT_LOCALE: Joi.string().default('en'),
+  I18N_SUPPORTED_LOCALES: Joi.string().default('en'),
+  I18N_CACHE_TTL_SECONDS: Joi.number().integer().min(0).default(300),
 
   // Cluster Mode
   CLUSTER_MODE: Joi.boolean().default(false),

--- a/src/config/feature-flags.config.ts
+++ b/src/config/feature-flags.config.ts
@@ -33,6 +33,7 @@ export interface FeatureFlagsConfig {
   ENABLE_SECURITY: boolean;
   ENABLE_TENANCY: boolean;
   ENABLE_CDN: boolean;
+  ENABLE_LOCALIZATION: boolean;
 }
 
 /**
@@ -65,6 +66,7 @@ export const defaultFeatureFlags: FeatureFlagsConfig = {
   ENABLE_SECURITY: true,
   ENABLE_TENANCY: true,
   ENABLE_CDN: true,
+  ENABLE_LOCALIZATION: true,
 };
 
 /**
@@ -134,6 +136,10 @@ export function loadFeatureFlags(): FeatureFlagsConfig {
     ENABLE_SECURITY: getBooleanEnv('ENABLE_SECURITY', defaultFeatureFlags.ENABLE_SECURITY),
     ENABLE_TENANCY: getBooleanEnv('ENABLE_TENANCY', defaultFeatureFlags.ENABLE_TENANCY),
     ENABLE_CDN: getBooleanEnv('ENABLE_CDN', defaultFeatureFlags.ENABLE_CDN),
+    ENABLE_LOCALIZATION: getBooleanEnv(
+      'ENABLE_LOCALIZATION',
+      defaultFeatureFlags.ENABLE_LOCALIZATION,
+    ),
   };
 }
 
@@ -179,6 +185,7 @@ export function getEnabledModules(flags: FeatureFlagsConfig): string[] {
   if (flags.ENABLE_SECURITY) modules.push('SecurityModule');
   if (flags.ENABLE_TENANCY) modules.push('TenancyModule');
   if (flags.ENABLE_CDN) modules.push('CDNModule');
+  if (flags.ENABLE_LOCALIZATION) modules.push('LocalizationModule');
 
   return modules;
 }

--- a/src/localization/dto/bundle-query.dto.ts
+++ b/src/localization/dto/bundle-query.dto.ts
@@ -1,0 +1,19 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { IsNotEmpty, IsOptional, IsString, MaxLength } from 'class-validator';
+
+export class BundleQueryDto {
+  @ApiProperty({ example: 'errors' })
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(128)
+  namespace: string;
+
+  @ApiPropertyOptional({
+    example: 'en',
+    description: 'If omitted, uses detected language from middleware / Accept-Language',
+  })
+  @IsOptional()
+  @IsString()
+  @MaxLength(32)
+  locale?: string;
+}

--- a/src/localization/dto/create-translation.dto.ts
+++ b/src/localization/dto/create-translation.dto.ts
@@ -1,0 +1,27 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty, IsString, MaxLength } from 'class-validator';
+
+export class CreateTranslationDto {
+  @ApiProperty({ example: 'errors' })
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(128)
+  namespace: string;
+
+  @ApiProperty({ example: 'not_found' })
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(512)
+  key: string;
+
+  @ApiProperty({ example: 'en' })
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(32)
+  locale: string;
+
+  @ApiProperty({ example: 'Resource was not found.' })
+  @IsString()
+  @IsNotEmpty()
+  value: string;
+}

--- a/src/localization/dto/export-query.dto.ts
+++ b/src/localization/dto/export-query.dto.ts
@@ -1,0 +1,22 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { IsIn, IsNotEmpty, IsOptional, IsString, MaxLength } from 'class-validator';
+
+export class ExportQueryDto {
+  @ApiProperty({ example: 'errors' })
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(128)
+  namespace: string;
+
+  @ApiPropertyOptional({ example: 'en' })
+  @IsOptional()
+  @IsString()
+  @MaxLength(32)
+  locale?: string;
+
+  @ApiPropertyOptional({ enum: ['json', 'csv'], default: 'json' })
+  @IsOptional()
+  @IsString()
+  @IsIn(['json', 'csv'])
+  format?: 'json' | 'csv' = 'json';
+}

--- a/src/localization/dto/import-translations.dto.ts
+++ b/src/localization/dto/import-translations.dto.ts
@@ -1,0 +1,52 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import {
+  IsArray,
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+  MaxLength,
+  ValidateNested,
+} from 'class-validator';
+
+export class TranslationImportRowDto {
+  @ApiProperty({ example: 'errors' })
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(128)
+  namespace: string;
+
+  @ApiProperty({ example: 'not_found' })
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(512)
+  key: string;
+
+  @ApiProperty({ example: 'en' })
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(32)
+  locale: string;
+
+  @ApiProperty({ example: 'Not found.' })
+  @IsString()
+  @IsNotEmpty()
+  value: string;
+}
+
+/** Body: `{ "translations": [...] }` or `{ "rows": [...] }` (alias). */
+export class ImportTranslationsDto {
+  @ApiPropertyOptional({ type: [TranslationImportRowDto] })
+  @IsOptional()
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => TranslationImportRowDto)
+  translations?: TranslationImportRowDto[];
+
+  @ApiPropertyOptional({ type: [TranslationImportRowDto], description: 'Alias of translations' })
+  @IsOptional()
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => TranslationImportRowDto)
+  rows?: TranslationImportRowDto[];
+}

--- a/src/localization/dto/list-translations-query.dto.ts
+++ b/src/localization/dto/list-translations-query.dto.ts
@@ -1,0 +1,38 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import { IsInt, IsOptional, IsString, Max, MaxLength, Min } from 'class-validator';
+
+export class ListTranslationsQueryDto {
+  @ApiPropertyOptional({ example: 'errors' })
+  @IsOptional()
+  @IsString()
+  @MaxLength(128)
+  namespace?: string;
+
+  @ApiPropertyOptional({ example: 'en' })
+  @IsOptional()
+  @IsString()
+  @MaxLength(32)
+  locale?: string;
+
+  @ApiPropertyOptional({ description: 'Search substring in key or value' })
+  @IsOptional()
+  @IsString()
+  @MaxLength(256)
+  search?: string;
+
+  @ApiPropertyOptional({ default: 1 })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  page?: number = 1;
+
+  @ApiPropertyOptional({ default: 20 })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  limit?: number = 20;
+}

--- a/src/localization/dto/update-translation.dto.ts
+++ b/src/localization/dto/update-translation.dto.ts
@@ -1,0 +1,27 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { IsOptional, IsString, MaxLength } from 'class-validator';
+
+export class UpdateTranslationDto {
+  @ApiPropertyOptional({ example: 'errors' })
+  @IsOptional()
+  @IsString()
+  @MaxLength(128)
+  namespace?: string;
+
+  @ApiPropertyOptional({ example: 'not_found' })
+  @IsOptional()
+  @IsString()
+  @MaxLength(512)
+  key?: string;
+
+  @ApiPropertyOptional({ example: 'en' })
+  @IsOptional()
+  @IsString()
+  @MaxLength(32)
+  locale?: string;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsString()
+  value?: string;
+}

--- a/src/localization/entities/translation.entity.ts
+++ b/src/localization/entities/translation.entity.ts
@@ -1,0 +1,35 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  UpdateDateColumn,
+  Index,
+  Unique,
+} from 'typeorm';
+
+@Entity('translations')
+@Unique(['namespace', 'translationKey', 'locale'])
+@Index('IDX_translations_namespace_locale', ['namespace', 'locale'])
+export class Translation {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column()
+  namespace: string;
+
+  @Column({ name: 'key' })
+  translationKey: string;
+
+  @Column()
+  locale: string;
+
+  @Column({ type: 'text' })
+  value: string;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}

--- a/src/localization/language-detection.service.spec.ts
+++ b/src/localization/language-detection.service.spec.ts
@@ -1,0 +1,82 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
+import { LanguageDetectionService } from './language-detection.service';
+
+function mockReq(headers: Record<string, string> = {}, query?: Record<string, string>) {
+  return {
+    headers,
+    query: query ?? {},
+  } as import('express').Request;
+}
+
+describe('LanguageDetectionService', () => {
+  let service: LanguageDetectionService;
+
+  async function createModule(config: Record<string, string>) {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        LanguageDetectionService,
+        {
+          provide: ConfigService,
+          useValue: {
+            get: (key: string) => config[key],
+          },
+        },
+      ],
+    }).compile();
+    return module.get(LanguageDetectionService);
+  }
+
+  beforeEach(async () => {
+    service = await createModule({
+      I18N_DEFAULT_LOCALE: 'en',
+      I18N_SUPPORTED_LOCALES: 'en,fr,de',
+    });
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('pickSupported', () => {
+    it('returns exact tag when listed', () => {
+      expect(service.pickSupported('fr')).toBe('fr');
+      expect(service.pickSupported('FR')).toBe('fr');
+    });
+
+    it('maps region subtag to primary when primary is supported', () => {
+      expect(service.pickSupported('fr-CA')).toBe('fr');
+    });
+
+    it('returns null when nothing matches', async () => {
+      const s = await createModule({ I18N_DEFAULT_LOCALE: 'en', I18N_SUPPORTED_LOCALES: 'en' });
+      expect(s.pickSupported('zz')).toBeNull();
+    });
+  });
+
+  describe('resolveWithSource', () => {
+    it('uses query lang when supported', () => {
+      const req = mockReq({ 'accept-language': 'en-US,en;q=0.9' });
+      expect(service.resolveWithSource(req, 'de')).toEqual({ locale: 'de', source: 'query' });
+    });
+
+    it('ignores unsupported query lang and falls through to header', () => {
+      const req = mockReq({ 'accept-language': 'fr-FR,fr;q=0.9,en;q=0.8' });
+      expect(service.resolveWithSource(req, 'xx')).toEqual({ locale: 'fr', source: 'header' });
+    });
+
+    it('respects q-values on Accept-Language', () => {
+      const req = mockReq({ 'accept-language': 'de;q=0.8,fr;q=0.9' });
+      expect(service.resolveWithSource(req)).toEqual({ locale: 'fr', source: 'header' });
+    });
+
+    it('uses default when header missing or unmatched', async () => {
+      const s = await createModule({ I18N_DEFAULT_LOCALE: 'en', I18N_SUPPORTED_LOCALES: 'en' });
+      expect(s.resolveWithSource(mockReq({}))).toEqual({ locale: 'en', source: 'default' });
+      expect(s.resolveWithSource(mockReq({ 'accept-language': 'ja,zh-CN;q=0.9' }))).toEqual({
+        locale: 'en',
+        source: 'default',
+      });
+    });
+  });
+});

--- a/src/localization/language-detection.service.ts
+++ b/src/localization/language-detection.service.ts
@@ -1,0 +1,104 @@
+import { Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { Request } from 'express';
+
+export type LocaleResolutionSource = 'query' | 'header' | 'default';
+
+export interface ResolvedLocale {
+  locale: string;
+  source: LocaleResolutionSource;
+}
+
+@Injectable()
+export class LanguageDetectionService {
+  constructor(private readonly configService: ConfigService) {}
+
+  getDefaultLocale(): string {
+    return this.configService.get<string>('I18N_DEFAULT_LOCALE')?.trim().toLowerCase() || 'en';
+  }
+
+  getSupportedLocales(): string[] {
+    const raw =
+      this.configService.get<string>('I18N_SUPPORTED_LOCALES') ||
+      this.configService.get<string>('I18N_DEFAULT_LOCALE') ||
+      'en';
+    return raw
+      .split(',')
+      .map((s) => this.normalizeLocaleTag(s))
+      .filter(Boolean);
+  }
+
+  normalizeLocaleTag(tag: string): string {
+    if (!tag) return '';
+    return tag.trim().toLowerCase().replace(/_/g, '-');
+  }
+
+  /** First supported locale that matches the tag (exact or primary subtag). */
+  pickSupported(tag: string): string | null {
+    const normalized = this.normalizeLocaleTag(tag);
+    if (!normalized) return null;
+    const supported = this.getSupportedLocales();
+    if (supported.includes(normalized)) return normalized;
+    const primary = normalized.split('-')[0];
+    if (supported.includes(primary)) return primary;
+    for (const s of supported) {
+      if (s.startsWith(`${primary}-`) || primary === s.split('-')[0]) {
+        return s;
+      }
+    }
+    return null;
+  }
+
+  resolveWithSource(req: Request, queryLang?: string): ResolvedLocale {
+    const defaultLocale = this.getDefaultLocale();
+
+    if (queryLang) {
+      const picked = this.pickSupported(queryLang);
+      if (picked) {
+        return { locale: picked, source: 'query' };
+      }
+    }
+
+    const header = req.headers['accept-language'];
+    if (header && typeof header === 'string') {
+      const fromHeader = this.parseAcceptLanguage(header);
+      if (fromHeader) {
+        return { locale: fromHeader, source: 'header' };
+      }
+    }
+
+    return { locale: defaultLocale, source: 'default' };
+  }
+
+  resolveLocale(req: Request, queryLang?: string): string {
+    return this.resolveWithSource(req, queryLang).locale;
+  }
+
+  /**
+   * RFC 7231-style Accept-Language: pick highest-q language that we support.
+   */
+  private parseAcceptLanguage(header: string): string | null {
+    const parts = header.split(',');
+    const candidates: Array<{ tag: string; q: number }> = [];
+    for (const part of parts) {
+      const [langPart, ...params] = part.trim().split(';');
+      const tag = this.normalizeLocaleTag(langPart);
+      if (!tag || tag === '*') continue;
+      let q = 1;
+      for (const p of params) {
+        const [k, v] = p.trim().split('=');
+        if (k?.toLowerCase() === 'q' && v) {
+          const n = parseFloat(v);
+          if (!Number.isNaN(n)) q = n;
+        }
+      }
+      candidates.push({ tag, q });
+    }
+    candidates.sort((a, b) => b.q - a.q);
+    for (const { tag } of candidates) {
+      const picked = this.pickSupported(tag);
+      if (picked) return picked;
+    }
+    return null;
+  }
+}

--- a/src/localization/language.middleware.ts
+++ b/src/localization/language.middleware.ts
@@ -1,0 +1,21 @@
+import { Injectable, NestMiddleware } from '@nestjs/common';
+import { NextFunction, Response } from 'express';
+import { RequestWithLocale } from '../common/types/request-with-locale';
+import { LanguageDetectionService } from './language-detection.service';
+
+@Injectable()
+export class LanguageMiddleware implements NestMiddleware {
+  constructor(private readonly languageDetection: LanguageDetectionService) {}
+
+  use(req: RequestWithLocale, _res: Response, next: NextFunction): void {
+    const raw = req.query?.lang;
+    const queryLang =
+      typeof raw === 'string'
+        ? raw
+        : Array.isArray(raw) && typeof raw[0] === 'string'
+          ? raw[0]
+          : undefined;
+    req.resolvedLocale = this.languageDetection.resolveLocale(req, queryLang);
+    next();
+  }
+}

--- a/src/localization/localization.constants.ts
+++ b/src/localization/localization.constants.ts
@@ -1,0 +1,5 @@
+export const I18N_CACHE_KEY_PREFIX = 'i18n:ns:';
+
+export function bundleCacheKey(namespace: string, locale: string): string {
+  return `${I18N_CACHE_KEY_PREFIX}${namespace}:${locale}`;
+}

--- a/src/localization/localization.controller.ts
+++ b/src/localization/localization.controller.ts
@@ -1,0 +1,133 @@
+import {
+  BadRequestException,
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  Patch,
+  Post,
+  Query,
+  Req,
+  Res,
+  UseGuards,
+} from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiProduces, ApiQuery, ApiTags } from '@nestjs/swagger';
+import { Response } from 'express';
+import { RequestWithLocale } from '../common/types/request-with-locale';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { RolesGuard } from '../auth/guards/roles.guard';
+import { Roles } from '../auth/decorators/roles.decorator';
+import { UserRole } from '../users/entities/user.entity';
+import { BundleQueryDto } from './dto/bundle-query.dto';
+import { CreateTranslationDto } from './dto/create-translation.dto';
+import { ExportQueryDto } from './dto/export-query.dto';
+import { ImportTranslationsDto } from './dto/import-translations.dto';
+import { ListTranslationsQueryDto } from './dto/list-translations-query.dto';
+import { UpdateTranslationDto } from './dto/update-translation.dto';
+import { LanguageDetectionService } from './language-detection.service';
+import { LocalizationService } from './localization.service';
+
+@ApiTags('localization')
+@Controller('localization')
+export class LocalizationController {
+  constructor(
+    private readonly localizationService: LocalizationService,
+    private readonly languageDetection: LanguageDetectionService,
+  ) {}
+
+  @Get('bundle')
+  @ApiOperation({ summary: 'Get merged translation bundle for a namespace' })
+  async getBundle(@Query() query: BundleQueryDto, @Req() req: RequestWithLocale) {
+    const locale =
+      query.locale?.trim() || req.resolvedLocale || this.languageDetection.getDefaultLocale();
+    return this.localizationService.getBundleForApi(query.namespace, locale);
+  }
+
+  @Get('detect')
+  @ApiOperation({ summary: 'Show how the request locale was resolved' })
+  @ApiQuery({ name: 'lang', required: false })
+  detect(@Req() req: RequestWithLocale, @Query('lang') lang?: string) {
+    return this.languageDetection.resolveWithSource(req, lang);
+  }
+
+  @Get('admin/translations')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(UserRole.ADMIN)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'List translations (admin)' })
+  listAdmin(@Query() query: ListTranslationsQueryDto) {
+    return this.localizationService.findAll(query);
+  }
+
+  @Get('admin/translations/:id')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(UserRole.ADMIN)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get one translation (admin)' })
+  findOne(@Param('id') id: string) {
+    return this.localizationService.findOne(id);
+  }
+
+  @Post('admin/translations')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(UserRole.ADMIN)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Create translation (admin)' })
+  create(@Body() dto: CreateTranslationDto) {
+    return this.localizationService.create(dto);
+  }
+
+  @Patch('admin/translations/:id')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(UserRole.ADMIN)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Update translation (admin)' })
+  update(@Param('id') id: string, @Body() dto: UpdateTranslationDto) {
+    return this.localizationService.update(id, dto);
+  }
+
+  @Delete('admin/translations/:id')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(UserRole.ADMIN)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Delete translation (admin)' })
+  async remove(@Param('id') id: string) {
+    await this.localizationService.remove(id);
+    return { deleted: true };
+  }
+
+  @Post('admin/import')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(UserRole.ADMIN)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Upsert translations from JSON (admin)' })
+  import(@Body() body: ImportTranslationsDto) {
+    const rows = body.translations ?? body.rows;
+    if (!rows?.length) {
+      throw new BadRequestException('Provide translations or rows array with at least one item');
+    }
+    return this.localizationService.importRows(rows);
+  }
+
+  @Get('admin/export')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(UserRole.ADMIN)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Export translations as JSON or CSV (admin)' })
+  @ApiProduces('application/json', 'text/csv')
+  async export(@Query() query: ExportQueryDto, @Res({ passthrough: true }) res: Response) {
+    const rows = await this.localizationService.exportRows(query.namespace, query.locale);
+    const format = query.format ?? 'json';
+    if (format === 'csv') {
+      const csv = LocalizationService.toCsv(rows);
+      res.setHeader('Content-Type', 'text/csv; charset=utf-8');
+      res.setHeader(
+        'Content-Disposition',
+        `attachment; filename="translations-${query.namespace}.csv"`,
+      );
+      return csv;
+    }
+    return rows;
+  }
+}

--- a/src/localization/localization.module.ts
+++ b/src/localization/localization.module.ts
@@ -1,0 +1,27 @@
+import { MiddlewareConsumer, Module, NestModule } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { RolesGuard } from '../auth/guards/roles.guard';
+import { Translation } from './entities/translation.entity';
+import { LanguageDetectionService } from './language-detection.service';
+import { LanguageMiddleware } from './language.middleware';
+import { LocalizationController } from './localization.controller';
+import { LocalizationService } from './localization.service';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Translation])],
+  controllers: [LocalizationController],
+  providers: [
+    LocalizationService,
+    LanguageDetectionService,
+    LanguageMiddleware,
+    JwtAuthGuard,
+    RolesGuard,
+  ],
+  exports: [LocalizationService, LanguageDetectionService],
+})
+export class LocalizationModule implements NestModule {
+  configure(consumer: MiddlewareConsumer) {
+    consumer.apply(LanguageMiddleware).forRoutes(LocalizationController);
+  }
+}

--- a/src/localization/localization.service.spec.ts
+++ b/src/localization/localization.service.spec.ts
@@ -1,0 +1,161 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { CACHE_MANAGER } from '@nestjs/cache-manager';
+import { ConfigService } from '@nestjs/config';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { LocalizationService } from './localization.service';
+import { LanguageDetectionService } from './language-detection.service';
+import { Translation } from './entities/translation.entity';
+import { bundleCacheKey } from './localization.constants';
+
+describe('LocalizationService', () => {
+  let service: LocalizationService;
+  let cacheManager: { get: jest.Mock; set: jest.Mock; del: jest.Mock };
+  let translationRepo: {
+    find: jest.Mock;
+    findOne: jest.Mock;
+    save: jest.Mock;
+    remove: jest.Mock;
+    create: jest.Mock;
+    upsert: jest.Mock;
+    createQueryBuilder: jest.Mock;
+  };
+
+  beforeEach(async () => {
+    cacheManager = {
+      get: jest.fn().mockResolvedValue(undefined),
+      set: jest.fn().mockResolvedValue(undefined),
+      del: jest.fn().mockResolvedValue(undefined),
+    };
+
+    translationRepo = {
+      find: jest.fn(),
+      findOne: jest.fn(),
+      save: jest.fn(),
+      remove: jest.fn(),
+      create: jest.fn((x) => ({ ...x, id: 'new-id' })),
+      upsert: jest.fn().mockResolvedValue(undefined),
+      createQueryBuilder: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        LocalizationService,
+        LanguageDetectionService,
+        {
+          provide: ConfigService,
+          useValue: {
+            get: (key: string) => {
+              if (key === 'I18N_DEFAULT_LOCALE') return 'en';
+              if (key === 'I18N_SUPPORTED_LOCALES') return 'en,fr';
+              if (key === 'I18N_CACHE_TTL_SECONDS') return '300';
+              return undefined;
+            },
+          },
+        },
+        { provide: CACHE_MANAGER, useValue: cacheManager },
+        { provide: getRepositoryToken(Translation), useValue: translationRepo },
+      ],
+    }).compile();
+
+    service = module.get(LocalizationService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('interpolate', () => {
+    it('replaces {{name}} placeholders', () => {
+      expect(service.interpolate('Hello {{name}}', { name: 'Ada' })).toBe('Hello Ada');
+    });
+
+    it('leaves unknown tokens', () => {
+      expect(service.interpolate('{{a}}', {})).toBe('{{a}}');
+    });
+  });
+
+  describe('translate', () => {
+    beforeEach(() => {
+      translationRepo.find.mockImplementation(
+        (opts: { where: { namespace: string; locale: string } }) => {
+          const { namespace, locale } = opts.where;
+          if (namespace === 'app' && locale === 'fr') {
+            return Promise.resolve([{ translationKey: 'b', value: 'deux' }]);
+          }
+          if (namespace === 'app' && locale === 'en') {
+            return Promise.resolve([
+              { translationKey: 'a', value: 'one' },
+              { translationKey: 'b', value: 'two' },
+              { translationKey: 'greet', value: 'Hi {{name}}' },
+            ]);
+          }
+          return Promise.resolve([]);
+        },
+      );
+    });
+
+    it('interpolates variables', async () => {
+      const t = await service.translate('app', 'greet', 'en', { name: 'Bo' });
+      expect(t).toBe('Hi Bo');
+    });
+
+    it('falls back to default locale for missing key in requested locale', async () => {
+      const t = await service.translate('app', 'a', 'fr');
+      expect(t).toBe('one');
+    });
+
+    it('uses primary locale when key exists there', async () => {
+      const t = await service.translate('app', 'b', 'fr');
+      expect(t).toBe('deux');
+    });
+
+    it('returns namespace.key when missing everywhere', async () => {
+      const t = await service.translate('app', 'missing', 'en');
+      expect(t).toBe('app.missing');
+    });
+  });
+
+  describe('invalidateBundles', () => {
+    it('calls cache del for unique namespace/locale pairs', async () => {
+      await service.invalidateBundles([
+        { namespace: 'n', locale: 'en' },
+        { namespace: 'n', locale: 'en' },
+        { namespace: 'n', locale: 'fr' },
+      ]);
+      expect(cacheManager.del).toHaveBeenCalledWith(bundleCacheKey('n', 'en'));
+      expect(cacheManager.del).toHaveBeenCalledWith(bundleCacheKey('n', 'fr'));
+      expect(cacheManager.del).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('create', () => {
+    it('invalidates bundle cache after save', async () => {
+      const saved = {
+        id: '1',
+        namespace: 'errors',
+        translationKey: 'x',
+        locale: 'en',
+        value: 'v',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+      translationRepo.save.mockResolvedValue(saved);
+      await service.create({
+        namespace: 'errors',
+        key: 'x',
+        locale: 'en',
+        value: 'v',
+      });
+      expect(cacheManager.del).toHaveBeenCalledWith(bundleCacheKey('errors', 'en'));
+    });
+  });
+
+  describe('toCsv', () => {
+    it('escapes commas and quotes', () => {
+      const csv = LocalizationService.toCsv([
+        { namespace: 'n', key: 'k', locale: 'en', value: 'say "hi", ok' },
+      ]);
+      expect(csv).toContain('"say ""hi"", ok"');
+    });
+  });
+});

--- a/src/localization/localization.service.ts
+++ b/src/localization/localization.service.ts
@@ -1,0 +1,306 @@
+import { CACHE_MANAGER } from '@nestjs/cache-manager';
+import {
+  BadRequestException,
+  ConflictException,
+  Inject,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Cache } from 'cache-manager';
+import { QueryFailedError, Repository } from 'typeorm';
+import { CreateTranslationDto } from './dto/create-translation.dto';
+import { ListTranslationsQueryDto } from './dto/list-translations-query.dto';
+import { TranslationImportRowDto } from './dto/import-translations.dto';
+import { UpdateTranslationDto } from './dto/update-translation.dto';
+import { Translation } from './entities/translation.entity';
+import { bundleCacheKey } from './localization.constants';
+import { LanguageDetectionService } from './language-detection.service';
+
+export interface TranslationListItemDto {
+  id: string;
+  namespace: string;
+  key: string;
+  locale: string;
+  value: string;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface PaginatedTranslations {
+  items: TranslationListItemDto[];
+  total: number;
+  page: number;
+  limit: number;
+}
+
+@Injectable()
+export class LocalizationService {
+  constructor(
+    @InjectRepository(Translation)
+    private readonly translationRepo: Repository<Translation>,
+    @Inject(CACHE_MANAGER) private readonly cacheManager: Cache,
+    private readonly configService: ConfigService,
+    private readonly languageDetection: LanguageDetectionService,
+  ) {}
+
+  private getCacheTtlMs(): number {
+    const sec = parseInt(this.configService.get<string>('I18N_CACHE_TTL_SECONDS') || '300', 10);
+    return Math.max(0, sec) * 1000;
+  }
+
+  private getDefaultLocale(): string {
+    return this.languageDetection.getDefaultLocale();
+  }
+
+  private toItem(entity: Translation): TranslationListItemDto {
+    return {
+      id: entity.id,
+      namespace: entity.namespace,
+      key: entity.translationKey,
+      locale: entity.locale,
+      value: entity.value,
+      createdAt: entity.createdAt,
+      updatedAt: entity.updatedAt,
+    };
+  }
+
+  async invalidateBundles(pairs: Array<{ namespace: string; locale: string }>): Promise<void> {
+    const seen = new Set<string>();
+    for (const { namespace, locale } of pairs) {
+      const k = `${namespace}\0${locale}`;
+      if (seen.has(k)) continue;
+      seen.add(k);
+      await this.cacheManager.del(bundleCacheKey(namespace, locale));
+    }
+  }
+
+  private async loadRawBundleFromDb(
+    namespace: string,
+    locale: string,
+  ): Promise<Record<string, string>> {
+    const rows = await this.translationRepo.find({
+      where: { namespace, locale: languageDetectionNormalize(locale) },
+      select: ['translationKey', 'value'],
+    });
+    const map: Record<string, string> = {};
+    for (const r of rows) {
+      map[r.translationKey] = r.value;
+    }
+    return map;
+  }
+
+  async getRawBundleCached(namespace: string, locale: string): Promise<Record<string, string>> {
+    const loc = languageDetectionNormalize(locale);
+    const key = bundleCacheKey(namespace, loc);
+    const ttl = this.getCacheTtlMs();
+    const cached = await this.cacheManager.get<Record<string, string>>(key);
+    if (cached) return cached;
+    const fresh = await this.loadRawBundleFromDb(namespace, loc);
+    if (ttl > 0) {
+      await this.cacheManager.set(key, fresh, ttl);
+    } else {
+      await this.cacheManager.set(key, fresh);
+    }
+    return fresh;
+  }
+
+  async getMessagesMerged(namespace: string, locale: string): Promise<Record<string, string>> {
+    const loc = this.languageDetection.pickSupported(locale) || this.getDefaultLocale();
+    const primary = await this.getRawBundleCached(namespace, loc);
+    const def = this.getDefaultLocale();
+    if (loc === def) {
+      return { ...primary };
+    }
+    const fallback = await this.getRawBundleCached(namespace, def);
+    return { ...fallback, ...primary };
+  }
+
+  interpolate(template: string, vars?: Record<string, string | number>): string {
+    if (!vars) return template;
+    return template.replace(/\{\{\s*(\w+)\s*\}\}/g, (_, k) =>
+      Object.prototype.hasOwnProperty.call(vars, k) ? String(vars[k]) : `{{${k}}}`,
+    );
+  }
+
+  async translate(
+    namespace: string,
+    key: string,
+    locale?: string,
+    vars?: Record<string, string | number>,
+  ): Promise<string> {
+    const loc = locale
+      ? this.languageDetection.pickSupported(locale) || this.getDefaultLocale()
+      : this.getDefaultLocale();
+    const merged = await this.getMessagesMerged(namespace, loc);
+    const raw = merged[key];
+    const text = raw !== undefined && raw !== null && raw !== '' ? raw : `${namespace}.${key}`;
+    return this.interpolate(text, vars);
+  }
+
+  async getBundleForApi(
+    namespace: string,
+    locale: string,
+  ): Promise<{ locale: string; namespace: string; messages: Record<string, string> }> {
+    const loc = this.languageDetection.pickSupported(locale) || this.getDefaultLocale();
+    const messages = await this.getMessagesMerged(namespace, loc);
+    return { namespace, locale: loc, messages };
+  }
+
+  async create(dto: CreateTranslationDto): Promise<TranslationListItemDto> {
+    const entity = this.translationRepo.create({
+      namespace: dto.namespace.trim(),
+      translationKey: dto.key.trim(),
+      locale: languageDetectionNormalize(dto.locale),
+      value: dto.value,
+    });
+    try {
+      const saved = await this.translationRepo.save(entity);
+      await this.invalidateBundles([{ namespace: saved.namespace, locale: saved.locale }]);
+      return this.toItem(saved);
+    } catch (e) {
+      if (isUniqueViolation(e)) {
+        throw new ConflictException(
+          'Translation already exists for this namespace, key, and locale',
+        );
+      }
+      throw e;
+    }
+  }
+
+  async findAll(query: ListTranslationsQueryDto): Promise<PaginatedTranslations> {
+    const page = query.page ?? 1;
+    const limit = query.limit ?? 20;
+    const qb = this.translationRepo.createQueryBuilder('t');
+    if (query.namespace) {
+      qb.andWhere('t.namespace = :ns', { ns: query.namespace.trim() });
+    }
+    if (query.locale) {
+      qb.andWhere('t.locale = :loc', { loc: languageDetectionNormalize(query.locale) });
+    }
+    if (query.search?.trim()) {
+      const term = `%${query.search.trim()}%`;
+      qb.andWhere('(t.translationKey ILIKE :term OR t.value ILIKE :term)', { term });
+    }
+    qb.orderBy('t.namespace', 'ASC')
+      .addOrderBy('t.locale', 'ASC')
+      .addOrderBy('t.translationKey', 'ASC');
+    const total = await qb.getCount();
+    qb.skip((page - 1) * limit).take(limit);
+    const rows = await qb.getMany();
+    return {
+      items: rows.map((r) => this.toItem(r)),
+      total,
+      page,
+      limit,
+    };
+  }
+
+  async findOne(id: string): Promise<TranslationListItemDto> {
+    const row = await this.translationRepo.findOne({ where: { id } });
+    if (!row) throw new NotFoundException('Translation not found');
+    return this.toItem(row);
+  }
+
+  async update(id: string, dto: UpdateTranslationDto): Promise<TranslationListItemDto> {
+    const row = await this.translationRepo.findOne({ where: { id } });
+    if (!row) throw new NotFoundException('Translation not found');
+    const before = { namespace: row.namespace, locale: row.locale };
+    if (dto.namespace !== undefined) row.namespace = dto.namespace.trim();
+    if (dto.key !== undefined) row.translationKey = dto.key.trim();
+    if (dto.locale !== undefined) row.locale = languageDetectionNormalize(dto.locale);
+    if (dto.value !== undefined) row.value = dto.value;
+    try {
+      const saved = await this.translationRepo.save(row);
+      await this.invalidateBundles([before, { namespace: saved.namespace, locale: saved.locale }]);
+      return this.toItem(saved);
+    } catch (e) {
+      if (isUniqueViolation(e)) {
+        throw new ConflictException(
+          'Translation already exists for this namespace, key, and locale',
+        );
+      }
+      throw e;
+    }
+  }
+
+  async remove(id: string): Promise<void> {
+    const row = await this.translationRepo.findOne({ where: { id } });
+    if (!row) throw new NotFoundException('Translation not found');
+    await this.translationRepo.remove(row);
+    await this.invalidateBundles([{ namespace: row.namespace, locale: row.locale }]);
+  }
+
+  async importRows(rows: TranslationImportRowDto[]): Promise<{ upserted: number }> {
+    if (!rows?.length) {
+      throw new BadRequestException('Import payload must contain at least one row');
+    }
+    const entities = rows.map((r) =>
+      this.translationRepo.create({
+        namespace: r.namespace.trim(),
+        translationKey: r.key.trim(),
+        locale: languageDetectionNormalize(r.locale),
+        value: r.value,
+      }),
+    );
+    await this.translationRepo.upsert(entities, {
+      conflictPaths: ['namespace', 'translationKey', 'locale'],
+      skipUpdateIfNoValuesChanged: true,
+    });
+    const pairs = rows.map((r) => ({
+      namespace: r.namespace.trim(),
+      locale: languageDetectionNormalize(r.locale),
+    }));
+    await this.invalidateBundles(pairs);
+    return { upserted: rows.length };
+  }
+
+  async exportRows(
+    namespace: string,
+    locale?: string,
+  ): Promise<Array<{ namespace: string; key: string; locale: string; value: string }>> {
+    const qb = this.translationRepo
+      .createQueryBuilder('t')
+      .where('t.namespace = :ns', { ns: namespace.trim() });
+    if (locale) {
+      qb.andWhere('t.locale = :loc', { loc: languageDetectionNormalize(locale) });
+    }
+    qb.orderBy('t.locale', 'ASC').addOrderBy('t.translationKey', 'ASC');
+    const rows = await qb.getMany();
+    return rows.map((r) => ({
+      namespace: r.namespace,
+      key: r.translationKey,
+      locale: r.locale,
+      value: r.value,
+    }));
+  }
+
+  static toCsv(
+    rows: Array<{ namespace: string; key: string; locale: string; value: string }>,
+  ): string {
+    const header = 'namespace,key,locale,value';
+    const lines = rows.map((r) =>
+      [csvEscape(r.namespace), csvEscape(r.key), csvEscape(r.locale), csvEscape(r.value)].join(','),
+    );
+    return [header, ...lines].join('\n');
+  }
+}
+
+function languageDetectionNormalize(locale: string): string {
+  return locale.trim().toLowerCase().replace(/_/g, '-');
+}
+
+function csvEscape(field: string): string {
+  if (/[",\n\r]/.test(field)) {
+    return `"${field.replace(/"/g, '""')}"`;
+  }
+  return field;
+}
+
+function isUniqueViolation(err: unknown): boolean {
+  return (
+    err instanceof QueryFailedError &&
+    (err as { driverError?: { code?: string } }).driverError?.code === '23505'
+  );
+}


### PR DESCRIPTION
**feat(localization): backend translation service, API, and caching (#254)**

# Pull request description

## Summary

This change adds a backend localization service so the platform can store and serve translations, detect the user’s language, cache bundles in Redis, and let admins manage strings via a secured API.

## What changed

- **Storage:** `Translation` entity with a unique constraint on `(namespace, translationKey, locale)` and an index on `(namespace, locale)`.
- **Runtime:** `LocalizationService` loads merged messages (requested locale over default), supports `translate()` with simple `{{placeholder}}` interpolation, and invalidates Redis cache keys `i18n:ns:{namespace}:{locale}` on writes.
- **Detection:** `LanguageDetectionService` resolves locale from `?lang=`, then `Accept-Language` (including `q` values), then `I18N_DEFAULT_LOCALE`. Supported list comes from `I18N_SUPPORTED_LOCALES`.
- **HTTP:** Public `GET /localization/bundle` and `GET /localization/detect`; admin routes under `/localization/admin/*` with JWT + `UserRole.ADMIN` for list, CRUD, import (upsert), and export (JSON or CSV).
- **Integration:** `LanguageMiddleware` runs for `LocalizationController` and sets `resolvedLocale`; `@CurrentLocale()` reads it (with env/default fallback). Feature flag `ENABLE_LOCALIZATION` (default on) registers the module in `AppModule`.
- **Tests:** Unit tests for language detection and for translate/fallback, interpolation, cache invalidation, and CSV export.

## Configuration

| Variable | Role |
|----------|------|
| `ENABLE_LOCALIZATION` | Toggle module load (default `true`) |
| `I18N_DEFAULT_LOCALE` | Fallback locale (default `en`) |
| `I18N_SUPPORTED_LOCALES` | Comma-separated tags (default `en`) |
| `I18N_CACHE_TTL_SECONDS` | Bundle cache TTL in seconds (default `300`) |

## Checklist

- [x] Translations stored with unique `(namespace, key, locale)`
- [x] Language detection and bundle fallbacks
- [x] Admin CRUD, import/export, caching behavior covered by unit tests

Closes #254 