### PR TITLE
chore: update docker-compose

### DIFF
--- a/infra/monitoring/docker-compose.yml
+++ b/infra/monitoring/docker-compose.yml
@@ -1,53 +1,186 @@
-version: '3.8'
+networks:
+  teachlink:
+    driver: bridge
+
+volumes:
+  postgres-data:
+  redis-data:
+  elasticsearch-data:
+  prometheus-data:
+  alertmanager-data:
+  grafana-data:
 
 services:
+  app:
+    build:
+      context: ../..
+      dockerfile: Dockerfile
+      target: production
+    container_name: teachlink-app
+    restart: unless-stopped
+    ports:
+      - '${APP_PORT:-3000}:3000'
+    env_file:
+      - ../../.env
+    environment:
+      DATABASE_HOST: postgres
+      DATABASE_PORT: 5432
+      REDIS_HOST: redis
+      REDIS_PORT: 6379
+      ELASTICSEARCH_NODE: http://elasticsearch:9200
+      NODE_ENV: production
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    networks:
+      - teachlink
+    healthcheck:
+      test: ['CMD', 'wget', '--quiet', '--tries=1', '--spider', 'http://localhost:3000/health']
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 30s
+
+  postgres:
+    image: postgres:16-alpine
+    container_name: teachlink-postgres
+    restart: unless-stopped
+    ports:
+      - '${DATABASE_PORT:-5432}:5432'
+    environment:
+      POSTGRES_USER: ${DATABASE_USER:-postgres}
+      POSTGRES_PASSWORD: ${DATABASE_PASSWORD:-postgres}
+      POSTGRES_DB: ${DATABASE_NAME:-teachlink}
+      PGDATA: /var/lib/postgresql/data/pgdata
+    networks:
+      - teachlink
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+    healthcheck:
+      test: ['CMD-SHELL', 'pg_isready -U ${DATABASE_USER:-postgres} -d ${DATABASE_NAME:-teachlink}']
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
+
+  redis:
+    image: redis:7-alpine
+    container_name: teachlink-redis
+    restart: unless-stopped
+    ports:
+      - '${REDIS_PORT:-6379}:6379'
+    command: >
+      redis-server
+      --appendonly yes
+      --appendfsync everysec
+      --maxmemory 256mb
+      --maxmemory-policy allkeys-lru
+    networks:
+      - teachlink
+    volumes:
+      - redis-data:/data
+    healthcheck:
+      test: ['CMD', 'redis-cli', 'ping']
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 5s
+
+  elasticsearch:
+    image: elasticsearch:8.13.4
+    container_name: teachlink-elasticsearch
+    restart: unless-stopped
+    ports:
+      - '9200:9200'
+    environment:
+      discovery.type: single-node
+      xpack.security.enabled: 'false'
+      ES_JAVA_OPTS: '-Xms512m -Xmx512m'
+      cluster.name: teachlink-cluster
+    networks:
+      - teachlink
+    volumes:
+      - elasticsearch-data:/usr/share/elasticsearch/data
+    healthcheck:
+      test:
+        [
+          'CMD-SHELL',
+          'curl -s http://localhost:9200/_cluster/health | grep -qv "\"status\":\"red\""',
+        ]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 60s
+
   prometheus:
     image: prom/prometheus:latest
     container_name: teachlink-prometheus
+    restart: unless-stopped
     ports:
       - '9090:9090'
-    volumes:
-      - ./prometheus.yml:/etc/prometheus/prometheus.yml:ro
-      - ./alerts.yml:/etc/prometheus/alerts.yml:ro
-      - prometheus-data:/prometheus
     command:
       - --config.file=/etc/prometheus/prometheus.yml
       - --storage.tsdb.retention.time=15d
       - --web.enable-lifecycle
     extra_hosts:
       - 'host.docker.internal:host-gateway'
-    restart: unless-stopped
+    networks:
+      - teachlink
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - ./alerts.yml:/etc/prometheus/alerts.yml:ro
+      - prometheus-data:/prometheus
+    healthcheck:
+      test: ['CMD', 'wget', '--quiet', '--tries=1', '--spider', 'http://localhost:9090/-/healthy']
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 15s
 
   alertmanager:
     image: prom/alertmanager:latest
     container_name: teachlink-alertmanager
+    restart: unless-stopped
     ports:
       - '9093:9093'
-    volumes:
-      - ./alertmanager.yml:/etc/alertmanager/alertmanager.yml:ro
-      - alertmanager-data:/alertmanager
     command:
       - --config.file=/etc/alertmanager/alertmanager.yml
       - --storage.path=/alertmanager
-    restart: always
+    networks:
+      - teachlink
+    volumes:
+      - ./alertmanager.yml:/etc/alertmanager/alertmanager.yml:ro
+      - alertmanager-data:/alertmanager
+    healthcheck:
+      test: ['CMD', 'wget', '--quiet', '--tries=1', '--spider', 'http://localhost:9093/-/healthy']
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 15s
 
   grafana:
     image: grafana/grafana:latest
     container_name: teachlink-grafana
+    restart: unless-stopped
     ports:
       - '3001:3000'
     environment:
       - GF_SECURITY_ADMIN_USER=${GRAFANA_ADMIN_USER:-admin}
       - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_ADMIN_PASSWORD:-admin}
       - GF_USERS_ALLOW_SIGN_UP=false
+    networks:
+      - teachlink
     volumes:
       - grafana-data:/var/lib/grafana
       - ./provisioning:/etc/grafana/provisioning:ro
     depends_on:
-      - prometheus
-    restart: unless-stopped
-
-volumes:
-  prometheus-data:
-  alertmanager-data:
-  grafana-data:
+      prometheus:
+        condition: service_healthy
+    healthcheck:
+      test: ['CMD', 'wget', '--quiet', '--tries=1', '--spider', 'http://localhost:3000/api/health']
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 15s


### PR DESCRIPTION
## Linked Issue

Closes #352

---

## What does this PR do?

Updates `infra/monitoring/docker-compose.yml` to serve as the full local development and observability stack for TeachLink. The existing monitoring-only compose (prometheus, alertmanager, grafana) has been extended with the core application services (NestJS app, PostgreSQL, Redis, Elasticsearch), all connected via a shared `teachlink` bridge network. Health checks have been added to every service so that dependent services only start once their dependencies are genuinely ready. Named volumes are declared for all stateful services to ensure data persists across container restarts. The deprecated `version` top-level key has also been removed in line with Docker Compose v2 conventions.

---

## Type of change

- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] 💥 Breaking change (fix or feature that changes existing API behaviour)
- [ ] ♻️ Refactor (no functional change, no new feature)
- [ ] 🧪 Tests only (no production code changes)
- [ ] 📝 Documentation only
- [x] 🔧 Chore (build, dependencies, CI config)

---

## Pre-merge checklist (required)

> **Do not remove items. Unchecked items without an explanation will block merge.**

**Branch & metadata**

- [x] Branch name follows `feature/issue-<N>-<slug>` / `fix/issue-<N>-<slug>` convention
- [x] Branch is up to date with the target branch (`develop` or `main`)
- [x] All commits and the PR title follow the Conventional Commits format with issue reference

**Code quality & tests**

- [x] `npm run lint:ci` — zero ESLint warnings
- [x] `npm run format:check` — Prettier reports no changes needed
- [x] `npm run typecheck` — zero TypeScript errors
- [x] `npm run test:ci` — all tests pass, coverage ≥ 70%
- [x] New service methods have corresponding `.spec.ts` unit tests — N/A (infrastructure change only)
- [x] New API endpoints are covered by at least one e2e test — N/A (no API surface changes)
- [x] No existing tests were deleted (if any were, justification is provided in the PR description)

**Error handling & NestJS best practices**

- [x] All new/updated DTOs use `class-validator` / `class-transformer` decorators — N/A
- [x] All controller entry points validate external input at the boundary — N/A
- [x] Controllers/services throw appropriate NestJS HTTP exceptions — N/A
- [x] Any new error shapes are handled by existing exception filters — N/A
- [x] Logging goes through the shared logging abstraction — N/A
- [x] Authentication/authorization guards are applied to all new/modified endpoints — N/A
- [x] If an endpoint is intentionally public, this is explicitly mentioned — N/A

**API documentation / Swagger**

- [x] Swagger / OpenAPI decorators are added or updated — N/A (no API surface changes)
- [x] There are **no** API surface changes introduced by this PR

**Breaking changes**

- [x] This PR does **not** introduce a breaking API change

---

## Test evidence (required)

**Services verified with `docker compose up`**

```text
docker compose -f infra/monitoring/docker-compose.yml up -d
docker compose -f infra/monitoring/docker-compose.yml ps
```

| Service | Port | Health |
|---|---|---|
| teachlink-app | 3000 | `/health` → 200 |
| teachlink-postgres | 5432 | `pg_isready` → accepting connections |
| teachlink-redis | 6379 | `redis-cli ping` → PONG |
| teachlink-elasticsearch | 9200 | `/_cluster/health` → status green/yellow |
| teachlink-prometheus | 9090 | `/-/healthy` → 200 |
| teachlink-alertmanager | 9093 | `/-/healthy` → 200 |
| teachlink-grafana | 3001 | `/api/health` → 200 |