### PR TITLE
feat: add DR plan, backup docs, standardize logging, and add log ship…

### DIFF
--- a/docs/backup-strategy.md
+++ b/docs/backup-strategy.md
@@ -1,0 +1,160 @@
+# Backup Strategy
+
+## Overview
+
+This document describes the backup configuration, schedule, storage architecture, and operational procedures for the TeachLink backend platform.
+
+---
+
+## Backup Schedule
+
+| Job Name                  | Cron        | UTC Time     | Description                                     |
+| ------------------------- | ----------- | ------------ | ----------------------------------------------- |
+| `weekly-database-backup`  | `0 2 * * 0` | Sunday 02:00 | Full PostgreSQL database backup                 |
+| `cleanup-expired-backups` | `0 3 * * *` | Daily 03:00  | Deletes backups older than the retention window |
+
+---
+
+## Backup Types
+
+| Type   | Description                               |
+| ------ | ----------------------------------------- |
+| `full` | Complete `pg_dump` of the entire database |
+
+Additional backup types (incremental, differential) can be added to the `BackupType` enum as requirements evolve.
+
+---
+
+## Retention Policy
+
+- **Default retention:** 30 days
+- **Configuration:** `BACKUP_RETENTION_DAYS` environment variable
+- Expired backups are identified by `createdAt < NOW() - retention_days` and status `COMPLETED`.
+- Deletion is queued via Bull (`DELETE_BACKUP` job) with 3 retry attempts and exponential backoff (5 s initial delay).
+
+---
+
+## Storage Architecture
+
+```
+PostgreSQL (primary)
+       │
+       ▼
+  pg_dump → encrypted with AWS KMS
+       │
+       ├──▶ S3 (primary region, us-east-1)   [encryptedStorageKey]
+       │
+       └──▶ S3 (secondary region, us-west-2) [replicatedStorageKey]
+```
+
+### Environment Variables
+
+| Variable                | Default     | Description                      |
+| ----------------------- | ----------- | -------------------------------- |
+| `BACKUP_PRIMARY_REGION` | `us-east-1` | Primary S3 region                |
+| `BACKUP_RETENTION_DAYS` | `30`        | Days to retain completed backups |
+| `DB_DATABASE`           | `teachlink` | Database name to back up         |
+
+---
+
+## Encryption
+
+All backups are encrypted using AWS KMS before being stored in S3.
+
+- KMS key ID is stored on the `BackupRecord` (`kmsKeyId` column).
+- Decryption uses `@aws-sdk/client-kms` `DecryptCommand` during restore.
+- KMS configuration is provided via `AWS_REGION` and IAM role/credentials.
+
+---
+
+## Integrity Verification
+
+After each backup completes, an integrity verification job is queued:
+
+- MD5 and SHA-256 checksums are computed and stored (`checksumMd5`, `checksumSha256` columns).
+- `integrityVerified` flag is set to `true` on success.
+- Only backups with `integrityVerified = true` are eligible for disaster recovery restore.
+- Verification timestamp is recorded in `verifiedAt`.
+
+---
+
+## Backup Record Schema
+
+Each backup is tracked in the `backup_records` table:
+
+| Column                 | Description                                              |
+| ---------------------- | -------------------------------------------------------- |
+| `id`                   | UUID primary key                                         |
+| `backupType`           | `full`                                                   |
+| `status`               | `pending` → `in_progress` → `completed` / `failed`       |
+| `region`               | AWS region where the primary copy resides                |
+| `databaseName`         | Name of the PostgreSQL database                          |
+| `storageKey`           | Raw (pre-encryption) S3 key                              |
+| `encryptedStorageKey`  | Encrypted backup S3 key                                  |
+| `replicatedStorageKey` | Cross-region replica S3 key                              |
+| `kmsKeyId`             | KMS key used for encryption                              |
+| `backupSizeBytes`      | Backup file size                                         |
+| `checksumMd5`          | MD5 of backup file                                       |
+| `checksumSha256`       | SHA-256 of backup file                                   |
+| `integrityVerified`    | Whether integrity check passed                           |
+| `verifiedAt`           | Timestamp of last integrity verification                 |
+| `expiresAt`            | Timestamp after which the record is eligible for cleanup |
+| `errorMessage`         | Last error (if `status = failed`)                        |
+| `retryCount`           | Number of retry attempts                                 |
+| `metadata`             | JSON: pg version, table counts, total rows, timings      |
+| `createdAt`            | Record creation time                                     |
+| `completedAt`          | Time backup completed                                    |
+
+---
+
+## Scheduled Task Resilience
+
+Both scheduled jobs are wrapped in the `ScheduledTaskMonitoringService`, which provides:
+
+- **Configurable retries:** `BACKUP_SCHEDULED_TASK_RETRY_LIMIT` (default: 2)
+- **Retry delay:** `BACKUP_SCHEDULED_TASK_RETRY_DELAY_MS` (default: 10,000 ms)
+- **Timeout:** `BACKUP_SCHEDULED_TASK_TIMEOUT_MS` (default: 30 minutes)
+- **Alerting on exhausted retries:** `BACKUP_SCHEDULED_FAILED` → `CRITICAL`
+
+---
+
+## Alerting
+
+| Alert Key                 | Severity | Trigger                              |
+| ------------------------- | -------- | ------------------------------------ |
+| `BACKUP_COMPLETED`        | INFO     | Backup completed successfully        |
+| `BACKUP_FAILED`           | CRITICAL | Backup job failed                    |
+| `BACKUP_SCHEDULED_FAILED` | CRITICAL | All scheduled task retries exhausted |
+
+---
+
+## Operational Procedures
+
+### Trigger a Manual Backup
+
+```bash
+POST /backup
+```
+
+### List Backups
+
+```bash
+GET /backup?status=completed&integrityVerified=true
+```
+
+### Check Backup Status
+
+```bash
+GET /backup/:id
+```
+
+### Restore from Backup
+
+See [Disaster Recovery Plan](./disaster-recovery.md) for full restore runbook.
+
+---
+
+## Related Documents
+
+- [Disaster Recovery Plan](./disaster-recovery.md)
+- [Monitoring Dashboard](./monitoring-dashboard.md)

--- a/docs/disaster-recovery.md
+++ b/docs/disaster-recovery.md
@@ -1,0 +1,171 @@
+# Disaster Recovery Plan
+
+## Overview
+
+This document defines the disaster recovery (DR) procedures for the TeachLink backend platform. It covers recovery objectives, recovery procedures, runbooks, and responsibilities.
+
+---
+
+## Recovery Objectives
+
+| Metric                             | Target                        |
+| ---------------------------------- | ----------------------------- |
+| **RTO** (Recovery Time Objective)  | ≤ 15 minutes                  |
+| **RPO** (Recovery Point Objective) | ≤ 7 days (weekly full backup) |
+
+The system alerts automatically when a recovery exceeds the RTO threshold (`DISASTER_RECOVERY_RTO_EXCEEDED` alert, `CRITICAL` severity).
+
+---
+
+## Architecture Overview
+
+```
+Primary Region (us-east-1)          Secondary Region (us-west-2)
+┌───────────────────────┐           ┌──────────────────────────┐
+│  PostgreSQL DB        │──backup──▶│  S3 Replicated Storage   │
+│  NestJS API           │           │  (cross-region copy)     │
+│  Redis Cache          │           └──────────────────────────┘
+└───────────────────────┘
+         │
+         ▼
+   AWS S3 (primary)
+   AWS KMS (encryption)
+```
+
+Backups are encrypted with AWS KMS before upload to S3 and replicated to the secondary region storage key.
+
+---
+
+## Backup Sources
+
+| Component      | Backup Method                 | Schedule               | Retention                                       |
+| -------------- | ----------------------------- | ---------------------- | ----------------------------------------------- |
+| PostgreSQL     | `pg_dump` (full)              | Every Sunday 02:00 UTC | 30 days (configurable: `BACKUP_RETENTION_DAYS`) |
+| Backup records | PostgreSQL (self-referential) | Same as above          | 30 days                                         |
+
+---
+
+## Disaster Scenarios
+
+### Scenario 1 — Primary Database Failure
+
+**Symptoms:** API returns 500 errors on all DB-dependent endpoints; health checks fail on database.
+
+**Response steps:**
+
+1. Trigger `POST /backup/restore/:backupId` with the latest verified backup ID.
+2. The `DisasterRecoveryService` will:
+   - Retrieve the latest integrity-verified backup from the repository.
+   - Download the backup from the secondary-region S3 key (`replicatedStorageKey`).
+   - Decrypt the data with AWS KMS (`DecryptCommand`).
+   - Run `pg_restore` against the primary database.
+3. Verify recovery by checking health endpoint: `GET /health`.
+4. Monitor the `DISASTER_RECOVERY_SUCCESS` or `DISASTER_RECOVERY_FAILED` alerts.
+
+### Scenario 2 — Primary Region Outage
+
+**Symptoms:** All services unreachable; AWS Console shows regional incident.
+
+**Response steps:**
+
+1. Update DNS / load balancer to point to standby deployment in `us-west-2`.
+2. Provision a new database instance in `us-west-2`.
+3. Trigger restore using backup from `us-west-2` S3 bucket (`BACKUP_SECONDARY_REGION=us-west-2`).
+4. Update environment variables (`DB_HOST`, `AWS_REGION`) and redeploy.
+5. Confirm all scheduled tasks (weekly backup, cleanup) resume after restart.
+
+### Scenario 3 — Corrupted/Compromised Data
+
+**Symptoms:** Data inconsistency detected; integrity check failures.
+
+**Response steps:**
+
+1. Identify the last known-good backup (integrity-verified, before the incident).
+2. Create a new empty database to avoid overwriting.
+3. Restore to the new database and validate.
+4. Swap connection string once validated.
+
+---
+
+## Recovery Runbook
+
+### Prerequisites
+
+Ensure the following environment variables are set on the recovery host:
+
+```env
+DB_HOST=<target-db-host>
+DB_PORT=5432
+DB_DATABASE=teachlink
+DB_USERNAME=<db-user>
+DB_PASSWORD=<db-password>
+AWS_REGION=us-east-1
+AWS_ACCESS_KEY_ID=<key>
+AWS_SECRET_ACCESS_KEY=<secret>
+BACKUP_PRIMARY_REGION=us-east-1
+BACKUP_SECONDARY_REGION=us-west-2
+```
+
+### Step-by-Step Restore
+
+```bash
+# 1. Identify the latest verified backup via API
+GET /backup?status=completed&integrityVerified=true
+
+# 2. Initiate restore
+POST /backup/restore/:backupId
+
+# 3. Monitor logs for recovery progress
+# Expected log events:
+#   - "Starting disaster recovery restore for backup: <id>"
+#   - "Downloading backup from secondary region"
+#   - "Decrypting backup"
+#   - "Restoring to primary database"
+#   - "Disaster recovery completed. RTO: <N> seconds"
+
+# 4. Validate health
+GET /health
+```
+
+### Automated Alerts
+
+| Alert Key                        | Severity | Meaning                                       |
+| -------------------------------- | -------- | --------------------------------------------- |
+| `DISASTER_RECOVERY_SUCCESS`      | INFO     | Recovery completed within RTO                 |
+| `DISASTER_RECOVERY_RTO_EXCEEDED` | CRITICAL | Recovery took > 15 minutes                    |
+| `DISASTER_RECOVERY_FAILED`       | CRITICAL | Recovery failed; manual intervention required |
+| `BACKUP_COMPLETED`               | INFO     | Scheduled backup succeeded                    |
+| `BACKUP_FAILED`                  | CRITICAL | Scheduled backup failed                       |
+| `BACKUP_SCHEDULED_FAILED`        | CRITICAL | All retry attempts exhausted                  |
+
+---
+
+## Testing the DR Plan
+
+Recovery tests should be run in a staging environment. The `RecoveryTest` entity tracks test results.
+
+**Monthly drill checklist:**
+
+- [ ] Trigger a manual backup and verify integrity.
+- [ ] Execute restore to a staging database.
+- [ ] Confirm RTO is within the 15-minute target.
+- [ ] Verify all application health checks pass post-restore.
+- [ ] Review and update this document if procedures have changed.
+
+---
+
+## Contacts and Escalation
+
+| Role             | Responsibility                      |
+| ---------------- | ----------------------------------- |
+| On-call Engineer | First responder; execute runbook    |
+| Platform Lead    | Escalation for region-level outages |
+| AWS Support      | Infrastructure-level issues         |
+
+---
+
+## Related Documents
+
+- [Backup Strategy](./backup-strategy.md)
+- [Monitoring Dashboard](./monitoring-dashboard.md)
+- [Migrations Guide](./migrations.md)

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -55,6 +55,8 @@ import { LocalizationModule } from './localization/localization.module';
 import { CsrfModule } from './common/csrf/csrf.module';
 import { TimeoutModule } from './common/timeout/timeout.module';
 import { ShutdownStateService } from './common/services/shutdown-state.service';
+import { LogShipperService } from './common/services/log-shipper.service';
+import { LoggingInterceptor } from './common/interceptors/logging.interceptor';
 
 @Global()
 @Module({})
@@ -380,6 +382,11 @@ export class AppModule {
         AppService,
         StartupLogger,
         ShutdownStateService,
+        LogShipperService,
+        {
+          provide: APP_INTERCEPTOR,
+          useClass: LoggingInterceptor,
+        },
         {
           provide: APP_INTERCEPTOR,
           useClass: MonitoringInterceptor,
@@ -393,7 +400,7 @@ export class AppModule {
           useClass: CustomThrottleGuard,
         },
       ],
-      exports: [ShutdownStateService],
+      exports: [ShutdownStateService, LogShipperService],
     };
   }
 }

--- a/src/common/common.module.ts
+++ b/src/common/common.module.ts
@@ -1,8 +1,11 @@
 import { Module } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
 import { TransactionHelperService } from './database/transaction-helper.service';
+import { LogShipperService } from './services/log-shipper.service';
 
 @Module({
-  providers: [TransactionHelperService],
-  exports: [TransactionHelperService],
+  imports: [ConfigModule],
+  providers: [TransactionHelperService, LogShipperService],
+  exports: [TransactionHelperService, LogShipperService],
 })
 export class CommonModule {}

--- a/src/common/interceptors/logging.interceptor.spec.ts
+++ b/src/common/interceptors/logging.interceptor.spec.ts
@@ -1,9 +1,11 @@
 import { LoggingInterceptor } from './logging.interceptor';
+import { LogShipperService } from '../services/log-shipper.service';
 import { of, firstValueFrom } from 'rxjs';
 
 describe('LoggingInterceptor', () => {
   it('attaches and propagates correlation ID header', async () => {
-    const interceptor = new LoggingInterceptor();
+    const mockShipper = { ship: jest.fn() } as unknown as LogShipperService;
+    const interceptor = new LoggingInterceptor(mockShipper);
 
     const req: any = { method: 'GET', url: '/spam', headers: {} };
     const headers: Record<string, string> = {};

--- a/src/common/interceptors/logging.interceptor.ts
+++ b/src/common/interceptors/logging.interceptor.ts
@@ -7,10 +7,25 @@ import {
   generateCorrelationId,
   getCorrelationId,
 } from '../utils/correlation.utils';
+import { LogShipperService } from '../services/log-shipper.service';
 
+/** Standard log-level labels used in the JSON envelope. */
+export type LogLevel = 'info' | 'warn' | 'error';
+
+/**
+ * Standard log envelope emitted for every HTTP request/response.
+ *
+ * All fields are present in every log entry so consumers can build
+ * consistent Elasticsearch mappings and Kibana dashboards without
+ * per-environment special-casing.
+ */
 export interface RequestLog {
-  requestId: string;
-  timestamp: string;
+  '@timestamp': string;
+  service: string;
+  environment: string;
+  level: LogLevel;
+  event: string;
+  correlationId: string;
   method: string;
   url: string;
   route: string;
@@ -27,18 +42,25 @@ export interface ResponseLog extends RequestLog {
 }
 
 /**
- * #154 – LoggingInterceptor
+ * #154 / #360 – LoggingInterceptor
  *
- * Logs every HTTP request with:
+ * Logs every HTTP request with a standardized JSON envelope:
+ *  - @timestamp, service, environment, level, event
+ *  - correlationId (propagated via AsyncLocalStorage / x-request-id header)
  *  - method, URL, resolved route, IP, user-agent
  *  - authenticated user ID + role (when present on request.user)
  *  - response status code and wall-clock response time
- *  - structured JSON output in production, pretty-printed in development
+ *
+ * JSON format is used in all environments for consistent parsing by
+ * log shippers and aggregators (#360).
  */
 @Injectable()
 export class LoggingInterceptor implements NestInterceptor {
   private readonly logger = new Logger(LoggingInterceptor.name);
-  private readonly isProd = process.env.NODE_ENV === 'production';
+  private readonly service = process.env.npm_package_name ?? 'teachlink-api';
+  private readonly environment = process.env.NODE_ENV ?? 'development';
+
+  constructor(private readonly logShipper: LogShipperService) {}
 
   intercept(context: ExecutionContext, next: CallHandler): Observable<unknown> {
     // Only intercept HTTP contexts (skip WebSockets, microservices, etc.)
@@ -54,14 +76,18 @@ export class LoggingInterceptor implements NestInterceptor {
     }
 
     const startTime = Date.now();
-    const requestId = getCorrelationId() || generateCorrelationId();
+    const correlationId = getCorrelationId() || generateCorrelationId();
 
     const response = httpCtx.getResponse<Response>();
-    response?.setHeader(CORRELATION_ID_HEADER, requestId);
+    response?.setHeader(CORRELATION_ID_HEADER, correlationId);
 
     const baseLog: RequestLog = {
-      requestId,
-      timestamp: new Date().toISOString(),
+      '@timestamp': new Date().toISOString(),
+      service: this.service,
+      environment: this.environment,
+      level: 'info',
+      event: 'request.incoming',
+      correlationId,
       method: request.method ?? 'UNKNOWN',
       url: request.url,
       route: request.route?.path ?? request.url,
@@ -71,17 +97,23 @@ export class LoggingInterceptor implements NestInterceptor {
       ...(request.user?.role !== undefined && { userRole: request.user.role as string }),
     };
 
-    this.logIncoming(baseLog);
+    this.emit('log', baseLog);
 
     return next.handle().pipe(
       tap(() => {
         const res = httpCtx.getResponse<Response>();
-        this.logOutgoing({
+        const outgoing: ResponseLog = {
           ...baseLog,
+          event: 'request.completed',
           statusCode: res.statusCode,
           responseTimeMs: Date.now() - startTime,
           contentLength: this.getContentLength(res),
-        });
+        };
+        outgoing.level = this.resolveLevel(res.statusCode);
+        this.emit(
+          outgoing.level === 'error' ? 'error' : outgoing.level === 'warn' ? 'warn' : 'log',
+          outgoing,
+        );
       }),
       catchError((error: unknown) => {
         const status =
@@ -89,11 +121,17 @@ export class LoggingInterceptor implements NestInterceptor {
             ? (error as { status: number }).status
             : 500;
 
-        this.logOutgoing({
+        const outgoing: ResponseLog = {
           ...baseLog,
+          event: 'request.completed',
+          level: this.resolveLevel(status),
           statusCode: status,
           responseTimeMs: Date.now() - startTime,
-        });
+        };
+        this.emit(
+          outgoing.level === 'error' ? 'error' : outgoing.level === 'warn' ? 'warn' : 'log',
+          outgoing,
+        );
 
         return throwError(() => error);
       }),
@@ -102,28 +140,16 @@ export class LoggingInterceptor implements NestInterceptor {
 
   // ─── Private helpers ───────────────────────────────────────────────────────
 
-  private logIncoming(log: RequestLog): void {
-    const message = `→ ${log.method} ${log.url}`;
-    if (this.isProd) {
-      this.logger.log(JSON.stringify({ event: 'request.incoming', ...log }));
-    } else {
-      this.logger.log(
-        `${message} | id=${log.requestId} ip=${log.ip}${log.userId ? ` user=${log.userId}` : ''}`,
-      );
-    }
+  /** Emit a structured JSON log entry and ship it to the external aggregator. */
+  private emit(nestLevel: 'log' | 'warn' | 'error', entry: RequestLog | ResponseLog): void {
+    this.logger[nestLevel](JSON.stringify(entry));
+    this.logShipper.ship(entry);
   }
 
-  private logOutgoing(log: ResponseLog): void {
-    const message = `← ${log.method} ${log.url} ${log.statusCode} ${log.responseTimeMs}ms`;
-    const level = log.statusCode >= 500 ? 'error' : log.statusCode >= 400 ? 'warn' : 'log';
-
-    if (this.isProd) {
-      this.logger[level](JSON.stringify({ event: 'request.completed', ...log }));
-    } else {
-      this.logger[level](
-        `${message} | id=${log.requestId}${log.userId ? ` user=${log.userId}` : ''}`,
-      );
-    }
+  private resolveLevel(statusCode: number): LogLevel {
+    if (statusCode >= 500) return 'error';
+    if (statusCode >= 400) return 'warn';
+    return 'info';
   }
 
   private resolveClientIp(request: Request): string {

--- a/src/common/services/log-shipper.service.ts
+++ b/src/common/services/log-shipper.service.ts
@@ -1,0 +1,120 @@
+import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { Client } from '@elastic/elasticsearch';
+
+/** Index prefix used for all application logs. */
+const LOG_INDEX_PREFIX = 'teachlink-logs';
+
+/** Elasticsearch index mappings for structured log fields. */
+const LOG_INDEX_MAPPINGS = {
+  mappings: {
+    dynamic: false,
+    properties: {
+      '@timestamp': { type: 'date' },
+      service: { type: 'keyword' },
+      environment: { type: 'keyword' },
+      level: { type: 'keyword' },
+      event: { type: 'keyword' },
+      correlationId: { type: 'keyword' },
+      method: { type: 'keyword' },
+      url: { type: 'keyword' },
+      route: { type: 'keyword' },
+      ip: { type: 'ip' },
+      userAgent: { type: 'text' },
+      userId: { type: 'keyword' },
+      userRole: { type: 'keyword' },
+      statusCode: { type: 'integer' },
+      responseTimeMs: { type: 'long' },
+      contentLength: { type: 'long' },
+    },
+  },
+  settings: {
+    number_of_shards: 1,
+    number_of_replicas: 1,
+  },
+};
+
+/** Index template name applied to all `teachlink-logs-*` indices. */
+const LOG_INDEX_TEMPLATE = 'teachlink-logs-template';
+
+/**
+ * #361 – LogShipperService
+ *
+ * Ships structured log entries to Elasticsearch using a daily rolling index
+ * pattern: `teachlink-logs-YYYY.MM.DD`.
+ *
+ * - Shipping is fire-and-forget; errors are caught and logged locally so a
+ *   downed Elasticsearch cluster never impacts API availability.
+ * - An index template is registered on module init so all future daily indices
+ *   inherit the correct field mappings automatically.
+ * - The service is disabled when `ELASTICSEARCH_NODE` is not configured.
+ */
+@Injectable()
+export class LogShipperService implements OnModuleInit {
+  private readonly logger = new Logger(LogShipperService.name);
+  private client: Client | null = null;
+
+  constructor(private readonly configService: ConfigService) {}
+
+  onModuleInit(): void {
+    const node = this.configService.get<string>('ELASTICSEARCH_NODE');
+    if (!node) {
+      this.logger.warn('ELASTICSEARCH_NODE not set – log shipping is disabled');
+      return;
+    }
+
+    const username = this.configService.get<string>('ELASTICSEARCH_USERNAME');
+    const password = this.configService.get<string>('ELASTICSEARCH_PASSWORD');
+    const apiKey = this.configService.get<string>('ELASTICSEARCH_API_KEY');
+
+    const auth = apiKey ? { apiKey } : username && password ? { username, password } : undefined;
+
+    this.client = new Client({ node, auth });
+
+    // Register the index template asynchronously; non-fatal if it fails.
+    this.ensureIndexTemplate().catch((err: unknown) => {
+      this.logger.warn(
+        `Failed to register log index template: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    });
+  }
+
+  /**
+   * Ships a structured log entry to Elasticsearch.
+   * Fire-and-forget – never throws.
+   */
+  ship(entry: Record<string, unknown>): void {
+    if (!this.client) return;
+
+    const index = this.dailyIndex();
+    this.client.index({ index, document: entry }).catch((err: unknown) => {
+      // Log locally but never propagate – shipping must not affect the request.
+      this.logger.warn(`Log shipping failed: ${err instanceof Error ? err.message : String(err)}`);
+    });
+  }
+
+  // ─── Private helpers ───────────────────────────────────────────────────────
+
+  /** Returns the rolling daily index name, e.g. `teachlink-logs-2026.04.26`. */
+  private dailyIndex(): string {
+    const now = new Date();
+    const yyyy = now.getUTCFullYear();
+    const mm = String(now.getUTCMonth() + 1).padStart(2, '0');
+    const dd = String(now.getUTCDate()).padStart(2, '0');
+    return `${LOG_INDEX_PREFIX}-${yyyy}.${mm}.${dd}`;
+  }
+
+  /**
+   * Creates (or updates) an Elasticsearch index template so all future daily
+   * log indices inherit consistent field mappings and settings.
+   */
+  private async ensureIndexTemplate(): Promise<void> {
+    await this.client!.indices.putIndexTemplate({
+      name: LOG_INDEX_TEMPLATE,
+      index_patterns: [`${LOG_INDEX_PREFIX}-*`],
+      ...LOG_INDEX_MAPPINGS,
+      priority: 100,
+    });
+    this.logger.log(`Elasticsearch log index template '${LOG_INDEX_TEMPLATE}' registered`);
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -10,7 +10,6 @@ import Redis from 'ioredis';
 import { AppModule } from './app.module';
 import { GlobalExceptionFilter } from './common/interceptors/global-exception.filter';
 import { ResponseTransformInterceptor } from './common/interceptors/response-transform.interceptor';
-import { LoggingInterceptor } from './common/interceptors/logging.interceptor';
 import { correlationMiddleware } from './common/utils/correlation.utils';
 import {
   API_VERSION_HEADER,
@@ -150,9 +149,6 @@ async function bootstrapWorker(): Promise<void> {
 
   // ─── Global Exception Filter ──────────────────────────────────────────────
   app.useGlobalFilters(new GlobalExceptionFilter());
-
-  // ─── Global Logging Interceptor ───────────────────────────────────────────
-  app.useGlobalInterceptors(new LoggingInterceptor());
 
   // ─── Global Response Transform Interceptor ───────────────────────────────
   app.useGlobalInterceptors(new ResponseTransformInterceptor());


### PR DESCRIPTION
## Summary

Resolves outstanding documentation and observability requirements across four issues.

**Closes #357 — Disaster Recovery Plan**
Added `docs/disaster-recovery.md` with RTO/RPO targets, scenario runbooks (DB failure, region outage, data corruption), automated alert reference, and a monthly drill checklist.

**Closes #356 — Backup Strategy**
Added `docs/backup-strategy.md` documenting the backup schedule, retention policy, S3 + KMS encryption architecture, `backup_records` schema, retry/resilience config, and operational procedures.

**Closes #360 — Logging Format Standardization**
Refactored `LoggingInterceptor` to always emit structured JSON with a consistent envelope: `@timestamp`, `service`, `environment`, `level`, `event`, and `correlationId`. Removed the prod/dev format split.

**Closes #361 — Log Shipment**
Added `LogShipperService` which ships every log entry to Elasticsearch using a daily rolling index (`teachlink-logs-YYYY.MM.DD`). Registers an index template on startup for consistent field mappings. Fire-and-forget — a downed ES cluster never impacts API availability. Disabled gracefully when `ELASTICSEARCH_NODE` is unset.