### PR TITLE
feat: implement optimistic locking across all entities

### DIFF
--- a/src/ab-testing/entities/experiment-metric.entity.ts
+++ b/src/ab-testing/entities/experiment-metric.entity.ts
@@ -5,6 +5,7 @@ import {
   CreateDateColumn,
   UpdateDateColumn,
   ManyToOne,
+  VersionColumn,
 } from 'typeorm';
 import { Experiment } from './experiment.entity';
 
@@ -20,6 +21,9 @@ export enum MetricType {
 export class ExperimentMetric {
   @PrimaryGeneratedColumn('uuid')
   id: string;
+
+  @VersionColumn()
+  version: number;
 
   @Column()
   name: string;

--- a/src/ab-testing/entities/experiment-variant.entity.ts
+++ b/src/ab-testing/entities/experiment-variant.entity.ts
@@ -7,6 +7,7 @@ import {
   DeleteDateColumn,
   ManyToOne,
   OneToMany,
+  VersionColumn,
 } from 'typeorm';
 import { Experiment } from './experiment.entity';
 import { VariantMetric } from './variant-metric.entity';
@@ -15,6 +16,9 @@ import { VariantMetric } from './variant-metric.entity';
 export class IExperimentVariant {
   @PrimaryGeneratedColumn('uuid')
   id: string;
+
+  @VersionColumn()
+  version: number;
 
   @Column()
   name: string;

--- a/src/ab-testing/entities/experiment.entity.ts
+++ b/src/ab-testing/entities/experiment.entity.ts
@@ -5,6 +5,7 @@ import {
   CreateDateColumn,
   UpdateDateColumn,
   OneToMany,
+  VersionColumn,
 } from 'typeorm';
 import { IExperimentVariant } from './experiment-variant.entity';
 import { ExperimentMetric } from './experiment-metric.entity';
@@ -27,6 +28,9 @@ export enum ExperimentType {
 export class Experiment {
   @PrimaryGeneratedColumn('uuid')
   id: string;
+
+  @VersionColumn()
+  version: number;
 
   @Column({ unique: true })
   name: string;

--- a/src/ab-testing/entities/variant-metric.entity.ts
+++ b/src/ab-testing/entities/variant-metric.entity.ts
@@ -5,6 +5,7 @@ import {
   CreateDateColumn,
   UpdateDateColumn,
   ManyToOne,
+  VersionColumn,
 } from 'typeorm';
 import { IExperimentVariant } from './experiment-variant.entity';
 
@@ -12,6 +13,9 @@ import { IExperimentVariant } from './experiment-variant.entity';
 export class VariantMetric {
   @PrimaryGeneratedColumn('uuid')
   id: string;
+
+  @VersionColumn()
+  version: number;
 
   @Column({ type: 'decimal', precision: 15, scale: 4, default: 0 })
   value: number;

--- a/src/assessment/entities/answer.entity.ts
+++ b/src/assessment/entities/answer.entity.ts
@@ -1,10 +1,13 @@
-import { Column, Entity, ManyToOne, PrimaryGeneratedColumn } from 'typeorm';
+import { Column, Entity, ManyToOne, PrimaryGeneratedColumn, VersionColumn } from 'typeorm';
 import { AssessmentAttempt } from './assessment-attempt.entity';
 import { Question } from './question.entity';
 @Entity()
 export class Answer {
   @PrimaryGeneratedColumn('uuid')
   id: string;
+
+  @VersionColumn()
+  version: number;
 
   @ManyToOne(() => AssessmentAttempt, (a) => a.answers)
   attempt: AssessmentAttempt;

--- a/src/assessment/entities/assessment-attempt.entity.ts
+++ b/src/assessment/entities/assessment-attempt.entity.ts
@@ -1,4 +1,11 @@
-import { Entity, PrimaryGeneratedColumn, Column, ManyToOne, OneToMany } from 'typeorm';
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  ManyToOne,
+  OneToMany,
+  VersionColumn,
+} from 'typeorm';
 import { AssessmentStatus } from '../enums/assessment-status.enum';
 import { Answer } from './answer.entity';
 import { Assessment } from './assessment.entity';
@@ -7,6 +14,9 @@ import { Assessment } from './assessment.entity';
 export class AssessmentAttempt {
   @PrimaryGeneratedColumn('uuid')
   id: string;
+
+  @VersionColumn()
+  version: number;
 
   @Column()
   studentId: string;

--- a/src/assessment/entities/assessment.entity.ts
+++ b/src/assessment/entities/assessment.entity.ts
@@ -6,6 +6,7 @@ import {
   Index,
   OneToMany,
   PrimaryGeneratedColumn,
+  VersionColumn,
 } from 'typeorm';
 import { Question } from './question.entity';
 
@@ -13,6 +14,9 @@ import { Question } from './question.entity';
 export class Assessment {
   @PrimaryGeneratedColumn('uuid')
   id: string;
+
+  @VersionColumn()
+  version: number;
 
   @Column()
   @Index()

--- a/src/assessment/entities/question.entity.ts
+++ b/src/assessment/entities/question.entity.ts
@@ -5,6 +5,7 @@ import {
   Index,
   ManyToOne,
   PrimaryGeneratedColumn,
+  VersionColumn,
 } from 'typeorm';
 import { QuestionType } from '../enums/question-type.enum';
 import { Assessment } from './assessment.entity';
@@ -13,6 +14,9 @@ import { Assessment } from './assessment.entity';
 export class Question {
   @PrimaryGeneratedColumn('uuid')
   id: string;
+
+  @VersionColumn()
+  version: number;
 
   @Column({ type: 'enum', enum: QuestionType })
   @Index()

--- a/src/audit-log/audit-log.entity.ts
+++ b/src/audit-log/audit-log.entity.ts
@@ -1,4 +1,11 @@
-import { Entity, Column, PrimaryGeneratedColumn, CreateDateColumn, Index } from 'typeorm';
+import {
+  Entity,
+  Column,
+  PrimaryGeneratedColumn,
+  CreateDateColumn,
+  Index,
+  VersionColumn,
+} from 'typeorm';
 import { AuditAction, AuditSeverity, AuditCategory } from './enums/audit-action.enum';
 
 @Entity('audit_logs')
@@ -12,6 +19,9 @@ import { AuditAction, AuditSeverity, AuditCategory } from './enums/audit-action.
 export class AuditLog {
   @PrimaryGeneratedColumn('uuid')
   id: string;
+
+  @VersionColumn()
+  version: number;
 
   @Column({ name: 'user_id', nullable: true })
   userId: string | null;

--- a/src/backup/entities/backup-record.entity.ts
+++ b/src/backup/entities/backup-record.entity.ts
@@ -6,6 +6,7 @@ import {
   UpdateDateColumn,
   DeleteDateColumn,
   Index,
+  VersionColumn,
 } from 'typeorm';
 import { BackupStatus } from '../enums/backup-status.enum';
 import { BackupType } from '../enums/backup-type.enum';
@@ -18,6 +19,9 @@ import { Region } from '../enums/region.enum';
 export class BackupRecord {
   @PrimaryGeneratedColumn('uuid')
   id: string;
+
+  @VersionColumn()
+  version: number;
 
   @Column({ type: 'enum', enum: BackupType, default: BackupType.FULL })
   backupType: BackupType;

--- a/src/backup/entities/recovery-test.entity.ts
+++ b/src/backup/entities/recovery-test.entity.ts
@@ -7,6 +7,7 @@ import {
   UpdateDateColumn,
   Index,
   JoinColumn,
+  VersionColumn,
 } from 'typeorm';
 import { RecoveryTestStatus } from '../enums/recovery-test-status.enum';
 import { BackupRecord } from './backup-record.entity';
@@ -18,6 +19,9 @@ import { BackupRecord } from './backup-record.entity';
 export class RecoveryTest {
   @PrimaryGeneratedColumn('uuid')
   id: string;
+
+  @VersionColumn()
+  version: number;
 
   @Column({ name: 'backup_record_id' })
   backupRecordId: string;

--- a/src/cdn/entities/content-metadata.entity.ts
+++ b/src/cdn/entities/content-metadata.entity.ts
@@ -5,6 +5,7 @@ import {
   CreateDateColumn,
   UpdateDateColumn,
   Index,
+  VersionColumn,
 } from 'typeorm';
 
 export enum ContentType {
@@ -29,6 +30,9 @@ export enum ContentStatus {
 export class ContentMetadata {
   @PrimaryGeneratedColumn('uuid')
   id: string;
+
+  @VersionColumn()
+  version: number;
 
   @Column({ name: 'content_id', unique: true })
   contentId: string;

--- a/src/common/interceptors/global-exception.filter.ts
+++ b/src/common/interceptors/global-exception.filter.ts
@@ -8,7 +8,7 @@ import {
 } from '@nestjs/common';
 import { Request, Response } from 'express';
 import { MulterError } from 'multer';
-import { QueryFailedError, EntityNotFoundError } from 'typeorm';
+import { QueryFailedError, EntityNotFoundError, OptimisticLockVersionMismatchError } from 'typeorm';
 import { IApiError, IValidationErrorDetail } from '../../interfaces/api-error.interface';
 import { CORRELATION_ID_HEADER, getCorrelationId } from '../utils/correlation.utils';
 
@@ -82,6 +82,16 @@ export class GlobalExceptionFilter implements ExceptionFilter {
         statusCode: HttpStatus.NOT_FOUND,
         message: 'The requested resource was not found.',
         error: 'Not Found',
+        stack: (exception as Error).stack,
+      };
+    }
+
+    // 4b. TypeORM - Optimistic Locking Conflict
+    if (exception instanceof OptimisticLockVersionMismatchError) {
+      return {
+        statusCode: HttpStatus.CONFLICT,
+        message: 'The resource was modified by another request. Please refresh and try again.',
+        error: 'Conflict',
         stack: (exception as Error).stack,
       };
     }

--- a/src/courses/entities/course-module.entity.ts
+++ b/src/courses/entities/course-module.entity.ts
@@ -6,6 +6,7 @@ import {
   OneToMany,
   Index,
   DeleteDateColumn,
+  VersionColumn,
 } from 'typeorm';
 import { Course } from './course.entity';
 import { Lesson } from './lesson.entity';
@@ -14,6 +15,9 @@ import { Lesson } from './lesson.entity';
 export class CourseModule {
   @PrimaryGeneratedColumn('uuid')
   id: string;
+
+  @VersionColumn()
+  version: number;
 
   @Column()
   title: string;

--- a/src/courses/entities/course.entity.ts
+++ b/src/courses/entities/course.entity.ts
@@ -8,6 +8,7 @@ import {
   ManyToOne,
   OneToMany,
   Index,
+  VersionColumn,
 } from 'typeorm';
 import { User } from '../../users/entities/user.entity';
 import { CourseModule } from './course-module.entity';
@@ -17,6 +18,9 @@ import { Enrollment } from './enrollment.entity';
 export class Course {
   @PrimaryGeneratedColumn('uuid')
   id: string;
+
+  @VersionColumn()
+  version: number;
 
   @Column()
   @Index()

--- a/src/courses/entities/enrollment.entity.ts
+++ b/src/courses/entities/enrollment.entity.ts
@@ -6,6 +6,7 @@ import {
   CreateDateColumn,
   UpdateDateColumn,
   Index,
+  VersionColumn,
 } from 'typeorm';
 import { User } from '../../users/entities/user.entity';
 import { Course } from './course.entity';
@@ -16,6 +17,9 @@ import { Course } from './course.entity';
 export class Enrollment {
   @PrimaryGeneratedColumn('uuid')
   id: string;
+
+  @VersionColumn()
+  version: number;
 
   @ManyToOne(() => User, (user) => user.enrollments, { onDelete: 'CASCADE' })
   user: User;

--- a/src/courses/entities/lesson.entity.ts
+++ b/src/courses/entities/lesson.entity.ts
@@ -5,6 +5,7 @@ import {
   ManyToOne,
   Index,
   DeleteDateColumn,
+  VersionColumn,
 } from 'typeorm';
 import { CourseModule } from './course-module.entity';
 
@@ -12,6 +13,9 @@ import { CourseModule } from './course-module.entity';
 export class Lesson {
   @PrimaryGeneratedColumn('uuid')
   id: string;
+
+  @VersionColumn()
+  version: number;
 
   @Column()
   title: string;

--- a/src/email-marketing/entities/ab-test-variant.entity.ts
+++ b/src/email-marketing/entities/ab-test-variant.entity.ts
@@ -1,4 +1,11 @@
-import { Entity, PrimaryGeneratedColumn, Column, ManyToOne, JoinColumn } from 'typeorm';
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  ManyToOne,
+  JoinColumn,
+  VersionColumn,
+} from 'typeorm';
 import { ApiProperty } from '@nestjs/swagger';
 
 import { ABTest } from './ab-test.entity';
@@ -8,6 +15,9 @@ export class ABTestVariant {
   @ApiProperty()
   @PrimaryGeneratedColumn('uuid')
   id: string;
+
+  @VersionColumn()
+  version: number;
 
   @ApiProperty()
   @Column()

--- a/src/email-marketing/entities/ab-test.entity.ts
+++ b/src/email-marketing/entities/ab-test.entity.ts
@@ -6,6 +6,7 @@ import {
   OneToOne,
   OneToMany,
   JoinColumn,
+  VersionColumn,
 } from 'typeorm';
 import { ApiProperty } from '@nestjs/swagger';
 
@@ -18,6 +19,9 @@ export class ABTest {
   @ApiProperty()
   @PrimaryGeneratedColumn('uuid')
   id: string;
+
+  @VersionColumn()
+  version: number;
 
   @ApiProperty()
   @Column()

--- a/src/email-marketing/entities/automation-action.entity.ts
+++ b/src/email-marketing/entities/automation-action.entity.ts
@@ -5,6 +5,7 @@ import {
   ManyToOne,
   JoinColumn,
   DeleteDateColumn,
+  VersionColumn,
 } from 'typeorm';
 import { ApiProperty } from '@nestjs/swagger';
 
@@ -16,6 +17,9 @@ export class AutomationAction {
   @ApiProperty()
   @PrimaryGeneratedColumn('uuid')
   id: string;
+
+  @VersionColumn()
+  version: number;
 
   @ApiProperty()
   @Column()

--- a/src/email-marketing/entities/automation-trigger.entity.ts
+++ b/src/email-marketing/entities/automation-trigger.entity.ts
@@ -5,6 +5,7 @@ import {
   ManyToOne,
   JoinColumn,
   DeleteDateColumn,
+  VersionColumn,
 } from 'typeorm';
 import { ApiProperty } from '@nestjs/swagger';
 
@@ -16,6 +17,9 @@ export class AutomationTrigger {
   @ApiProperty()
   @PrimaryGeneratedColumn('uuid')
   id: string;
+
+  @VersionColumn()
+  version: number;
 
   @ApiProperty()
   @Column()

--- a/src/email-marketing/entities/automation-workflow.entity.ts
+++ b/src/email-marketing/entities/automation-workflow.entity.ts
@@ -6,6 +6,7 @@ import {
   UpdateDateColumn,
   DeleteDateColumn,
   OneToMany,
+  VersionColumn,
 } from 'typeorm';
 import { ApiProperty } from '@nestjs/swagger';
 
@@ -18,6 +19,9 @@ export class AutomationWorkflow {
   @ApiProperty()
   @PrimaryGeneratedColumn('uuid')
   id: string;
+
+  @VersionColumn()
+  version: number;
 
   @ApiProperty()
   @Column()

--- a/src/email-marketing/entities/campaign-recipient.entity.ts
+++ b/src/email-marketing/entities/campaign-recipient.entity.ts
@@ -6,6 +6,7 @@ import {
   JoinColumn,
   Index,
   DeleteDateColumn,
+  VersionColumn,
 } from 'typeorm';
 import { ApiProperty } from '@nestjs/swagger';
 
@@ -18,6 +19,9 @@ export class CampaignRecipient {
   @ApiProperty()
   @PrimaryGeneratedColumn('uuid')
   id: string;
+
+  @VersionColumn()
+  version: number;
 
   @ApiProperty()
   @Column()

--- a/src/email-marketing/entities/campaign.entity.ts
+++ b/src/email-marketing/entities/campaign.entity.ts
@@ -10,6 +10,7 @@ import {
   OneToOne,
   JoinColumn,
   Index,
+  VersionColumn,
 } from 'typeorm';
 import { ApiProperty } from '@nestjs/swagger';
 
@@ -23,6 +24,9 @@ export class Campaign {
   @ApiProperty()
   @PrimaryGeneratedColumn('uuid')
   id: string;
+
+  @VersionColumn()
+  version: number;
 
   @ApiProperty()
   @Column()

--- a/src/email-marketing/entities/email-event.entity.ts
+++ b/src/email-marketing/entities/email-event.entity.ts
@@ -1,4 +1,11 @@
-import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn, Index } from 'typeorm';
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  Index,
+  VersionColumn,
+} from 'typeorm';
 import { ApiProperty } from '@nestjs/swagger';
 
 import { EmailEventType } from '../enums/email-event-type.enum';
@@ -10,6 +17,9 @@ export class EmailEvent {
   @ApiProperty()
   @PrimaryGeneratedColumn('uuid')
   id: string;
+
+  @VersionColumn()
+  version: number;
 
   @ApiProperty()
   @Column()

--- a/src/email-marketing/entities/email-subscription.entity.ts
+++ b/src/email-marketing/entities/email-subscription.entity.ts
@@ -1,4 +1,11 @@
-import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn, Index } from 'typeorm';
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  Index,
+  VersionColumn,
+} from 'typeorm';
 import { ApiProperty } from '@nestjs/swagger';
 
 @Entity('email_subscriptions')
@@ -7,6 +14,9 @@ export class EmailSubscription {
   @ApiProperty()
   @PrimaryGeneratedColumn('uuid')
   id: string;
+
+  @VersionColumn()
+  version: number;
 
   @ApiProperty()
   @Column({ unique: true })

--- a/src/email-marketing/entities/email-template.entity.ts
+++ b/src/email-marketing/entities/email-template.entity.ts
@@ -5,6 +5,7 @@ import {
   CreateDateColumn,
   UpdateDateColumn,
   DeleteDateColumn,
+  VersionColumn,
 } from 'typeorm';
 import { ApiProperty } from '@nestjs/swagger';
 
@@ -13,6 +14,9 @@ export class EmailTemplate {
   @ApiProperty()
   @PrimaryGeneratedColumn('uuid')
   id: string;
+
+  @VersionColumn()
+  version: number;
 
   @ApiProperty()
   @Column()

--- a/src/email-marketing/entities/segment-rule.entity.ts
+++ b/src/email-marketing/entities/segment-rule.entity.ts
@@ -5,6 +5,7 @@ import {
   ManyToOne,
   JoinColumn,
   DeleteDateColumn,
+  VersionColumn,
 } from 'typeorm';
 import { ApiProperty } from '@nestjs/swagger';
 
@@ -17,6 +18,9 @@ export class SegmentRule {
   @ApiProperty()
   @PrimaryGeneratedColumn('uuid')
   id: string;
+
+  @VersionColumn()
+  version: number;
 
   @ApiProperty()
   @Column()

--- a/src/email-marketing/entities/segment.entity.ts
+++ b/src/email-marketing/entities/segment.entity.ts
@@ -6,6 +6,7 @@ import {
   UpdateDateColumn,
   DeleteDateColumn,
   OneToMany,
+  VersionColumn,
 } from 'typeorm';
 import { ApiProperty } from '@nestjs/swagger';
 
@@ -16,6 +17,9 @@ export class Segment {
   @ApiProperty()
   @PrimaryGeneratedColumn('uuid')
   id: string;
+
+  @VersionColumn()
+  version: number;
 
   @ApiProperty()
   @Column()

--- a/src/gamification/entities/badge.entity.ts
+++ b/src/gamification/entities/badge.entity.ts
@@ -1,9 +1,12 @@
-import { Entity, PrimaryGeneratedColumn, Column } from 'typeorm';
+import { Entity, PrimaryGeneratedColumn, Column, VersionColumn } from 'typeorm';
 
 @Entity('badges')
 export class Badge {
   @PrimaryGeneratedColumn('uuid')
   id: string;
+
+  @VersionColumn()
+  version: number;
 
   @Column()
   name: string;

--- a/src/gamification/entities/challenge.entity.ts
+++ b/src/gamification/entities/challenge.entity.ts
@@ -1,9 +1,12 @@
-import { Entity, PrimaryGeneratedColumn, Column } from 'typeorm';
+import { Entity, PrimaryGeneratedColumn, Column, VersionColumn } from 'typeorm';
 
 @Entity('challenges')
 export class Challenge {
   @PrimaryGeneratedColumn('uuid')
   id: string;
+
+  @VersionColumn()
+  version: number;
 
   @Column()
   title: string;

--- a/src/gamification/entities/point-transaction.entity.ts
+++ b/src/gamification/entities/point-transaction.entity.ts
@@ -1,10 +1,20 @@
-import { Entity, PrimaryGeneratedColumn, Column, ManyToOne, CreateDateColumn } from 'typeorm';
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  ManyToOne,
+  CreateDateColumn,
+  VersionColumn,
+} from 'typeorm';
 import { User } from '../../users/entities/user.entity';
 
 @Entity('point_transactions')
 export class PointTransaction {
   @PrimaryGeneratedColumn('uuid')
   id: string;
+
+  @VersionColumn()
+  version: number;
 
   @ManyToOne(() => User)
   user: User;

--- a/src/gamification/entities/user-badge.entity.ts
+++ b/src/gamification/entities/user-badge.entity.ts
@@ -1,4 +1,10 @@
-import { Entity, PrimaryGeneratedColumn, ManyToOne, CreateDateColumn } from 'typeorm';
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  ManyToOne,
+  CreateDateColumn,
+  VersionColumn,
+} from 'typeorm';
 import { User } from '../../users/entities/user.entity';
 import { Badge } from './badge.entity';
 
@@ -6,6 +12,9 @@ import { Badge } from './badge.entity';
 export class UserBadge {
   @PrimaryGeneratedColumn('uuid')
   id: string;
+
+  @VersionColumn()
+  version: number;
 
   @ManyToOne(() => User)
   user: User;

--- a/src/gamification/entities/user-challenge.entity.ts
+++ b/src/gamification/entities/user-challenge.entity.ts
@@ -1,4 +1,4 @@
-import { Entity, PrimaryGeneratedColumn, ManyToOne, Column } from 'typeorm';
+import { Entity, PrimaryGeneratedColumn, ManyToOne, Column, VersionColumn } from 'typeorm';
 import { User } from '../../users/entities/user.entity';
 import { Challenge } from './challenge.entity';
 
@@ -6,6 +6,9 @@ import { Challenge } from './challenge.entity';
 export class UserChallenge {
   @PrimaryGeneratedColumn('uuid')
   id: string;
+
+  @VersionColumn()
+  version: number;
 
   @ManyToOne(() => User)
   user: User;

--- a/src/gamification/entities/user-progress.entity.ts
+++ b/src/gamification/entities/user-progress.entity.ts
@@ -1,10 +1,21 @@
-import { Entity, PrimaryGeneratedColumn, Column, OneToOne, JoinColumn, Index } from 'typeorm';
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  OneToOne,
+  JoinColumn,
+  Index,
+  VersionColumn,
+} from 'typeorm';
 import { User } from '../../users/entities/user.entity';
 
 @Entity('user_progress')
 export class UserProgress {
   @PrimaryGeneratedColumn('uuid')
   id: string;
+
+  @VersionColumn()
+  version: number;
 
   @OneToOne(() => User)
   @JoinColumn()

--- a/src/localization/entities/translation.entity.ts
+++ b/src/localization/entities/translation.entity.ts
@@ -7,6 +7,7 @@ import {
   DeleteDateColumn,
   Index,
   Unique,
+  VersionColumn,
 } from 'typeorm';
 
 @Entity('translations')
@@ -15,6 +16,9 @@ import {
 export class Translation {
   @PrimaryGeneratedColumn('uuid')
   id: string;
+
+  @VersionColumn()
+  version: number;
 
   @Column()
   namespace: string;

--- a/src/migrations/entities/migration.entity.ts
+++ b/src/migrations/entities/migration.entity.ts
@@ -20,7 +20,7 @@ export class Migration {
   id: string;
 
   @VersionColumn()
-  version: number;
+  lockVersion: number;
 
   @Column({ unique: true })
   name: string;

--- a/src/migrations/entities/migration.entity.ts
+++ b/src/migrations/entities/migration.entity.ts
@@ -4,6 +4,7 @@ import {
   PrimaryGeneratedColumn,
   CreateDateColumn,
   UpdateDateColumn,
+  VersionColumn,
 } from 'typeorm';
 
 export enum MigrationStatus {
@@ -17,6 +18,9 @@ export enum MigrationStatus {
 export class Migration {
   @PrimaryGeneratedColumn('uuid')
   id: string;
+
+  @VersionColumn()
+  version: number;
 
   @Column({ unique: true })
   name: string;

--- a/src/moderation/analytics/moderation-event.entity.ts
+++ b/src/moderation/analytics/moderation-event.entity.ts
@@ -1,9 +1,12 @@
-import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn } from 'typeorm';
+import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn, VersionColumn } from 'typeorm';
 
 @Entity()
 export class ModerationEvent {
   @PrimaryGeneratedColumn()
   id: number;
+
+  @VersionColumn()
+  version: number;
 
   @Column('text')
   content: string;

--- a/src/moderation/manual/review-item.entity.ts
+++ b/src/moderation/manual/review-item.entity.ts
@@ -1,9 +1,12 @@
-import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn } from 'typeorm';
+import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn, VersionColumn } from 'typeorm';
 
 @Entity()
 export class ReviewItem {
   @PrimaryGeneratedColumn()
   id: number;
+
+  @VersionColumn()
+  version: number;
 
   @Column('text')
   content: string;

--- a/src/monitoring/metrics/metrics-collection.service.ts
+++ b/src/monitoring/metrics/metrics-collection.service.ts
@@ -65,6 +65,9 @@ export class MetricsCollectionService implements OnModuleInit {
     this.dbPoolSize = new Gauge({
       name: 'db_pool_size',
       help: 'Current DB connection pool size (active + idle)',
+      registers: [this.registry],
+    });
+
     // User Registrations Counter
     this.userRegistrations = new Counter({
       name: 'user_registrations_total',

--- a/src/notifications/entities/notification-preferences.entity.ts
+++ b/src/notifications/entities/notification-preferences.entity.ts
@@ -6,6 +6,7 @@ import {
   JoinColumn,
   CreateDateColumn,
   UpdateDateColumn,
+  VersionColumn,
 } from 'typeorm';
 import { User } from '../../users/entities/user.entity';
 
@@ -13,6 +14,9 @@ import { User } from '../../users/entities/user.entity';
 export class NotificationPreferences {
   @PrimaryGeneratedColumn('uuid')
   id: string;
+
+  @VersionColumn()
+  version: number;
 
   @Column()
   userId: string;

--- a/src/notifications/entities/notification.entity.ts
+++ b/src/notifications/entities/notification.entity.ts
@@ -7,6 +7,7 @@ import {
   DeleteDateColumn,
   ManyToOne,
   Index,
+  VersionColumn,
 } from 'typeorm';
 import { User } from '../../users/entities/user.entity';
 
@@ -28,6 +29,9 @@ export enum NotificationPriority {
 export class Notification {
   @PrimaryGeneratedColumn('uuid')
   id: string;
+
+  @VersionColumn()
+  version: number;
 
   @Column()
   @Index()

--- a/src/payments/entities/invoice.entity.ts
+++ b/src/payments/entities/invoice.entity.ts
@@ -7,6 +7,7 @@ import {
   ManyToOne,
   JoinColumn,
   Index,
+  VersionColumn,
 } from 'typeorm';
 import { Payment } from './payment.entity';
 import { User } from '../../users/entities/user.entity';
@@ -30,6 +31,9 @@ interface InvoiceItem {
 export class Invoice {
   @PrimaryGeneratedColumn('uuid')
   id: string;
+
+  @VersionColumn()
+  version: number;
 
   @Column({ type: 'varchar', unique: true })
   @Index()

--- a/src/payments/entities/payment.entity.ts
+++ b/src/payments/entities/payment.entity.ts
@@ -7,6 +7,7 @@ import {
   ManyToOne,
   JoinColumn,
   Index,
+  VersionColumn,
 } from 'typeorm';
 import { User } from '../../users/entities/user.entity';
 import { Course } from '../../courses/entities/course.entity';
@@ -33,6 +34,9 @@ export enum PaymentMethod {
 export class Payment {
   @PrimaryGeneratedColumn('uuid')
   id: string;
+
+  @VersionColumn()
+  version: number;
 
   @Column({ type: 'decimal', precision: 10, scale: 2 })
   amount: number;

--- a/src/payments/entities/refund.entity.ts
+++ b/src/payments/entities/refund.entity.ts
@@ -6,6 +6,7 @@ import {
   UpdateDateColumn,
   ManyToOne,
   JoinColumn,
+  VersionColumn,
 } from 'typeorm';
 import { Payment } from './payment.entity';
 
@@ -21,6 +22,9 @@ export enum RefundStatus {
 export class Refund {
   @PrimaryGeneratedColumn('uuid')
   id: string;
+
+  @VersionColumn()
+  version: number;
 
   @Column({ type: 'decimal', precision: 10, scale: 2, nullable: true })
   amount: number;

--- a/src/payments/entities/subscription.entity.ts
+++ b/src/payments/entities/subscription.entity.ts
@@ -7,6 +7,7 @@ import {
   ManyToOne,
   JoinColumn,
   Index,
+  VersionColumn,
 } from 'typeorm';
 import { User } from '../../users/entities/user.entity';
 
@@ -31,6 +32,9 @@ export enum SubscriptionInterval {
 export class Subscription {
   @PrimaryGeneratedColumn('uuid')
   id: string;
+
+  @VersionColumn()
+  version: number;
 
   @Column({ type: 'varchar', unique: true, nullable: true })
   providerSubscriptionId: string;

--- a/src/payments/webhooks/entities/webhook-retry.entity.ts
+++ b/src/payments/webhooks/entities/webhook-retry.entity.ts
@@ -5,6 +5,7 @@ import {
   CreateDateColumn,
   UpdateDateColumn,
   Index,
+  VersionColumn,
 } from 'typeorm';
 
 export enum WebhookStatus {
@@ -27,6 +28,9 @@ export enum WebhookProvider {
 export class WebhookRetry {
   @PrimaryGeneratedColumn('uuid')
   id: string;
+
+  @VersionColumn()
+  version: number;
 
   @Column({ type: 'enum', enum: WebhookProvider })
   provider: WebhookProvider;

--- a/src/tenancy/entities/tenant-billing.entity.ts
+++ b/src/tenancy/entities/tenant-billing.entity.ts
@@ -8,6 +8,7 @@ import {
   ManyToOne,
   JoinColumn,
   Index,
+  VersionColumn,
 } from 'typeorm';
 import { Tenant } from './tenant.entity';
 
@@ -21,6 +22,9 @@ export enum BillingCycle {
 export class TenantBilling {
   @PrimaryGeneratedColumn('uuid')
   id: string;
+
+  @VersionColumn()
+  version: number;
 
   @Column()
   @Index()

--- a/src/tenancy/entities/tenant-config.entity.ts
+++ b/src/tenancy/entities/tenant-config.entity.ts
@@ -8,6 +8,7 @@ import {
   ManyToOne,
   JoinColumn,
   Index,
+  VersionColumn,
 } from 'typeorm';
 import { Tenant } from './tenant.entity';
 
@@ -15,6 +16,9 @@ import { Tenant } from './tenant.entity';
 export class TenantConfig {
   @PrimaryGeneratedColumn('uuid')
   id: string;
+
+  @VersionColumn()
+  version: number;
 
   @Column()
   @Index()

--- a/src/tenancy/entities/tenant-customization.entity.ts
+++ b/src/tenancy/entities/tenant-customization.entity.ts
@@ -8,6 +8,7 @@ import {
   ManyToOne,
   JoinColumn,
   Index,
+  VersionColumn,
 } from 'typeorm';
 import { Tenant } from './tenant.entity';
 
@@ -15,6 +16,9 @@ import { Tenant } from './tenant.entity';
 export class TenantCustomization {
   @PrimaryGeneratedColumn('uuid')
   id: string;
+
+  @VersionColumn()
+  version: number;
 
   @Column()
   @Index()

--- a/src/tenancy/entities/tenant.entity.ts
+++ b/src/tenancy/entities/tenant.entity.ts
@@ -6,6 +6,7 @@ import {
   UpdateDateColumn,
   DeleteDateColumn,
   Index,
+  VersionColumn,
 } from 'typeorm';
 
 export enum TenantStatus {
@@ -26,6 +27,9 @@ export enum TenantPlan {
 export class Tenant {
   @PrimaryGeneratedColumn('uuid')
   id: string;
+
+  @VersionColumn()
+  version: number;
 
   @Column({ unique: true })
   @Index()

--- a/src/users/entities/user.entity.ts
+++ b/src/users/entities/user.entity.ts
@@ -7,6 +7,7 @@ import {
   DeleteDateColumn,
   Index,
   OneToMany,
+  VersionColumn,
 } from 'typeorm';
 import { Course } from '../../courses/entities/course.entity';
 import { Enrollment } from '../../courses/entities/enrollment.entity';
@@ -27,6 +28,9 @@ export enum UserStatus {
 export class User {
   @PrimaryGeneratedColumn('uuid')
   id: string;
+
+  @VersionColumn()
+  version: number;
 
   @Column({ unique: true })
   @Index()


### PR DESCRIPTION
Close #388 

## Overview
This PR implements optimistic locking to prevent data loss during concurrent updates across the system.

## Changes
- **Database Entities**: Added `@VersionColumn()` to all entity files in `src/*/entities/*.entity.ts`. 
- **Conflict Handling**: Updated `GlobalExceptionFilter` to intercept TypeORM's `OptimisticLockVersionMismatchError` and return a proper `409 Conflict` HTTP response.
- **Bug Fixes**: 
    - Resolved a naming conflict in the `Migration` entity by using `lockVersion` for the ORM versioning.
    - Fixed a pre-existing syntax error (missing closing brace) in `MetricsCollectionService`.

## Impacted Files
- `src/*/entities/*.entity.ts`
- `src/common/interceptors/global-exception.filter.ts`
- `src/monitoring/metrics/metrics-collection.service.ts`
