### PR TITLE
Feat/audit logging password policy

### DIFF
--- a/src/audit-log/audit-log.service.ts
+++ b/src/audit-log/audit-log.service.ts
@@ -5,6 +5,11 @@ import { AuditLog } from './audit-log.entity';
 import { AuditAction, AuditSeverity, AuditCategory } from './enums/audit-action.enum';
 import { ConfigService } from '@nestjs/config';
 import { sanitizePii } from '../common/utils/pii-sanitizer.utils';
+import {
+  buildRetentionCutoff,
+  buildRetentionUntil,
+  resolveRetentionDays,
+} from '../middleware/audit/log-retention.policy';
 
 export interface IAuditLogEntry {
   userId?: string;
@@ -76,15 +81,16 @@ export class AuditLogService {
     private readonly auditRepo: Repository<AuditLog>,
     private readonly configService: ConfigService,
   ) {
-    this.retentionDays = this.configService.get<number>('AUDIT_LOG_RETENTION_DAYS', 365);
+    this.retentionDays = resolveRetentionDays(
+      this.configService.get<number>('AUDIT_LOG_RETENTION_DAYS', 365),
+    );
   }
 
   /**
    * Log an audit event
    */
   async log(entry: IAuditLogEntry): Promise<AuditLog> {
-    const retentionUntil = new Date();
-    retentionUntil.setDate(retentionUntil.getDate() + this.retentionDays);
+    const retentionUntil = buildRetentionUntil(this.retentionDays);
 
     const log = this.auditRepo.create({
       ...entry,
@@ -510,8 +516,7 @@ export class AuditLogService {
    * Apply retention policy - delete old logs
    */
   async applyRetentionPolicy(): Promise<number> {
-    const cutoffDate = new Date();
-    cutoffDate.setDate(cutoffDate.getDate() - this.retentionDays);
+    const cutoffDate = buildRetentionCutoff(this.retentionDays);
 
     const result = await this.auditRepo
       .createQueryBuilder()

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -10,6 +10,7 @@ import { SessionModule } from '../session/session.module';
 import { TransactionService } from '../common/database/transaction.service';
 import { NotificationsModule } from '../notifications/notifications.module';
 import { AuditLogModule } from '../audit-log/audit-log.module';
+import { PasswordPolicyService } from './services/password-policy.service';
 
 function parseJwtSecrets(raw: string): Record<string, string> {
   try {
@@ -69,7 +70,7 @@ function getCurrentJwtAccessSecret(configService: ConfigService): string {
     }),
   ],
   controllers: [AuthController],
-  providers: [AuthService, JwtStrategy, TransactionService],
+  providers: [AuthService, JwtStrategy, TransactionService, PasswordPolicyService],
   exports: [AuthService],
 })
 export class AuthModule {}

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -16,6 +16,7 @@ import {
 import { NotificationsService } from '../notifications/notifications.service';
 import { AuditLogService } from '../audit-log/audit-log.service';
 import { AuditAction, AuditSeverity } from '../audit-log/enums/audit-action.enum';
+import { PasswordPolicyService } from './services/password-policy.service';
 
 interface IJwtTokenPayload {
   sub: string;
@@ -69,6 +70,7 @@ export class AuthService {
     private readonly transactionService: TransactionService,
     private readonly notificationsService: NotificationsService,
     private readonly auditLogService: AuditLogService,
+    private readonly passwordPolicyService: PasswordPolicyService,
   ) {}
 
   async register(
@@ -76,6 +78,8 @@ export class AuthService {
     ipAddress?: string,
     userAgent?: string,
   ): Promise<IRegisterResponse> {
+    await this.passwordPolicyService.enforce(registerDto.password);
+
     return await this.transactionService.runInTransaction(async (_manager) => {
       // Create user
       const user = await this.usersService.create(registerDto);
@@ -306,6 +310,8 @@ export class AuthService {
   }
 
   async resetPassword(resetPasswordDto: ResetPasswordDto): Promise<{ message: string }> {
+    await this.passwordPolicyService.enforce(resetPasswordDto.newPassword);
+
     // Find user by reset token
     const userOrNull = await this.usersService.findByPasswordResetToken(resetPasswordDto.token);
     const user = ensureValidUserToken(
@@ -346,6 +352,8 @@ export class AuthService {
       );
       throw new BadRequestException('Current password is incorrect');
     }
+
+    await this.passwordPolicyService.enforce(changePasswordDto.newPassword);
 
     // Update password
     await this.usersService.update(userId, { password: changePasswordDto.newPassword });

--- a/src/auth/services/password-policy.service.ts
+++ b/src/auth/services/password-policy.service.ts
@@ -1,0 +1,122 @@
+import { BadRequestException, Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { createHash } from 'crypto';
+import axios from 'axios';
+import {
+  calculatePasswordStrength,
+  IPasswordStrengthResult,
+} from '../../common/validators/password.validator';
+
+const DEFAULT_MIN_LENGTH = 12;
+const HIBP_RANGE_ENDPOINT = 'https://api.pwnedpasswords.com/range';
+
+interface IBreachCheckResult {
+  checked: boolean;
+  breached: boolean;
+  breachCount: number;
+}
+
+@Injectable()
+export class PasswordPolicyService {
+  private readonly logger = new Logger(PasswordPolicyService.name);
+
+  constructor(private readonly configService: ConfigService) {}
+
+  async enforce(password: string): Promise<void> {
+    const complexity = this.validateComplexity(password);
+    if (!complexity.isValid) {
+      throw new BadRequestException(complexity.errors.join('; '));
+    }
+
+    const breachResult = await this.checkBreach(password);
+    if (breachResult.breached) {
+      throw new BadRequestException(
+        'Password has appeared in known data breaches. Choose a different password.',
+      );
+    }
+  }
+
+  validateComplexity(password: string): IPasswordStrengthResult {
+    const result = calculatePasswordStrength(password);
+    const minLength = this.configService.get<number>(
+      'PASSWORD_POLICY_MIN_LENGTH',
+      DEFAULT_MIN_LENGTH,
+    );
+
+    if (password.length < minLength) {
+      result.errors.push(`Password must be at least ${minLength} characters long`);
+    }
+
+    if (/\s/.test(password)) {
+      result.errors.push('Password must not contain whitespace');
+    }
+
+    if (/(password|qwerty|123456|letmein|admin)/i.test(password)) {
+      result.errors.push('Password must not include common weak patterns');
+    }
+
+    return {
+      ...result,
+      isValid: result.errors.length === 0,
+    };
+  }
+
+  async checkBreach(password: string): Promise<IBreachCheckResult> {
+    const breachCheckEnabled =
+      this.configService.get<string>('PASSWORD_BREACH_CHECK_ENABLED', 'true') !== 'false';
+
+    if (!breachCheckEnabled || process.env.NODE_ENV === 'test') {
+      return { checked: false, breached: false, breachCount: 0 };
+    }
+
+    const hash = createHash('sha1').update(password).digest('hex').toUpperCase();
+    const prefix = hash.slice(0, 5);
+    const suffix = hash.slice(5);
+
+    try {
+      const response = await axios.get<string>(`${HIBP_RANGE_ENDPOINT}/${prefix}`, {
+        timeout: 5000,
+        headers: {
+          'Add-Padding': 'true',
+        },
+        responseType: 'text',
+      });
+
+      const lines = response.data.split('\n');
+      const breachThreshold = this.configService.get<number>('PASSWORD_BREACH_MIN_COUNT', 1);
+
+      for (const line of lines) {
+        const [hashSuffix, countRaw] = line.trim().split(':');
+        if (!hashSuffix || !countRaw) {
+          continue;
+        }
+
+        if (hashSuffix === suffix) {
+          const breachCount = Number.parseInt(countRaw, 10) || 0;
+          return {
+            checked: true,
+            breached: breachCount >= breachThreshold,
+            breachCount,
+          };
+        }
+      }
+
+      return { checked: true, breached: false, breachCount: 0 };
+    } catch (error) {
+      const failClosed =
+        this.configService.get<string>('PASSWORD_BREACH_CHECK_FAIL_CLOSED', 'false') === 'true';
+      this.logger.warn(
+        'Password breach check failed',
+        error instanceof Error ? error.message : String(error),
+      );
+
+      if (failClosed) {
+        throw new BadRequestException(
+          'Password breach verification unavailable. Please try again.',
+        );
+      }
+
+      return { checked: false, breached: false, breachCount: 0 };
+    }
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -23,6 +23,8 @@ import helmet from 'helmet';
 import { corsConfig } from './config/cors.config';
 import { ShutdownStateService } from './common/services/shutdown-state.service';
 import { TIME, BYTES } from './common/constants/time.constants';
+import { AuditLogService } from './audit-log/audit-log.service';
+import { createAuditLoggerMiddleware } from './middleware/audit/audit-logger.middleware';
 
 type SessionRequest = Request & {
   session?: Session & Partial<SessionData> & { userAgent?: string };
@@ -105,6 +107,13 @@ async function bootstrapWorker(): Promise<void> {
   }
 
   app.use(correlationMiddleware);
+
+  try {
+    const auditLogService = app.get(AuditLogService, { strict: false });
+    app.use(createAuditLoggerMiddleware(auditLogService));
+  } catch {
+    logger.warn('AuditLogService not available. Global audit middleware was not registered.');
+  }
 
   app.use(
     session({

--- a/src/middleware/audit/audit-logger.middleware.ts
+++ b/src/middleware/audit/audit-logger.middleware.ts
@@ -1,0 +1,73 @@
+import { Logger } from '@nestjs/common';
+import { NextFunction, Request, Response } from 'express';
+import { AuditLogService } from '../../audit-log/audit-log.service';
+import { AuditSeverity } from '../../audit-log/enums/audit-action.enum';
+import { resolveUserAction } from './user-action-tracker';
+
+interface IRequestWithUser extends Request {
+  user?: {
+    id?: string;
+    email?: string;
+  };
+  requestId?: string;
+}
+
+const logger = new Logger('AuditLoggerMiddleware');
+
+const SKIP_PATTERNS = [/^\/health/, /^\/favicon/, /^\/api$/];
+
+function shouldSkipLogging(path: string): boolean {
+  return SKIP_PATTERNS.some((pattern) => pattern.test(path));
+}
+
+export function createAuditLoggerMiddleware(auditLogService: AuditLogService) {
+  return (req: IRequestWithUser, res: Response, next: NextFunction): void => {
+    const startTime = Date.now();
+    const endpoint = req.originalUrl || req.path;
+
+    if (shouldSkipLogging(endpoint)) {
+      next();
+      return;
+    }
+
+    res.on('finish', () => {
+      const responseTimeMs = Date.now() - startTime;
+      const statusCode = res.statusCode;
+      const userAction = resolveUserAction(req.method, endpoint);
+
+      const severity =
+        statusCode >= 500
+          ? AuditSeverity.ERROR
+          : statusCode >= 400
+            ? AuditSeverity.WARNING
+            : AuditSeverity.INFO;
+
+      void auditLogService
+        .log({
+          userId: req.user?.id,
+          userEmail: req.user?.email,
+          action: userAction.action,
+          category: userAction.category,
+          severity,
+          description: userAction.description,
+          apiEndpoint: endpoint,
+          httpMethod: req.method,
+          statusCode,
+          responseTimeMs,
+          ipAddress: req.ip,
+          userAgent: req.headers['user-agent'] || 'unknown',
+          requestId: req.requestId,
+          metadata: {
+            path: req.path,
+            baseUrl: req.baseUrl,
+            queryKeys: Object.keys(req.query || {}),
+          },
+        })
+        .catch((error: unknown) => {
+          logger.error('Failed to write audit log from middleware', error as Error);
+        });
+    });
+
+    next();
+  };
+}

--- a/src/middleware/audit/log-retention.policy.ts
+++ b/src/middleware/audit/log-retention.policy.ts
@@ -1,0 +1,21 @@
+const DEFAULT_RETENTION_DAYS = 365;
+
+export function resolveRetentionDays(configuredDays?: number): number {
+  if (!configuredDays || configuredDays < 1) {
+    return DEFAULT_RETENTION_DAYS;
+  }
+
+  return configuredDays;
+}
+
+export function buildRetentionUntil(retentionDays: number, now: Date = new Date()): Date {
+  const retentionUntil = new Date(now);
+  retentionUntil.setDate(retentionUntil.getDate() + resolveRetentionDays(retentionDays));
+  return retentionUntil;
+}
+
+export function buildRetentionCutoff(retentionDays: number, now: Date = new Date()): Date {
+  const cutoff = new Date(now);
+  cutoff.setDate(cutoff.getDate() - resolveRetentionDays(retentionDays));
+  return cutoff;
+}

--- a/src/middleware/audit/user-action-tracker.ts
+++ b/src/middleware/audit/user-action-tracker.ts
@@ -1,0 +1,78 @@
+import { AuditAction, AuditCategory } from '../../audit-log/enums/audit-action.enum';
+
+export interface IUserActionDescriptor {
+  action: AuditAction;
+  category: AuditCategory;
+  description: string;
+}
+
+const WRITE_METHODS = new Set(['POST', 'PUT', 'PATCH', 'DELETE']);
+
+export function resolveUserAction(method: string, path: string): IUserActionDescriptor {
+  const normalizedMethod = method.toUpperCase();
+  const normalizedPath = path.toLowerCase();
+
+  if (normalizedPath.includes('/auth/login')) {
+    return {
+      action: AuditAction.LOGIN,
+      category: AuditCategory.AUTHENTICATION,
+      description: `User authentication attempt via ${normalizedMethod} ${path}`,
+    };
+  }
+
+  if (normalizedPath.includes('/auth/logout')) {
+    return {
+      action: AuditAction.LOGOUT,
+      category: AuditCategory.AUTHENTICATION,
+      description: `User logout via ${normalizedMethod} ${path}`,
+    };
+  }
+
+  if (normalizedPath.includes('/auth/register')) {
+    return {
+      action: AuditAction.REGISTER,
+      category: AuditCategory.AUTHENTICATION,
+      description: `User registration via ${normalizedMethod} ${path}`,
+    };
+  }
+
+  if (normalizedMethod === 'GET') {
+    return {
+      action: AuditAction.DATA_VIEWED,
+      category: AuditCategory.DATA_ACCESS,
+      description: `Data access via ${normalizedMethod} ${path}`,
+    };
+  }
+
+  if (normalizedMethod === 'POST') {
+    return {
+      action: AuditAction.DATA_CREATED,
+      category: WRITE_METHODS.has(normalizedMethod)
+        ? AuditCategory.DATA_MODIFICATION
+        : AuditCategory.DATA_ACCESS,
+      description: `Resource creation via ${normalizedMethod} ${path}`,
+    };
+  }
+
+  if (normalizedMethod === 'PUT' || normalizedMethod === 'PATCH') {
+    return {
+      action: AuditAction.DATA_UPDATED,
+      category: AuditCategory.DATA_MODIFICATION,
+      description: `Resource update via ${normalizedMethod} ${path}`,
+    };
+  }
+
+  if (normalizedMethod === 'DELETE') {
+    return {
+      action: AuditAction.DATA_DELETED,
+      category: AuditCategory.DATA_MODIFICATION,
+      description: `Resource deletion via ${normalizedMethod} ${path}`,
+    };
+  }
+
+  return {
+    action: AuditAction.API_CALLED,
+    category: AuditCategory.DATA_ACCESS,
+    description: `API call via ${normalizedMethod} ${path}`,
+  };
+}


### PR DESCRIPTION
## feat: audit logging password policy

Closes #398 
Closes #400
Closes #406 

**This PR delivers two security/observability improvements:**

- Global audit middleware now captures detailed user/API actions with severity, metadata, and retention-aware handling.
- Auth now enforces a stronger password policy at service level, including breach detection (HIBP k-anonymity), and applies it consistently to register, reset, and change-password flows.