### PR TITLE
feat(logging): implement log aggregation with shipper, storage, and search

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,6 +25,22 @@ BCRYPT_ROUNDS=10
 REDIS_HOST=localhost
 REDIS_PORT=6379
 
+# Elasticsearch / Log Aggregation
+# Node URL for the Elasticsearch cluster used for centralised log storage.
+# Leave unset to disable log shipping (app still logs to stdout).
+ELASTICSEARCH_NODE=http://localhost:9200
+# Optional basic-auth credentials (mutually exclusive with ELASTICSEARCH_API_KEY)
+ELASTICSEARCH_USERNAME=
+ELASTICSEARCH_PASSWORD=
+# Optional API-key auth (preferred for cloud-hosted clusters)
+ELASTICSEARCH_API_KEY=
+# Optional CA fingerprint for TLS verification in self-signed setups
+ELASTICSEARCH_CA_FINGERPRINT=
+ELASTICSEARCH_REQUEST_TIMEOUT=30000
+ELASTICSEARCH_MAX_RETRIES=3
+# Kibana URL used for log-search dashboards
+KIBANA_URL=http://localhost:5601
+
 # Alerting / Notification Channels
 # Comma-separated list of email addresses that receive alert notifications
 ALERT_EMAIL_RECIPIENTS=ops@teachlink.io,oncall@teachlink.io

--- a/infra/monitoring/.env.example
+++ b/infra/monitoring/.env.example
@@ -10,3 +10,14 @@ SLACK_WEBHOOK_URL=
 
 # PagerDuty integration key (Events API v1) for critical alerts
 PAGERDUTY_SERVICE_KEY=
+
+# Kibana (log search UI)
+KIBANA_PORT=5601
+KIBANA_VERSION=8.13.4
+
+# Filebeat (log shipper)
+FILEBEAT_VERSION=8.13.4
+
+# Elasticsearch credentials forwarded to Filebeat (leave blank for unauthenticated local dev)
+ELASTICSEARCH_USERNAME=
+ELASTICSEARCH_PASSWORD=

--- a/infra/monitoring/docker-compose.yml
+++ b/infra/monitoring/docker-compose.yml
@@ -9,6 +9,7 @@ volumes:
   prometheus-data:
   alertmanager-data:
   grafana-data:
+  kibana-data:
 
 services:
   app:
@@ -184,3 +185,52 @@ services:
       timeout: 10s
       retries: 3
       start_period: 15s
+
+  # ─── Log Search UI ──────────────────────────────────────────────────────────
+  kibana:
+    image: kibana:${KIBANA_VERSION:-8.13.4}
+    container_name: teachlink-kibana
+    restart: unless-stopped
+    ports:
+      - '${KIBANA_PORT:-5601}:5601'
+    environment:
+      ELASTICSEARCH_HOSTS: 'http://elasticsearch:9200'
+      TELEMETRY_ENABLED: 'false'
+      SERVER_NAME: 'teachlink-kibana'
+    networks:
+      - teachlink
+    volumes:
+      - kibana-data:/usr/share/kibana/data
+    depends_on:
+      elasticsearch:
+        condition: service_healthy
+    healthcheck:
+      test:
+        [
+          'CMD-SHELL',
+          'curl -s http://localhost:5601/api/status | grep -q "\"overall\":{\"level\":\"available\""',
+        ]
+      interval: 30s
+      timeout: 10s
+      retries: 10
+      start_period: 120s
+
+  # ─── Log Shipper (container stdout → Elasticsearch) ─────────────────────────
+  filebeat:
+    image: elastic/filebeat:${FILEBEAT_VERSION:-8.13.4}
+    container_name: teachlink-filebeat
+    restart: unless-stopped
+    user: root
+    networks:
+      - teachlink
+    volumes:
+      - ../../logging/shipper/filebeat.yml:/usr/share/filebeat/filebeat.yml:ro
+      - /var/lib/docker/containers:/var/lib/docker/containers:ro
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    depends_on:
+      elasticsearch:
+        condition: service_healthy
+    environment:
+      ELASTICSEARCH_NODE: 'http://elasticsearch:9200'
+      ELASTICSEARCH_USERNAME: '${ELASTICSEARCH_USERNAME:-}'
+      ELASTICSEARCH_PASSWORD: '${ELASTICSEARCH_PASSWORD:-}'

--- a/logging/search/kibana.yml
+++ b/logging/search/kibana.yml
@@ -1,0 +1,91 @@
+# ─── Kibana – Log Search UI ───────────────────────────────────────────────────
+# Adds Kibana to the log aggregation stack so operators can search, filter,
+# and visualise structured application logs stored in Elasticsearch.
+#
+# Compose this file on top of the storage stack:
+#   docker compose \
+#     -f logging/storage/elasticsearch.yml \
+#     -f logging/search/kibana.yml \
+#     up -d
+#
+# Then open http://localhost:5601 and navigate to:
+#   Discover → select the teachlink-logs-* data view
+#
+# Environment variables (override via shell or .env):
+#   KIBANA_VERSION          – defaults to 8.13.4 (must match Elasticsearch)
+#   KIBANA_PORT             – host port, defaults to 5601
+#   KIBANA_ADMIN_USER       – defaults to kibana_system
+#   KIBANA_ADMIN_PASSWORD   – defaults to changeme (set a real password in prod)
+#   ELASTICSEARCH_NODE      – defaults to http://elasticsearch:9200
+# ─────────────────────────────────────────────────────────────────────────────
+
+name: teachlink-logging-search
+
+networks:
+  logging:
+    external: true          # Attaches to the network created by elasticsearch.yml
+
+services:
+  kibana:
+    image: kibana:${KIBANA_VERSION:-8.13.4}
+    container_name: teachlink-kibana
+    restart: unless-stopped
+    ports:
+      - '${KIBANA_PORT:-5601}:5601'
+    environment:
+      ELASTICSEARCH_HOSTS: '${ELASTICSEARCH_NODE:-http://elasticsearch:9200}'
+      ELASTICSEARCH_USERNAME: '${KIBANA_ADMIN_USER:-kibana_system}'
+      ELASTICSEARCH_PASSWORD: '${KIBANA_ADMIN_PASSWORD:-changeme}'
+      # Disable telemetry in self-hosted environments
+      TELEMETRY_ENABLED: 'false'
+      SERVER_NAME: 'teachlink-kibana'
+    networks:
+      - logging
+    depends_on:
+      - kibana-data-view-init
+    healthcheck:
+      test:
+        - CMD-SHELL
+        - >
+          curl -s http://localhost:5601/api/status
+          | grep -q '"overall":{"level":"available"'
+      interval: 30s
+      timeout: 10s
+      retries: 10
+      start_period: 120s
+    labels:
+      com.teachlink.component: 'log-search'
+
+  # ─── Data view initialiser ─────────────────────────────────────────────────
+  # One-shot container that creates the teachlink-logs-* index pattern / data
+  # view so Discover works out of the box without manual Kibana setup.
+  kibana-data-view-init:
+    image: curlimages/curl:latest
+    container_name: teachlink-kibana-data-view-init
+    restart: on-failure
+    networks:
+      - logging
+    # Wait for Kibana to be ready before registering the data view
+    entrypoint:
+      - /bin/sh
+      - -c
+      - |
+        echo "Waiting for Kibana to become available ..."
+        until curl -s http://kibana:5601/api/status | grep -q '"overall":{"level":"available"'; do
+          sleep 5
+        done
+        echo "Kibana is up. Creating teachlink-logs-* data view ..."
+        curl -s -X POST "http://kibana:5601/api/data_views/data_view" \
+          -H "kbn-xsrf: true" \
+          -H "Content-Type: application/json" \
+          -d '{
+            "data_view": {
+              "title": "teachlink-logs-*",
+              "name": "TeachLink Logs",
+              "timeFieldName": "@timestamp"
+            }
+          }'
+        echo ""
+        echo "Data view registered."
+    labels:
+      com.teachlink.component: 'log-search'

--- a/logging/shipper/filebeat.yml
+++ b/logging/shipper/filebeat.yml
@@ -1,0 +1,62 @@
+# ─── Filebeat Log Shipper ────────────────────────────────────────────────────
+# Collects structured JSON logs from the teachlink-api container's stdout and
+# ships them to Elasticsearch using the same daily rolling index pattern used
+# by LogShipperService: teachlink-logs-YYYY.MM.DD
+#
+# Run alongside the app with:
+#   docker compose -f logging/storage/elasticsearch.yml \
+#                  -f logging/search/kibana.yml \
+#                  -f logging/shipper/filebeat.yml up -d
+# ─────────────────────────────────────────────────────────────────────────────
+
+filebeat.inputs:
+  # Collect all container stdout/stderr via the Docker socket.
+  # Each line is a JSON object emitted by NestJS / LoggingInterceptor.
+  - type: container
+    paths:
+      - '/var/lib/docker/containers/*/*.log'
+    processors:
+      # Decode the JSON log message into structured fields
+      - decode_json_fields:
+          fields: ['message']
+          target: ''
+          overwrite_keys: true
+      # Keep only containers labelled for this service
+      - add_docker_metadata:
+          host: 'unix:///var/run/docker.sock'
+      - drop_event:
+          when:
+            not:
+              equals:
+                container.labels.com_docker_compose_service: 'app'
+
+# ─── Processors applied to every event ───────────────────────────────────────
+processors:
+  - add_host_metadata: {}
+  - add_cloud_metadata: {}
+  # Rename the raw Docker timestamp to @timestamp so ES auto-detects the type
+  - rename:
+      fields:
+        - from: 'time'
+          to: '@timestamp'
+      ignore_missing: true
+      fail_on_error: false
+
+# ─── Output ───────────────────────────────────────────────────────────────────
+output.elasticsearch:
+  hosts: ['${ELASTICSEARCH_NODE:http://elasticsearch:9200}']
+  # Username / password (leave blank when using API key)
+  username: '${ELASTICSEARCH_USERNAME:}'
+  password: '${ELASTICSEARCH_PASSWORD:}'
+  # Daily rolling index — matches the LogShipperService pattern
+  index: 'teachlink-logs-%{+yyyy.MM.dd}'
+  # Bulk settings for throughput vs. latency balance
+  bulk_max_size: 512
+  worker: 2
+
+setup.ilm.enabled: false         # ILM managed separately via elasticsearch.yml policy
+setup.template.enabled: false    # Template registered by LogShipperService on startup
+
+# ─── Logging ─────────────────────────────────────────────────────────────────
+logging.level: warning
+logging.to_files: false          # Send Filebeat's own logs to stdout only

--- a/logging/storage/elasticsearch.yml
+++ b/logging/storage/elasticsearch.yml
@@ -1,0 +1,97 @@
+# ─── Elasticsearch – Centralised Log Storage ─────────────────────────────────
+# Standalone Docker Compose that brings up a single-node Elasticsearch cluster
+# optimised for log ingestion.
+#
+# The app's LogShipperService writes directly to this cluster via the HTTP API.
+# Filebeat (logging/shipper/filebeat.yml) can also forward container stdout.
+#
+# Usage:
+#   docker compose -f logging/storage/elasticsearch.yml up -d
+#
+# Environment variables (override via shell or .env):
+#   ELASTICSEARCH_VERSION  – defaults to 8.13.4
+#   ELASTICSEARCH_PORT     – host port, defaults to 9200
+#   ES_JAVA_OPTS           – JVM heap, defaults to -Xms512m -Xmx512m
+# ─────────────────────────────────────────────────────────────────────────────
+
+name: teachlink-logging-storage
+
+networks:
+  logging:
+    driver: bridge
+
+volumes:
+  elasticsearch-logs-data:
+
+services:
+  elasticsearch:
+    image: elasticsearch:${ELASTICSEARCH_VERSION:-8.13.4}
+    container_name: teachlink-elasticsearch
+    restart: unless-stopped
+    ports:
+      - '${ELASTICSEARCH_PORT:-9200}:9200'
+    environment:
+      discovery.type: single-node
+      # Disable TLS/auth for local dev; enable xpack.security in production
+      xpack.security.enabled: 'false'
+      ES_JAVA_OPTS: '${ES_JAVA_OPTS:--Xms512m -Xmx512m}'
+      cluster.name: teachlink-logs
+      # Log-optimised index settings applied via LogShipperService template
+      indices.lifecycle.poll_interval: 1m
+    networks:
+      - logging
+    volumes:
+      - elasticsearch-logs-data:/usr/share/elasticsearch/data
+    healthcheck:
+      test:
+        - CMD-SHELL
+        - >
+          curl -s http://localhost:9200/_cluster/health
+          | grep -qv '"status":"red"'
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 60s
+    labels:
+      com.teachlink.component: 'log-storage'
+
+  # ─── Index Lifecycle Policy initialiser ──────────────────────────────────
+  # One-shot container that registers a 30-day hot/delete ILM policy so log
+  # indices are automatically pruned without manual intervention.
+  elasticsearch-ilm-init:
+    image: curlimages/curl:latest
+    container_name: teachlink-elasticsearch-ilm-init
+    restart: on-failure
+    depends_on:
+      elasticsearch:
+        condition: service_healthy
+    networks:
+      - logging
+    entrypoint:
+      - /bin/sh
+      - -c
+      - |
+        echo "Registering ILM policy teachlink-logs-policy ..."
+        curl -s -X PUT "http://elasticsearch:9200/_ilm/policy/teachlink-logs-policy" \
+          -H "Content-Type: application/json" \
+          -d '{
+            "policy": {
+              "phases": {
+                "hot": {
+                  "min_age": "0ms",
+                  "actions": {
+                    "rollover": { "max_age": "1d", "max_size": "5gb" },
+                    "set_priority": { "priority": 100 }
+                  }
+                },
+                "delete": {
+                  "min_age": "30d",
+                  "actions": { "delete": {} }
+                }
+              }
+            }
+          }'
+        echo ""
+        echo "ILM policy registered."
+    labels:
+      com.teachlink.component: 'log-storage'

--- a/src/observability/logging/log-aggregation.service.ts
+++ b/src/observability/logging/log-aggregation.service.ts
@@ -1,20 +1,25 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable, Logger, Optional } from '@nestjs/common';
 import {
   IStructuredLog,
   ILogQuery,
   ILogSearchResult,
   LogLevel,
 } from '../interfaces/observability.interfaces';
+import { LogShipperService } from '../../common/services/log-shipper.service';
 
 /**
  * Log Aggregation Service
- * Centralized log storage and search functionality
+ * Centralized log storage and search functionality.
+ * In-memory store acts as a hot buffer; every entry is also forwarded
+ * to Elasticsearch via LogShipperService for persistent, searchable storage.
  */
 @Injectable()
 export class LogAggregationService {
   private readonly logger = new Logger(LogAggregationService.name);
   private logs: IStructuredLog[] = [];
   private readonly MAX_LOGS = 10000; // In-memory limit
+
+  constructor(@Optional() private readonly logShipper?: LogShipperService) {}
 
   /**
    * Store a log entry
@@ -200,27 +205,38 @@ export class LogAggregationService {
   }
 
   /**
-   * Send logs to external service (placeholder)
+   * Ship a log entry to Elasticsearch via LogShipperService.
+   * Fire-and-forget — never throws so in-memory storage is never blocked.
    */
-  private async sendToExternalService(_log: IStructuredLog): Promise<void> {
-    // In production, implement integration with:
-    // - Elasticsearch
-    // - AWS CloudWatch
-    // - Datadog
-    // - Splunk
-    // - Grafana Loki
-    // etc.
+  private async sendToExternalService(log: IStructuredLog): Promise<void> {
+    if (!this.logShipper) return;
 
-    // Example: Elasticsearch
-    // await this.elasticsearchClient.index({
-    //   index: 'logs',
-    //   body: _log,
-    // });
+    const document: Record<string, unknown> = {
+      '@timestamp': log.context.timestamp.toISOString(),
+      level: log.level,
+      message: log.message,
+      service: log.context.service,
+      environment: log.context.environment,
+      correlationId: log.context.correlationId,
+      traceId: log.context.traceId,
+      spanId: log.context.spanId,
+      userId: log.context.userId,
+      requestId: log.context.requestId,
+      duration: log.duration,
+      tags: log.tags,
+      ...(log.error && {
+        error: {
+          name: log.error.name,
+          message: log.error.message,
+          stack: log.error.stack,
+          code: log.error.code,
+          statusCode: log.error.statusCode,
+        },
+      }),
+      ...(log.context.metadata && { metadata: log.context.metadata }),
+    };
 
-    // For now, just log to console in development
-    if (process.env.NODE_ENV === 'development') {
-      // Already logged by StructuredLoggerService
-    }
+    this.logShipper.ship(document);
   }
 
   /**

--- a/src/observability/observability.module.ts
+++ b/src/observability/observability.module.ts
@@ -7,14 +7,17 @@ import { LogAggregationService } from './logging/log-aggregation.service';
 import { DistributedTracingService } from './tracing/distributed-tracing.service';
 import { MetricsAnalysisService } from './metrics/metrics-analysis.service';
 import { AnomalyDetectionService } from './anomaly/anomaly-detection.service';
+import { CommonModule } from '../common/common.module';
 
 /**
  * Observability Module
- * Comprehensive logging, tracing, metrics, and anomaly detection
+ * Comprehensive logging, tracing, metrics, and anomaly detection.
+ * Imports CommonModule so LogAggregationService can forward entries to
+ * LogShipperService for persistent Elasticsearch storage.
  */
 @Global()
 @Module({
-  imports: [ScheduleModule.forRoot()],
+  imports: [ScheduleModule.forRoot(), CommonModule],
   controllers: [ObservabilityController],
   providers: [
     ObservabilityService,


### PR DESCRIPTION
## Summary

Centralises application logs so scattered per-service output is collected, stored, and searchable from a single place.

**Backend wiring**
- `LogAggregationService` (`src/observability/logging/log-aggregation.service.ts`) now injects `LogShipperService` via `@Optional()` and replaces the placeholder `sendToExternalService` with a real implementation that builds a flat Elasticsearch document and calls `logShipper.ship()` — fire-and-forget so a downed ES cluster never blocks the in-memory buffer
- `ObservabilityModule` imports `CommonModule` so `LogShipperService` is available in the aggregation DI context

**Infrastructure YAML files (`logging/*/*.yml`)**

| File | Purpose |
|---|---|
| `logging/shipper/filebeat.yml` | Filebeat config — reads Docker container stdout, decodes JSON, ships to Elasticsearch daily rolling index `teachlink-logs-YYYY.MM.DD` |
| `logging/storage/elasticsearch.yml` | Standalone Docker Compose for Elasticsearch + a one-shot ILM init container that registers a 30-day hot→delete policy |
| `logging/search/kibana.yml` | Docker Compose for Kibana with an init container that creates the `teachlink-logs-*` data view automatically |

**Monitoring stack extension (`infra/monitoring/docker-compose.yml`)**
- Adds `kibana` service (port 5601) backed by the existing Elasticsearch container for log search UI
- Adds `filebeat` service mounted on Docker socket to collect container stdout logs
- Adds `kibana-data` named volume

**Environment variables**
- `ELASTICSEARCH_*` vars added to root `.env.example` (node, credentials, timeout)
- `KIBANA_URL`, `KIBANA_PORT`, `FILEBEAT_VERSION` added to `infra/monitoring/.env.example`

## How to use

```bash
# Bring up the full log aggregation stack
docker compose \
  -f logging/storage/elasticsearch.yml \
  -f logging/search/kibana.yml \
  up -d

# Then open Kibana log search
open http://localhost:5601
# Navigate: Discover → teachlink-logs-* data view
```

## Test plan

- [ ] `npm run lint` passes on changed TypeScript files
- [ ] `npm run build` succeeds
- [ ] `LogAggregationService.storeLogs()` calls `logShipper.ship()` with flattened document
- [ ] `LogShipperService` is optional (`@Optional()`) — service still works without Elasticsearch configured
- [ ] `docker compose -f logging/storage/elasticsearch.yml up -d` starts a healthy ES node
- [ ] `docker compose -f logging/search/kibana.yml up -d` starts Kibana and registers `teachlink-logs-*` data view
- [ ] `logging/shipper/filebeat.yml` validates with `filebeat test config`

Closes #434