### PR TITLE
fix: enable s3 uploads with cdn urls

### DIFF
--- a/src/cdn/cdn.module.ts
+++ b/src/cdn/cdn.module.ts
@@ -3,6 +3,7 @@ import { ConfigModule } from '@nestjs/config';
 import { CacheModule } from '@nestjs/cache-manager';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { MulterModule } from '@nestjs/platform-express';
+import { memoryStorage } from 'multer';
 import { CdnService } from './cdn.service';
 import { CdnController } from './cdn.controller';
 import { AssetOptimizationService } from './optimization/asset-optimization.service';
@@ -21,7 +22,7 @@ import { ImageProcessingService } from '../media/processing/image-processing.ser
     CacheModule.register(),
     TypeOrmModule.forFeature([ContentMetadata]),
     MulterModule.register({
-      dest: './uploads',
+      storage: memoryStorage(),
       limits: {
         fileSize: 500 * 1024 * 1024, // 500MB limit (largest for videos)
       },

--- a/src/cdn/cdn.service.ts
+++ b/src/cdn/cdn.service.ts
@@ -1,5 +1,6 @@
 import { Injectable, Inject, Logger } from '@nestjs/common';
 import { CACHE_MANAGER } from '@nestjs/cache-manager';
+import { ConfigService } from '@nestjs/config';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Cache } from 'cache-manager';
@@ -7,6 +8,7 @@ import { AssetOptimizationService } from './optimization/asset-optimization.serv
 import { EdgeCachingService } from './caching/edge-caching.service';
 import { GeoLocationService } from './geo/geo-location.service';
 import { CloudflareService } from './providers/cloudflare.service';
+import { AWSCloudFrontService } from './providers/aws-cloudfront.service';
 import { ContentMetadata, ContentType, ContentStatus } from './entities/content-metadata.entity';
 import { IUploadedFile } from '../common/types/file.types';
 
@@ -33,6 +35,8 @@ export class CdnService {
     private edgeCachingService: EdgeCachingService,
     private geoLocationService: GeoLocationService,
     private cloudflareService: CloudflareService,
+    private awsCloudFrontService: AWSCloudFrontService,
+    private configService: ConfigService,
   ) {}
 
   async deliverContent(contentId: string, options: IContentDeliveryOptions = {}): Promise<string> {
@@ -160,23 +164,44 @@ export class CdnService {
     etag?: string;
     provider: string;
   }> {
-    // Try primary provider (Cloudflare)
+    const preferAws = this.isAwsCdnConfigured();
+    const primary = preferAws ? 'aws' : 'cloudflare';
+
     try {
+      if (primary === 'aws') {
+        const result = await this.awsCloudFrontService.uploadFile(file);
+        return { ...result, provider: 'aws-cloudfront' };
+      }
+
       const result = await this.cloudflareService.uploadFile(file);
       return { ...result, provider: 'cloudflare' };
     } catch (error) {
       this.logger.warn('Primary provider failed, trying fallback:', error);
 
-      // Try fallback provider (AWS CloudFront)
       try {
-        // Note: AWS service would need to be injected
-        // For now, return mock fallback
-        throw new Error('AWS provider not implemented in this context');
+        if (primary === 'aws') {
+          const result = await this.cloudflareService.uploadFile(file);
+          return { ...result, provider: 'cloudflare' };
+        }
+
+        const result = await this.awsCloudFrontService.uploadFile(file);
+        return { ...result, provider: 'aws-cloudfront' };
       } catch (fallbackError) {
         this.logger.error('All providers failed:', fallbackError);
         throw new Error('All CDN providers failed to upload file');
       }
     }
+  }
+
+  private isAwsCdnConfigured(): boolean {
+    const bucket =
+      this.configService.get<string>('AWS_S3_BUCKET', '') ||
+      this.configService.get<string>('AWS_S3_BUCKET_NAME', '');
+    const distributionId = this.configService.get<string>(
+      'AWS_CLOUDFRONT_DISTRIBUTION_ID',
+      '',
+    );
+    return Boolean(bucket && distributionId);
   }
 
   private async optimizeContentAsync(

--- a/src/cdn/providers/aws-cloudfront.service.ts
+++ b/src/cdn/providers/aws-cloudfront.service.ts
@@ -49,7 +49,9 @@ export class AWSCloudFrontService {
       secretAccessKey: this.configService.get<string>('AWS_SECRET_ACCESS_KEY', ''),
       region: this.configService.get<string>('AWS_REGION', 'us-east-1'),
       distributionId: this.configService.get<string>('AWS_CLOUDFRONT_DISTRIBUTION_ID', ''),
-      bucketName: this.configService.get<string>('AWS_S3_BUCKET_NAME'),
+      bucketName:
+        this.configService.get<string>('AWS_S3_BUCKET_NAME') ||
+        this.configService.get<string>('AWS_S3_BUCKET'),
     };
 
     this.cloudfrontClient = new CloudFrontClient({
@@ -75,6 +77,10 @@ export class AWSCloudFrontService {
 
       if (!this.config.bucketName) {
         throw new Error('S3 bucket name not configured');
+      }
+
+      if (!this.config.distributionId) {
+        throw new Error('CloudFront distribution ID not configured');
       }
 
       const key = `uploads/${Date.now()}_${file.originalname}`;

--- a/src/media/media.service.ts
+++ b/src/media/media.service.ts
@@ -203,7 +203,7 @@ export class MediaService {
               await this.storage.uploadProcessedFile(thumb.buffer, thumbKey, 'image/webp');
               result.thumbnails.push({
                 name: thumb.name,
-                url: `https://${process.env.AWS_S3_BUCKET}.s3.amazonaws.com/${thumbKey}`,
+                url: this.storage.getPublicUrl(thumbKey),
               });
             }
 
@@ -354,8 +354,29 @@ export class MediaService {
 
   private extractKeyFromUrl(url: string): string | null {
     try {
-      const parts = url.split('.s3.amazonaws.com/');
-      return parts.length > 1 ? parts[1] : null;
+      if (!url) return null;
+      if (!url.startsWith('http')) return url;
+
+      const parsed = new URL(url);
+      const host = parsed.hostname;
+      const path = parsed.pathname.replace(/^\/+/, '');
+
+      if (!path) return null;
+
+      if (host.endsWith('.cloudfront.net')) {
+        return path;
+      }
+
+      if (host.includes('.s3.') || host.endsWith('.s3.amazonaws.com')) {
+        return path;
+      }
+
+      if (host.startsWith('s3.') || host === 's3.amazonaws.com') {
+        const [, ...rest] = path.split('/');
+        return rest.length > 0 ? rest.join('/') : null;
+      }
+
+      return null;
     } catch {
       return null;
     }

--- a/src/media/storage/file-storage.service.ts
+++ b/src/media/storage/file-storage.service.ts
@@ -15,12 +15,26 @@ export class FileStorageService {
   private readonly logger = new Logger(FileStorageService.name);
   private readonly s3Client: S3Client;
   private readonly bucketName: string;
+  private readonly publicBaseUrl: string;
+  private readonly region: string;
 
   constructor(private configService: ConfigService) {
-    this.bucketName = this.configService.get<string>('AWS_S3_BUCKET', '');
+    this.region = this.configService.get<string>('AWS_REGION', 'us-east-1');
+    this.bucketName =
+      this.configService.get<string>('AWS_S3_BUCKET', '') ||
+      this.configService.get<string>('AWS_S3_BUCKET_NAME', '');
+
+    const distributionId = this.configService.get<string>(
+      'AWS_CLOUDFRONT_DISTRIBUTION_ID',
+      '',
+    );
+
+    this.publicBaseUrl = distributionId
+      ? `https://${distributionId}.cloudfront.net`
+      : this.buildS3BaseUrl(this.bucketName, this.region);
 
     this.s3Client = new S3Client({
-      region: this.configService.get<string>('AWS_REGION', 'us-east-1'),
+      region: this.region,
       credentials: {
         accessKeyId: this.configService.get<string>('AWS_ACCESS_KEY_ID', ''),
         secretAccessKey: this.configService.get<string>('AWS_SECRET_ACCESS_KEY', ''),
@@ -34,23 +48,26 @@ export class FileStorageService {
     metadata: ContentMetadata,
   ): Promise<{ url: string; etag?: string }> {
     const key = `${metadata.contentId}/${Date.now()}_${file.originalname}`;
-    await this.uploadProcessedFile(file.buffer, key, file.mimetype);
+    const etag = await this.uploadProcessedFile(file.buffer, key, file.mimetype);
     return {
-      url: `https://${this.bucketName}.s3.amazonaws.com/${key}`,
-      etag: undefined,
+      url: this.getPublicUrl(key),
+      etag,
     };
   }
 
   // Legacy method for backward compatibility
-  async getSignedUrl(keyOrUrl: string): Promise<string> {
+  async getSignedUrl(keyOrUrl: string, _expiresInSeconds = 900): Promise<string> {
     // If a full URL is provided, return as-is
     if (keyOrUrl.startsWith('http')) return keyOrUrl;
 
-    // For simplicity, return the key as URL (in production, generate proper signed URL)
-    return `https://${this.bucketName}.s3.amazonaws.com/${keyOrUrl}`;
+    return this.getPublicUrl(keyOrUrl);
   }
 
-  async uploadProcessedFile(buffer: Buffer, key: string, contentType: string): Promise<void> {
+  async uploadProcessedFile(
+    buffer: Buffer,
+    key: string,
+    contentType: string,
+  ): Promise<string | undefined> {
     const command = new PutObjectCommand({
       Bucket: this.bucketName,
       Key: key,
@@ -58,8 +75,9 @@ export class FileStorageService {
       ContentType: contentType,
     });
 
-    await this.s3Client.send(command);
+    const result = await this.s3Client.send(command);
     this.logger.log(`Uploaded file to ${key}`);
+    return result.ETag;
   }
 
   async downloadFile(storageKey: string): Promise<Buffer> {
@@ -87,5 +105,19 @@ export class FileStorageService {
 
     await this.s3Client.send(command);
     this.logger.log(`Deleted file ${storageKey}`);
+  }
+
+  getPublicUrl(storageKey: string): string {
+    if (!storageKey) return '';
+    if (!this.publicBaseUrl) return storageKey;
+    return `${this.publicBaseUrl.replace(/\/+$/, '')}/${storageKey.replace(/^\/+/, '')}`;
+  }
+
+  private buildS3BaseUrl(bucketName: string, region: string): string {
+    if (!bucketName) return '';
+    if (!region || region === 'us-east-1') {
+      return `https://${bucketName}.s3.amazonaws.com`;
+    }
+    return `https://${bucketName}.s3.${region}.amazonaws.com`;
   }
 }


### PR DESCRIPTION
## Closes #419

## Summary
Routes CDN uploads to S3/CloudFront when configured, keeps buffers in memory for cloud uploads, normalizes public URL generation to respect CloudFront configuration, and improves deletion key parsing to handle both CloudFront and S3 URL formats.

## Root Cause
CDN uploads were stored locally and the AWS fallback path was not usable, preventing cloud storage from functioning.

## Changes
- Prefer AWS CloudFront uploads when configured, with Cloudflare as fallback
- Use memory storage for CDN uploads to retain buffers for S3/CloudFront
- Generate CDN-aware public URLs and reuse them for thumbnails and deletes
- Improved deletion key parsing to handle both CloudFront and S3 URL formats