### PR TITLE
feat: harden container security policies and runtime protection

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,63 @@
+# ── Version control ────────────────────────────────────────────────────────────
+.git
+.gitignore
+.gitattributes
+
+# ── Secrets & credentials ──────────────────────────────────────────────────────
+.env
+.env.*
+!.env.example
+*.pem
+*.key
+*.p12
+*.pfx
+*.crt
+*.cer
+secrets/
+credentials/
+
+# ── Dev / local config ─────────────────────────────────────────────────────────
+.editorconfig
+.eslintrc*
+.eslintignore
+.prettierrc*
+.prettierignore
+.stylelintrc*
+jest.config*
+tsconfig*.json
+!tsconfig.build.json
+
+# ── Dependencies (rebuilt inside image) ───────────────────────────────────────
+node_modules/
+
+# ── Build artefacts ────────────────────────────────────────────────────────────
+dist/
+build/
+coverage/
+*.tsbuildinfo
+
+# ── Docs & non-runtime files ───────────────────────────────────────────────────
+README.md
+CONTRIBUTING.md
+CHANGELOG.md
+LICENSE
+docs/
+*.md
+
+# ── CI / tooling ──────────────────────────────────────────────────────────────
+.github/
+.husky/
+.vscode/
+.idea/
+*.log
+npm-debug.log*
+
+# ── OS artefacts ──────────────────────────────────────────────────────────────
+.DS_Store
+Thumbs.db
+
+# ── Test files ────────────────────────────────────────────────────────────────
+**/*.spec.ts
+**/*.test.ts
+**/*.e2e-spec.ts
+test/

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,33 +3,37 @@ FROM node:18-alpine AS builder
 
 WORKDIR /app
 
-# Install dependencies
 COPY package.json package-lock.json ./
 RUN npm ci
 
-# Copy source code
 COPY . .
-
-# Build the application
 RUN npm run build
 
 # Stage 2: Production
-FROM node:18-alpine
+FROM node:18-alpine AS production
+
+# Install dumb-init for proper signal handling
+RUN apk add --no-cache dumb-init \
+  && rm -rf /var/cache/apk/*
 
 WORKDIR /app
 
-# Copy built application from builder stage
+# Install production dependencies as root before switching user
+COPY package.json package-lock.json ./
+RUN npm ci --only=production --ignore-scripts \
+  && npm cache clean --force
+
 COPY --from=builder /app/dist ./dist
-COPY package.json ./
 
-# Install production dependencies
-RUN npm ci --only=production
+# Create writable tmp dir for the app, then lock down ownership
+RUN mkdir -p /app/tmp && chown -R node:node /app
 
-# Use non-root user for security
+# Drop to non-root user
 USER node
 
-# Expose application port
 EXPOSE 3000
 
-# Start the application
+# no-new-privileges enforced at runtime via security_opt in compose;
+# dumb-init ensures SIGTERM is forwarded to the Node process
+ENTRYPOINT ["dumb-init", "--"]
 CMD ["node", "dist/main.js"]

--- a/infra/monitoring/docker-compose.yml
+++ b/infra/monitoring/docker-compose.yml
@@ -37,6 +37,23 @@ services:
         condition: service_healthy
     networks:
       - teachlink
+    # ── Runtime security hardening ──────────────────────────────────────────
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+    read_only: true
+    tmpfs:
+      - /app/tmp:size=64m,mode=1777
+      - /tmp:size=32m,mode=1777
+    deploy:
+      resources:
+        limits:
+          cpus: '1.0'
+          memory: 512M
+        reservations:
+          cpus: '0.25'
+          memory: 128M
     healthcheck:
       test: ['CMD', 'wget', '--quiet', '--tries=1', '--spider', 'http://localhost:3000/health']
       interval: 30s
@@ -59,6 +76,23 @@ services:
       - teachlink
     volumes:
       - postgres-data:/var/lib/postgresql/data
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+    cap_add:
+      - CHOWN
+      - FOWNER
+      - SETUID
+      - SETGID
+    deploy:
+      resources:
+        limits:
+          cpus: '1.0'
+          memory: 512M
+        reservations:
+          cpus: '0.25'
+          memory: 128M
     healthcheck:
       test: ['CMD-SHELL', 'pg_isready -U ${DATABASE_USER:-postgres} -d ${DATABASE_NAME:-teachlink}']
       interval: 10s
@@ -82,6 +116,18 @@ services:
       - teachlink
     volumes:
       - redis-data:/data
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+    deploy:
+      resources:
+        limits:
+          cpus: '0.5'
+          memory: 256M
+        reservations:
+          cpus: '0.1'
+          memory: 64M
     healthcheck:
       test: ['CMD', 'redis-cli', 'ping']
       interval: 10s
@@ -104,6 +150,22 @@ services:
       - teachlink
     volumes:
       - elasticsearch-data:/usr/share/elasticsearch/data
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+    cap_add:
+      - CHOWN
+      - SETUID
+      - SETGID
+    deploy:
+      resources:
+        limits:
+          cpus: '1.0'
+          memory: 1G
+        reservations:
+          cpus: '0.25'
+          memory: 512M
     healthcheck:
       test:
         [
@@ -133,6 +195,18 @@ services:
       - ./prometheus.yml:/etc/prometheus/prometheus.yml:ro
       - ./alerts.yml:/etc/prometheus/alerts.yml:ro
       - prometheus-data:/prometheus
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+    deploy:
+      resources:
+        limits:
+          cpus: '0.5'
+          memory: 256M
+        reservations:
+          cpus: '0.1'
+          memory: 64M
     healthcheck:
       test: ['CMD', 'wget', '--quiet', '--tries=1', '--spider', 'http://localhost:9090/-/healthy']
       interval: 30s
@@ -154,6 +228,18 @@ services:
     volumes:
       - ./alertmanager.yml:/etc/alertmanager/alertmanager.yml:ro
       - alertmanager-data:/alertmanager
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+    deploy:
+      resources:
+        limits:
+          cpus: '0.25'
+          memory: 128M
+        reservations:
+          cpus: '0.05'
+          memory: 32M
     healthcheck:
       test: ['CMD', 'wget', '--quiet', '--tries=1', '--spider', 'http://localhost:9093/-/healthy']
       interval: 30s
@@ -179,6 +265,18 @@ services:
     depends_on:
       prometheus:
         condition: service_healthy
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+    deploy:
+      resources:
+        limits:
+          cpus: '0.5'
+          memory: 256M
+        reservations:
+          cpus: '0.1'
+          memory: 64M
     healthcheck:
       test: ['CMD', 'wget', '--quiet', '--tries=1', '--spider', 'http://localhost:3000/api/health']
       interval: 30s
@@ -199,6 +297,15 @@ services:
     depends_on:
       redis:
         condition: service_healthy
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+    deploy:
+      resources:
+        limits:
+          cpus: '0.1'
+          memory: 64M
 
   postgres_exporter:
     image: prometheuscommunity/postgres-exporter:latest
@@ -213,6 +320,15 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+    deploy:
+      resources:
+        limits:
+          cpus: '0.1'
+          memory: 64M
 
   # ─── Log Search UI ──────────────────────────────────────────────────────────
   kibana:
@@ -232,6 +348,22 @@ services:
     depends_on:
       elasticsearch:
         condition: service_healthy
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+    cap_add:
+      - CHOWN
+      - SETUID
+      - SETGID
+    deploy:
+      resources:
+        limits:
+          cpus: '0.5'
+          memory: 512M
+        reservations:
+          cpus: '0.1'
+          memory: 128M
     healthcheck:
       test:
         [
@@ -262,3 +394,17 @@ services:
       ELASTICSEARCH_NODE: 'http://elasticsearch:9200'
       ELASTICSEARCH_USERNAME: '${ELASTICSEARCH_USERNAME:-}'
       ELASTICSEARCH_PASSWORD: '${ELASTICSEARCH_PASSWORD:-}'
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+    cap_add:
+      - DAC_READ_SEARCH
+    deploy:
+      resources:
+        limits:
+          cpus: '0.25'
+          memory: 128M
+        reservations:
+          cpus: '0.05'
+          memory: 32M


### PR DESCRIPTION
closes #425 

Summary
  
  Hardens container security across the stack to address containers running with excessive
  privileges.
  
  Changes
  
  Dockerfile
  
  - Added dumb-init for proper signal handling and graceful shutdown
  - --ignore-scripts on npm ci to block malicious dependency install scripts
  - npm cache clean --force to reduce image attack surface
  - /app/tmp is the only writable directory; all other paths are owned by node:node
  
  docker-compose.yml
  
  - security_opt: no-new-privileges:true on all services — blocks privilege escalation via
  setuid binaries
  - cap_drop: ALL on all services — removes all Linux capabilities by default
  - Minimum cap_add only where required (e.g. CHOWN/SETUID/SETGID for
  postgres/elasticsearch/kibana, DAC_READ_SEARCH for filebeat)
  - read_only: true + tmpfs on the app container — immutable filesystem at runtime
  - CPU and memory deploy.resources.limits on every service — prevents resource exhaustion from
  a compromised container
  
  .dockerignore (new)
  
  - Excludes .env/secrets, node_modules, .git, CI config, test files, and docs from the build
  context, preventing accidental secret leakage into the image
  
  Image Scanning
  
  Already covered by .github/workflows/security.yml — Trivy image scan + IaC config scan with
  SARIF upload to the GitHub Security tab on every PR and nightly.
  
  Testing
  
  - docker build --target production . builds successfully
  - All services start with docker compose up without capability or permission errors

