### PR TITLE
feat: implement traffic mirroring for canary deployments (#639)

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -12,9 +12,9 @@ import { loadFeatureFlags } from './config/feature-flags.config';
 import { SessionModule } from './session/session.module';
 import { DebuggingModule } from './debugging/debugging.module';
 import { DataPipelineModule } from './data-pipeline/data-pipeline.module';
+import { CanaryModule } from './canary/canary.module';
 
 const featureFlags = loadFeatureFlags();
-
 
 @Module({
   imports: [
@@ -26,10 +26,11 @@ const featureFlags = loadFeatureFlags();
     ...(featureFlags.ENABLE_RATE_LIMITING ? [RateLimitingModule] : []),
     DebuggingModule,
     DataPipelineModule,
+    CanaryModule,
   ],
   controllers: [AppController],
   providers: featureFlags.ENABLE_RATE_LIMITING
     ? [{ provide: APP_GUARD, useClass: QuotaGuard }]
     : [],
 })
-export class AppModule { }
+export class AppModule {}

--- a/src/canary/canary-metrics.service.ts
+++ b/src/canary/canary-metrics.service.ts
@@ -1,0 +1,92 @@
+import { Injectable, Logger } from '@nestjs/common';
+
+export interface MirrorResult {
+  path: string;
+  method: string;
+  statusCode: number;
+  durationMs: number;
+  success: boolean;
+}
+
+export interface CanaryStats {
+  totalRequests: number;
+  successCount: number;
+  failureCount: number;
+  averageDurationMs: number;
+  successRate: number;
+}
+
+@Injectable()
+export class CanaryMetricsService {
+  private readonly logger = new Logger(CanaryMetricsService.name);
+  private readonly results: MirrorResult[] = [];
+
+  private readonly promoteThreshold = parseFloat(
+    process.env.CANARY_PROMOTE_THRESHOLD || '0.95',
+  );
+  private readonly rollbackThreshold = parseFloat(
+    process.env.CANARY_ROLLBACK_THRESHOLD || '0.70',
+  );
+  private readonly minSampleSize = parseInt(
+    process.env.CANARY_MIN_SAMPLE_SIZE || '20',
+    10,
+  );
+
+  recordMirrorResult(result: MirrorResult): void {
+    this.results.push(result);
+    this.logger.debug(
+      `Mirror [${result.method} ${result.path}] → ${result.statusCode} in ${result.durationMs}ms`,
+    );
+    this.evaluateCanary();
+  }
+
+  getStats(): CanaryStats {
+    const total = this.results.length;
+    if (total === 0) {
+      return {
+        totalRequests: 0,
+        successCount: 0,
+        failureCount: 0,
+        averageDurationMs: 0,
+        successRate: 0,
+      };
+    }
+
+    const successCount = this.results.filter((r) => r.success).length;
+    const failureCount = total - successCount;
+    const averageDurationMs =
+      this.results.reduce((sum, r) => sum + r.durationMs, 0) / total;
+    const successRate = successCount / total;
+
+    return {
+      totalRequests: total,
+      successCount,
+      failureCount,
+      averageDurationMs: Math.round(averageDurationMs),
+      successRate: Math.round(successRate * 100) / 100,
+    };
+  }
+
+  private evaluateCanary(): void {
+    const stats = this.getStats();
+
+    if (stats.totalRequests < this.minSampleSize) {
+      return;
+    }
+
+    if (stats.successRate >= this.promoteThreshold) {
+      this.logger.log(
+        `Canary PROMOTE signal: success rate ${stats.successRate} >= ${this.promoteThreshold} ` +
+          `over ${stats.totalRequests} requests.`,
+      );
+      return;
+    }
+
+    if (stats.successRate < this.rollbackThreshold) {
+      this.logger.error(
+        `Canary ROLLBACK signal: success rate ${stats.successRate} < ${this.rollbackThreshold} ` +
+          `over ${stats.totalRequests} requests.`,
+      );
+    }
+  }
+}

--- a/src/canary/canary.module.ts
+++ b/src/canary/canary.module.ts
@@ -1,0 +1,15 @@
+import { MiddlewareConsumer, Module, NestModule, RequestMethod } from '@nestjs/common';
+import { CanaryMetricsService } from './canary-metrics.service';
+import { TrafficMirrorMiddleware } from '../common/middleware/traffic-mirror.middleware';
+
+@Module({
+  providers: [CanaryMetricsService],
+  exports: [CanaryMetricsService],
+})
+export class CanaryModule implements NestModule {
+  configure(consumer: MiddlewareConsumer): void {
+    consumer
+      .apply(TrafficMirrorMiddleware)
+      .forRoutes({ path: '*', method: RequestMethod.ALL });
+  }
+}

--- a/src/common/middleware/traffic-mirror.middleware.ts
+++ b/src/common/middleware/traffic-mirror.middleware.ts
@@ -1,0 +1,84 @@
+import { Injectable, Logger, NestMiddleware } from '@nestjs/common';
+import { Request, Response, NextFunction } from 'express';
+import * as http from 'http';
+import * as https from 'https';
+import { CanaryMetricsService } from '../../canary/canary-metrics.service';
+
+@Injectable()
+export class TrafficMirrorMiddleware implements NestMiddleware {
+  private readonly logger = new Logger(TrafficMirrorMiddleware.name);
+
+  constructor(private readonly metrics: CanaryMetricsService) {}
+
+  use(req: Request, res: Response, next: NextFunction): void {
+    const canaryHost = process.env.CANARY_HOST;
+    const canaryPort = parseInt(process.env.CANARY_PORT || '3001', 10);
+    const mirrorEnabled = process.env.CANARY_MIRROR_ENABLED === 'true';
+
+    if (mirrorEnabled && canaryHost) {
+      this.mirrorRequest(req, canaryHost, canaryPort);
+    }
+
+    next();
+  }
+
+  private mirrorRequest(req: Request, host: string, port: number): void {
+    const startTime = Date.now();
+    const useHttps = process.env.CANARY_USE_HTTPS === 'true';
+    const transport = useHttps ? https : http;
+
+    const options: http.RequestOptions = {
+      hostname: host,
+      port,
+      path: req.originalUrl,
+      method: req.method,
+      headers: {
+        ...req.headers,
+        host,
+        'x-mirrored-request': 'true',
+        'x-original-host': req.hostname,
+      },
+    };
+
+    const mirrorReq = transport.request(options, (mirrorRes) => {
+      const duration = Date.now() - startTime;
+      this.metrics.recordMirrorResult({
+        path: req.originalUrl,
+        method: req.method,
+        statusCode: mirrorRes.statusCode ?? 0,
+        durationMs: duration,
+        success: (mirrorRes.statusCode ?? 0) < 500,
+      });
+
+      // Drain the mirrored response so the socket is released
+      mirrorRes.resume();
+    });
+
+    mirrorReq.on('error', (err) => {
+      const duration = Date.now() - startTime;
+      this.logger.warn(
+        `Canary mirror failed [${req.method} ${req.originalUrl}]: ${err.message}`,
+      );
+      this.metrics.recordMirrorResult({
+        path: req.originalUrl,
+        method: req.method,
+        statusCode: 0,
+        durationMs: duration,
+        success: false,
+      });
+    });
+
+    if (req.body && typeof req.body === 'object') {
+      try {
+        const bodyStr = JSON.stringify(req.body as Record<string, unknown>);
+        mirrorReq.setHeader('content-type', 'application/json');
+        mirrorReq.setHeader('content-length', Buffer.byteLength(bodyStr));
+        mirrorReq.write(bodyStr);
+      } catch {
+        // Non-serialisable body — skip body forwarding
+      }
+    }
+
+    mirrorReq.end();
+  }
+}


### PR DESCRIPTION
## What this PR does

Adds traffic mirroring support so new canary versions can be tested 
against live traffic without affecting current clients.

## Changes

- Added `TrafficMirrorMiddleware` that duplicates incoming requests 
  to a configurable canary host in the background
- Added `CanaryMetricsService` that tracks mirrored request outcomes 
  and logs promote or rollback signals based on success rate thresholds
- Added `CanaryModule` to wire the middleware and service together 
  and apply mirroring globally
- Registered `CanaryModule` in `app.module.ts`

## How it works

- Set `CANARY_MIRROR_ENABLED=true`, `CANARY_HOST`, and `CANARY_PORT` 
  in your environment to enable mirroring
- Mirrored requests run in the background and never block the 
  original response
- The metrics service automatically logs a promote signal when 
  success rate reaches 95% and a rollback signal when it drops below 70%

Closes #639