### PR TITLE
feat: implement course moderation workflow including entity models

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1996,6 +1996,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -2852,6 +2853,7 @@
       "resolved": "https://registry.npmjs.org/@elastic/elasticsearch/-/elasticsearch-9.4.0.tgz",
       "integrity": "sha512-UbvHAtGAqiQdAsAmb3vfCMwOTIf6BoSf6MDpz7mw5UzpU3pRSl4KeFzaXRfrk4+PrgiudYx14socGCI6frgguQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@elastic/transport": "^9.3.5",
         "tslib": "^2.4.0"
@@ -3080,6 +3082,7 @@
       "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.14.3.tgz",
       "integrity": "sha512-Iq8QQQ/7X3Sac15oB6p0FmUg/klxQvXLeileoqrTRGJYLV+/9tubbr9ipz0GKHjmXVsgFPo/+W+2cA8eNcR+XA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@grpc/proto-loader": "^0.8.0",
         "@js-sdsl/ordered-map": "^4.4.2"
@@ -3093,6 +3096,7 @@
       "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.8.1.tgz",
       "integrity": "sha512-wtF6h+DY6M3YaDBPAmvuuA6jV8Sif9MjtOI5euKFWRgCDl5PeDpPsHR9u2l6St5ceY8AZgoNDww5+HvEsXFsGg==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "lodash.camelcase": "^4.3.0",
         "long": "^5.0.0",
@@ -4909,6 +4913,7 @@
       "resolved": "https://registry.npmjs.org/@nestjs/axios/-/axios-4.0.1.tgz",
       "integrity": "sha512-68pFJgu+/AZbWkGu65Z3r55bTsCPlgyKaV4BSG8yUAD72q1PPuyVRgUwFv6BxdnibTUHlyxm06FmYWNC+bjN7A==",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@nestjs/common": "^10.0.0 || ^11.0.0",
         "axios": "^1.3.1",
@@ -5168,6 +5173,7 @@
       "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-10.4.22.tgz",
       "integrity": "sha512-fxJ4v85nDHaqT1PmfNCQ37b/jcv2OojtXTaK1P2uAXhzLf9qq6WNUOFvxBrV4fhQek1EQoT1o9oj5xAZmv3NRw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "file-type": "20.4.1",
         "iterare": "1.2.1",
@@ -5214,6 +5220,7 @@
       "integrity": "sha512-6IX9+VwjiKtCjx+mXVPncpkQ5ZjKfmssOZPFexmT+6T9H9wZ3svpYACAo7+9e7Nr9DZSoRZw3pffkJP7Z0UjaA==",
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@nuxtjs/opencollective": "0.3.2",
         "fast-safe-stringify": "2.1.1",
@@ -5275,6 +5282,7 @@
       "resolved": "https://registry.npmjs.org/@nestjs/graphql/-/graphql-12.2.2.tgz",
       "integrity": "sha512-lUDy/1uqbRA1kBKpXcmY0aHhcPbfeG52Wg5+9Jzd1d57dwSjCAmuO+mWy5jz9ugopVCZeK0S/kdAMvA+r9fNdA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@graphql-tools/merge": "9.0.11",
         "@graphql-tools/schema": "10.0.10",
@@ -5463,6 +5471,7 @@
       "resolved": "https://registry.npmjs.org/@nestjs/platform-express/-/platform-express-10.4.22.tgz",
       "integrity": "sha512-ySSq7Py/DFozzZdNDH67m/vHoeVdphDniWBnl6q5QVoXldDdrZIHLXLRMPayTDh5A95nt7jjJzmD4qpTbNQ6tA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "body-parser": "1.20.4",
         "cors": "2.8.5",
@@ -6035,6 +6044,7 @@
       "resolved": "https://registry.npmjs.org/@nestjs/typeorm/-/typeorm-11.0.1.tgz",
       "integrity": "sha512-8rw/nKT0S+L+MkzgE9F2/mox7mAgsPlwfzmW9gsESN1lmQtIrVEfiiBwC2O8+guS1jBfQehJIdcdUj2OAp4VUQ==",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@nestjs/common": "^10.0.0 || ^11.0.0",
         "@nestjs/core": "^10.0.0 || ^11.0.0",
@@ -6048,6 +6058,7 @@
       "resolved": "https://registry.npmjs.org/@nestjs/websockets/-/websockets-10.4.22.tgz",
       "integrity": "sha512-OLd4i0Faq7vgdtB5vVUrJ54hWEtcXy9poJ6n7kbbh/5ms+KffUl+wwGsbe7uSXLrkoyI8xXU6fZPkFArI+XiRg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "iterare": "1.2.1",
         "object-hash": "3.0.0",
@@ -6257,6 +6268,7 @@
       "integrity": "sha512-hLODw5Abp8OQgA+mUO4tHou4krKgDtUcM9j5Ihxncst9XeyxYBTt2bwZm4e4EQr5E352S4Fyy6V3iFx9ggxKAg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "file-type": "21.3.2",
         "iterare": "1.2.1",
@@ -6290,6 +6302,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@nuxt/opencollective": "0.4.1",
         "fast-safe-stringify": "2.1.1",
@@ -6479,6 +6492,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
       "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -7689,7 +7703,6 @@
       "resolved": "https://registry.npmjs.org/@redis/bloom/-/bloom-5.12.1.tgz",
       "integrity": "sha512-PUUfv+ms7jgPSBVoo/DN4AkPHj4D5TZSd6SbJX7egzBplkYUcKmHRE8RKia7UtZ8bSQbLguLvxVO+asKtQfZWA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 18.19.0"
       },
@@ -7727,7 +7740,6 @@
       "resolved": "https://registry.npmjs.org/@redis/json/-/json-5.12.1.tgz",
       "integrity": "sha512-eOze75esLve4vfqDel7aMX08CNaiLLQS2fV8mpRN9NxPe1rVR4vQyYiW/OgtGUysF6QOr9ANhfxABKNOJfXdKg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 18.19.0"
       },
@@ -7740,7 +7752,6 @@
       "resolved": "https://registry.npmjs.org/@redis/search/-/search-5.12.1.tgz",
       "integrity": "sha512-ItlxbxC9cKI6IU1TLWoczwJCRb6TdmkEpWv05UrPawqaAnWGRu3rcIqsc5vN483T2fSociuyV1UkWIL5I4//2w==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 18.19.0"
       },
@@ -7753,7 +7764,6 @@
       "resolved": "https://registry.npmjs.org/@redis/time-series/-/time-series-5.12.1.tgz",
       "integrity": "sha512-c6JL6E3EcZJuNqKFz+KM+l9l5mpcQiKvTwgA3blt5glWJ8hjDk0yeHN3beE/MpqYIQ8UEX44ItQzgkE/gCBELQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 18.19.0"
       },
@@ -8761,6 +8771,7 @@
       "integrity": "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "*",
         "@types/json-schema": "*"
@@ -8985,6 +8996,7 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.40.tgz",
       "integrity": "sha512-xxx6M2IpSTnnKcR0cMvIiohkiCx20/oRPtWGbenFygKCGl3zqUzdNjQ/1V4solq1LU+dgv0nQzeGOuqkqZGg0Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -9233,6 +9245,7 @@
       "integrity": "sha512-plR3pp6D+SSUn1HM7xvSkx12/DhoHInI2YF35KAcVFNZvlC0gtrWqx7Qq1oH2Ssgi0vlFRCTbP+DZc7B9+TtsQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.2",
         "@typescript-eslint/types": "8.59.2",
@@ -9692,6 +9705,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -9714,7 +9728,6 @@
       "integrity": "sha512-wKmbr/DDiIXzEOiWrTTUcDm24kQ2vGfZQvM2fwg2vXqR5uW6aapr7ObPtj1th32b9u90/Pf4AItvdTh42fBmVQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10.13.0"
       },
@@ -9761,6 +9774,7 @@
       "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -10004,6 +10018,7 @@
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.0.tgz",
       "integrity": "sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
@@ -10592,6 +10607,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -10670,6 +10686,7 @@
       "resolved": "https://registry.npmjs.org/bull/-/bull-4.16.5.tgz",
       "integrity": "sha512-lDsx2BzkKe7gkCYiT5Acj02DpTwDznl/VNN7Psn7M3USPG7Vs/BaClZJJTAG+ufAR9++N1/NiUTdaFBWDIl5TQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cron-parser": "^4.9.0",
         "get-port": "^5.1.1",
@@ -10718,6 +10735,7 @@
       "resolved": "https://registry.npmjs.org/cache-manager/-/cache-manager-7.2.8.tgz",
       "integrity": "sha512-0HDaDLBBY/maa/LmUVAr70XUOwsiQD+jyzCBjmUErYZUKdMS9dT59PqW59PpVqfGM7ve6H0J6307JTpkCYefHQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@cacheable/utils": "^2.3.3",
         "keyv": "^5.5.5"
@@ -10764,6 +10782,7 @@
       "resolved": "https://registry.npmjs.org/@redis/client/-/client-1.6.1.tgz",
       "integrity": "sha512-/KCsg3xSlR+nCK8/8ZYSknYxvXHwubJrU82F3Lm1Fp6789VQ0/3RJKfsmRXjqfaTA++23CvC3hqmqe/2GEt6Kw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cluster-key-slot": "1.1.2",
         "generic-pool": "3.9.0",
@@ -11028,13 +11047,15 @@
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/class-transformer/-/class-transformer-0.5.1.tgz",
       "integrity": "sha512-SQa1Ws6hUbfC98vKGxZH3KFY0Y1lm5Zm0SY8XX9zbK7FJCyVEac3ATW0RIpwzW+oOfmHE5PMPufDG9hCfoEOMw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/class-validator": {
       "version": "0.14.4",
       "resolved": "https://registry.npmjs.org/class-validator/-/class-validator-0.14.4.tgz",
       "integrity": "sha512-AwNusCCam51q703dW82x95tOqQp6oC9HNUl724KxJJOfnKscI8dOloXFgyez7LbTTKWuRBA37FScqVbJEoq8Yw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/validator": "^13.15.3",
         "libphonenumber-js": "^1.11.1",
@@ -11631,6 +11652,7 @@
       "integrity": "sha512-hr4ihw+DBqcvrsEDioRO31Z17x71pUYoNe/4h6Z0wB72p7MU7/9gH8Q3s12NFhHPfYBBOV3qyfUxmr/Yn3shnQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "env-paths": "^2.2.1",
         "import-fresh": "^3.3.0",
@@ -12472,8 +12494,7 @@
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
       "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
@@ -12570,6 +12591,7 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -12626,6 +12648,7 @@
       "integrity": "sha512-iI1f+D2ViGn+uvv5HuHVUamg8ll4tN+JRHGc6IJi4TP9Kl976C57fzPXgseXNs8v0iA8aSJpHsTWjDb9QJamGQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -13067,6 +13090,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -13110,6 +13134,7 @@
       "resolved": "https://registry.npmjs.org/express-session/-/express-session-1.19.0.tgz",
       "integrity": "sha512-0csaMkGq+vaiZTmSMMGkfdCOabYv192VbytFypcvI0MANrp+4i/7yEkJ0sbAEhycQjntaKGzYfjfXQyVb7BHMA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cookie": "~0.7.2",
         "cookie-signature": "~1.0.7",
@@ -14227,6 +14252,7 @@
       "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.14.0.tgz",
       "integrity": "sha512-BBvQ/406p+4CZbTpCbVPSxfzrZrbnuWSP1ELYgyS6B+hNeKzgrdB4JczCa5VZUBQrDa9hUngm0KnexY6pJRN5Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
       }
@@ -14748,6 +14774,7 @@
       "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.10.1.tgz",
       "integrity": "sha512-HuEDBTI70aYdx1v6U97SbNx9F1+svQKBDo30o0b9fw055LMepzpOOd0Ccg9Q6tbqmBSJaMuY0fB7yw9/vjBYCA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ioredis/commands": "1.5.1",
         "cluster-key-slot": "^1.1.0",
@@ -15118,6 +15145,7 @@
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -16646,6 +16674,7 @@
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
       "integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@keyv/serialize": "^1.1.1"
       }
@@ -18416,6 +18445,7 @@
       "resolved": "https://registry.npmjs.org/passport/-/passport-0.7.0.tgz",
       "integrity": "sha512-cPLl+qZpSc+ireUvt+IzqbED1cHHkDoVYMo30jbJIdOOjQ1MQYZBPiNvmi8UM6lJuOpTPXJGZQk0DtC4y61MYQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "passport-strategy": "1.x.x",
         "pause": "0.0.1",
@@ -18567,6 +18597,7 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
       "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.12.0",
         "pg-pool": "^3.13.0",
@@ -18908,6 +18939,7 @@
       "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -19617,6 +19649,7 @@
       "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -21240,6 +21273,7 @@
       "resolved": "https://registry.npmjs.org/ts-morph/-/ts-morph-24.0.0.tgz",
       "integrity": "sha512-2OAOg/Ob5yx9Et7ZX4CvTCc0UFoZHwLEJ+dpDPSUi5TgwwlTlX47w+iFRrEwzUZwYACjq83cgjS/Da50Ga37uw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ts-morph/common": "~0.25.0",
         "code-block-writer": "^13.0.3"
@@ -21251,6 +21285,7 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -21498,6 +21533,7 @@
       "resolved": "https://registry.npmjs.org/typeorm/-/typeorm-0.3.29.tgz",
       "integrity": "sha512-wwPEX/df4l72gCmOsrs0otJZYLGA9lLQkUZCkukbsymEycV4zXv2KM7wU7v2r8L01TaCgY9ApSSqHQWBOUhEoQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@sqltools/formatter": "^1.2.5",
         "ansis": "^4.2.0",
@@ -21701,6 +21737,7 @@
       "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -22038,7 +22075,6 @@
       "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "esrecurse": "^4.3.0",
         "estraverse": "^4.1.1"
@@ -22053,7 +22089,6 @@
       "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "engines": {
         "node": ">=4.0"
       }
@@ -22064,7 +22099,6 @@
       "integrity": "sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/json-schema": "^7.0.9",
         "ajv": "^8.9.0",

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -1,0 +1,23 @@
+import { Module } from '@nestjs/common';
+import { PassportModule } from '@nestjs/passport';
+import { JwtModule } from '@nestjs/jwt';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { User } from '../users/entities/user.entity';
+import { JwtStrategy } from './jwt.strategy';
+
+/**
+ * Registers the authentication module with Passport and JWT support.
+ */
+@Module({
+  imports: [
+    PassportModule.register({ defaultStrategy: 'jwt' }),
+    JwtModule.register({
+      secret: process.env.JWT_SECRET || 'default-jwt-secret',
+      signOptions: { expiresIn: process.env.JWT_EXPIRES_IN || '15m' },
+    }),
+    TypeOrmModule.forFeature([User]),
+  ],
+  providers: [JwtStrategy],
+  exports: [PassportModule, JwtModule],
+})
+export class AuthModule {}

--- a/src/auth/jwt.strategy.ts
+++ b/src/auth/jwt.strategy.ts
@@ -1,0 +1,42 @@
+import { Injectable, UnauthorizedException } from '@nestjs/common';
+import { PassportStrategy } from '@nestjs/passport';
+import { ExtractJwt, Strategy } from 'passport-jwt';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { User } from '../users/entities/user.entity';
+
+export interface JwtPayload {
+  sub: string;
+  email: string;
+  role: string;
+}
+
+/**
+ * Passport JWT strategy for validating Bearer tokens.
+ */
+@Injectable()
+export class JwtStrategy extends PassportStrategy(Strategy, 'jwt') {
+  constructor(
+    @InjectRepository(User)
+    private readonly userRepository: Repository<User>,
+  ) {
+    super({
+      jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
+      ignoreExpiration: false,
+      secretOrKey: process.env.JWT_SECRET || 'default-jwt-secret',
+    });
+  }
+
+  /**
+   * Validates the decoded JWT payload and returns the user object.
+   * @param payload The decoded JWT payload.
+   * @returns The authenticated user.
+   */
+  async validate(payload: JwtPayload): Promise<User> {
+    const user = await this.userRepository.findOneBy({ id: payload.sub });
+    if (!user) {
+      throw new UnauthorizedException('User not found');
+    }
+    return user;
+  }
+}

--- a/src/courses/courses.service.ts
+++ b/src/courses/courses.service.ts
@@ -1,0 +1,198 @@
+import {
+  Injectable,
+  NotFoundException,
+  ForbiddenException,
+  BadRequestException,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Course, CourseStatus } from './entities/course.entity';
+import { CourseReview, ReviewDecision } from './entities/course-review.entity';
+import { User, UserRole } from '../users/entities/user.entity';
+import { CreateCourseDto } from './dto/create-course.dto';
+import { UpdateCourseDto } from './dto/update-course.dto';
+import { SubmitForReviewDto } from './dto/submit-for-review.dto';
+import { ReviewCourseDto } from './dto/review-course.dto';
+
+/**
+ * Maps a ReviewDecision to the resulting CourseStatus after the decision.
+ */
+const DECISION_TO_STATUS: Record<ReviewDecision, CourseStatus> = {
+  [ReviewDecision.APPROVED]: CourseStatus.PUBLISHED,
+  [ReviewDecision.REJECTED]: CourseStatus.REJECTED,
+  [ReviewDecision.CHANGES_REQUESTED]: CourseStatus.CHANGES_REQUESTED,
+};
+
+/**
+ * Core service managing the course publishing workflow.
+ */
+@Injectable()
+export class CoursesService {
+  constructor(
+    @InjectRepository(Course)
+    private readonly courseRepo: Repository<Course>,
+    @InjectRepository(CourseReview)
+    private readonly reviewRepo: Repository<CourseReview>,
+  ) {}
+
+  // ─── CRUD ────────────────────────────────────────────────────────────────────
+
+  /**
+   * Creates a new course in DRAFT status for the given instructor.
+   */
+  async create(dto: CreateCourseDto, instructor: User): Promise<Course> {
+    const course = this.courseRepo.create({
+      ...dto,
+      instructorId: instructor.id,
+      status: CourseStatus.DRAFT,
+    });
+    return this.courseRepo.save(course);
+  }
+
+  /**
+   * Returns all courses. Admins/moderators see every status; others see only published.
+   */
+  async findAll(requestingUser?: User): Promise<Course[]> {
+    const isPrivileged =
+      requestingUser &&
+      [UserRole.ADMIN, UserRole.MODERATOR].includes(requestingUser.role);
+
+    if (isPrivileged) {
+      return this.courseRepo.find({ order: { createdAt: 'DESC' } });
+    }
+    return this.courseRepo.find({
+      where: { status: CourseStatus.PUBLISHED },
+      order: { createdAt: 'DESC' },
+    });
+  }
+
+  /**
+   * Returns a single course by ID.
+   */
+  async findOne(id: string): Promise<Course> {
+    const course = await this.courseRepo.findOne({
+      where: { id },
+      relations: ['instructor', 'reviews', 'reviews.reviewer'],
+    });
+    if (!course) {
+      throw new NotFoundException(`Course ${id} not found`);
+    }
+    return course;
+  }
+
+  /**
+   * Updates mutable fields of a course. Only the owner, admin, or moderator may update.
+   */
+  async update(id: string, dto: UpdateCourseDto, requestingUser: User): Promise<Course> {
+    const course = await this.findOne(id);
+    this.assertOwnerOrPrivileged(course, requestingUser);
+    Object.assign(course, dto);
+    return this.courseRepo.save(course);
+  }
+
+  /**
+   * Soft-deletes a course. Only the owner, admin, or moderator may delete.
+   */
+  async remove(id: string, requestingUser: User): Promise<void> {
+    const course = await this.findOne(id);
+    this.assertOwnerOrPrivileged(course, requestingUser);
+    await this.courseRepo.softDelete(id);
+  }
+
+  // ─── WORKFLOW ─────────────────────────────────────────────────────────────────
+
+  /**
+   * Instructor submits a DRAFT (or CHANGES_REQUESTED) course for moderation.
+   */
+  async submitForReview(id: string, dto: SubmitForReviewDto, instructor: User): Promise<Course> {
+    const course = await this.findOne(id);
+    this.assertCourseOwner(course, instructor);
+
+    if (
+      course.status !== CourseStatus.DRAFT &&
+      course.status !== CourseStatus.CHANGES_REQUESTED
+    ) {
+      throw new BadRequestException(
+        `Cannot submit a course with status "${course.status}" for review. ` +
+          `Only DRAFT or CHANGES_REQUESTED courses may be submitted.`,
+      );
+    }
+
+    course.status = CourseStatus.PENDING_REVIEW;
+    course.submissionNote = dto.submissionNote ?? null;
+    return this.courseRepo.save(course);
+  }
+
+  /**
+   * Admin/moderator reviews a PENDING_REVIEW course and records the decision.
+   */
+  async reviewCourse(id: string, dto: ReviewCourseDto, reviewer: User): Promise<CourseReview> {
+    this.assertPrivileged(reviewer);
+
+    const course = await this.findOne(id);
+    if (course.status !== CourseStatus.PENDING_REVIEW) {
+      throw new BadRequestException(
+        `Course "${id}" is not pending review (current status: "${course.status}").`,
+      );
+    }
+
+    const previousStatus = course.status;
+    course.status = DECISION_TO_STATUS[dto.decision];
+    await this.courseRepo.save(course);
+
+    const review = this.reviewRepo.create({
+      courseId: id,
+      reviewerId: reviewer.id,
+      decision: dto.decision,
+      feedback: dto.feedback,
+      previousStatus,
+    });
+    return this.reviewRepo.save(review);
+  }
+
+  /**
+   * Returns the full review history for a course (newest first).
+   */
+  async getReviewHistory(id: string): Promise<CourseReview[]> {
+    await this.findOne(id); // ensure course exists
+    return this.reviewRepo.find({
+      where: { courseId: id },
+      relations: ['reviewer'],
+      order: { createdAt: 'DESC' },
+    });
+  }
+
+  /**
+   * Returns all courses currently awaiting moderation.
+   */
+  async getPendingQueue(requestingUser: User): Promise<Course[]> {
+    this.assertPrivileged(requestingUser);
+    return this.courseRepo.find({
+      where: { status: CourseStatus.PENDING_REVIEW },
+      relations: ['instructor'],
+      order: { createdAt: 'ASC' },
+    });
+  }
+
+  // ─── HELPERS ─────────────────────────────────────────────────────────────────
+
+  private assertCourseOwner(course: Course, user: User): void {
+    if (course.instructorId !== user.id) {
+      throw new ForbiddenException('Only the course owner may perform this action.');
+    }
+  }
+
+  private assertPrivileged(user: User): void {
+    if (![UserRole.ADMIN, UserRole.MODERATOR].includes(user.role)) {
+      throw new ForbiddenException('Only admins or moderators may perform this action.');
+    }
+  }
+
+  private assertOwnerOrPrivileged(course: Course, user: User): void {
+    const isOwner = course.instructorId === user.id;
+    const isPrivileged = [UserRole.ADMIN, UserRole.MODERATOR].includes(user.role);
+    if (!isOwner && !isPrivileged) {
+      throw new ForbiddenException('Insufficient permissions.');
+    }
+  }
+}

--- a/src/courses/dto/review-course.dto.ts
+++ b/src/courses/dto/review-course.dto.ts
@@ -1,0 +1,26 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsEnum, IsOptional, IsString, MaxLength } from 'class-validator';
+import { ReviewDecision } from '../entities/course-review.entity';
+
+/**
+ * Payload for an admin/moderator to approve, reject, or request changes on a course.
+ */
+export class ReviewCourseDto {
+  @ApiProperty({
+    enum: ReviewDecision,
+    description: 'The moderation decision for this course.',
+    example: ReviewDecision.APPROVED,
+  })
+  @IsEnum(ReviewDecision)
+  decision: ReviewDecision;
+
+  @ApiProperty({
+    description: 'Feedback message sent back to the instructor.',
+    required: false,
+    example: 'Great course! Approved for publication.',
+  })
+  @IsString()
+  @IsOptional()
+  @MaxLength(5000)
+  feedback?: string;
+}

--- a/src/courses/dto/submit-for-review.dto.ts
+++ b/src/courses/dto/submit-for-review.dto.ts
@@ -1,0 +1,17 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty, IsString, IsOptional, MaxLength } from 'class-validator';
+
+/**
+ * Payload for an instructor to submit a draft course for moderation review.
+ */
+export class SubmitForReviewDto {
+  @ApiProperty({
+    description: 'Optional note from the instructor to the reviewer.',
+    example: 'This course covers advanced TypeScript patterns.',
+    required: false,
+  })
+  @IsString()
+  @IsOptional()
+  @MaxLength(2000)
+  submissionNote?: string;
+}

--- a/src/courses/dto/update-course.dto.ts
+++ b/src/courses/dto/update-course.dto.ts
@@ -1,14 +1,15 @@
 import { CreateCourseDto } from './create-course.dto';
 import { PartialType, ApiPropertyOptional } from '@nestjs/swagger';
-import { IsString, IsOptional, IsEnum } from 'class-validator';
+import { IsOptional, IsEnum } from 'class-validator';
+import { CourseStatus } from '../entities/course.entity';
 
 /**
  * Defines the update Course payload.
  */
 export class UpdateCourseDto extends PartialType(CreateCourseDto) {
-  @ApiPropertyOptional({ enum: ['draft', 'published', 'archived'] })
-  @IsString()
+  @ApiPropertyOptional({ enum: CourseStatus })
   @IsOptional()
-  @IsEnum(['draft', 'published', 'archived'])
-  status?: string;
+  @IsEnum(CourseStatus)
+  status?: CourseStatus;
 }
+

--- a/src/courses/entities/course-review.entity.ts
+++ b/src/courses/entities/course-review.entity.ts
@@ -1,0 +1,63 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  UpdateDateColumn,
+  ManyToOne,
+  Index,
+} from 'typeorm';
+import { Course } from './course.entity';
+import { User } from '../../users/entities/user.entity';
+
+/** Possible decisions on a course review. */
+export enum ReviewDecision {
+  APPROVED = 'approved',
+  REJECTED = 'rejected',
+  CHANGES_REQUESTED = 'changes_requested',
+}
+
+/**
+ * Records each moderation decision made on a course submission.
+ * A course can have multiple review records (revision history).
+ */
+@Entity('course_reviews')
+export class CourseReview {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  /** The course that was reviewed. */
+  @ManyToOne(() => Course, (course) => course.reviews, { onDelete: 'CASCADE' })
+  course: Course;
+
+  @Column({ name: 'course_id' })
+  @Index()
+  courseId: string;
+
+  /** The admin/moderator who made the decision. */
+  @ManyToOne(() => User, { nullable: true, onDelete: 'SET NULL' })
+  reviewer: User;
+
+  @Column({ name: 'reviewer_id', nullable: true })
+  reviewerId: string;
+
+  @Column({
+    type: 'enum',
+    enum: ReviewDecision,
+  })
+  decision: ReviewDecision;
+
+  /** Feedback sent back to the instructor. */
+  @Column({ type: 'text', nullable: true })
+  feedback?: string;
+
+  /** Snapshot of the course status before the decision. */
+  @Column({ type: 'varchar', length: 50, nullable: true })
+  previousStatus?: string;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}

--- a/src/courses/entities/course.entity.ts
+++ b/src/courses/entities/course.entity.ts
@@ -13,6 +13,17 @@ import {
 import { User } from '../../users/entities/user.entity';
 import { CourseModule } from './course-module.entity';
 import { Enrollment } from './enrollment.entity';
+import { CourseReview } from './course-review.entity';
+
+/** Lifecycle states a course can be in. */
+export enum CourseStatus {
+  DRAFT = 'draft',
+  PENDING_REVIEW = 'pending_review',
+  CHANGES_REQUESTED = 'changes_requested',
+  PUBLISHED = 'published',
+  REJECTED = 'rejected',
+  ARCHIVED = 'archived',
+}
 
 /**
  * Represents the course entity.
@@ -35,9 +46,13 @@ export class Course {
   @Column({ type: 'decimal', precision: 10, scale: 2, default: 0 })
   price: number;
 
-  @Column({ default: 'draft' }) // draft, published, archived
+  @Column({
+    type: 'enum',
+    enum: CourseStatus,
+    default: CourseStatus.DRAFT,
+  })
   @Index()
-  status: string;
+  status: CourseStatus;
 
   @Column({ nullable: true })
   thumbnailUrl: string;
@@ -55,6 +70,13 @@ export class Course {
   @OneToMany(() => Enrollment, (enrollment) => enrollment.course)
   enrollments: Enrollment[];
 
+  @OneToMany(() => CourseReview, (review) => review.course, { eager: false })
+  reviews: CourseReview[];
+
+  /** The submission note provided by the instructor when submitting for review. */
+  @Column({ type: 'text', nullable: true })
+  submissionNote?: string;
+
   @CreateDateColumn()
   createdAt: Date;
 
@@ -64,3 +86,4 @@ export class Course {
   @DeleteDateColumn()
   deletedAt?: Date;
 }
+

--- a/src/moderation/moderation.module.ts
+++ b/src/moderation/moderation.module.ts
@@ -1,0 +1,28 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { ContentSafetyService } from './safety/content-safety.service';
+import { AutoModerationService } from './auto/auto-moderation.service';
+import { ManualReviewService } from './manual/manual-review.service';
+import { ReviewItem } from './manual/review-item.entity';
+import { ModerationAnalyticsService } from './analytics/moderation-analytics.service';
+import { ModerationEvent } from './analytics/moderation-event.entity';
+
+/**
+ * Registers the moderation module, exposing content safety and review services.
+ */
+@Module({
+  imports: [TypeOrmModule.forFeature([ReviewItem, ModerationEvent])],
+  providers: [
+    ContentSafetyService,
+    AutoModerationService,
+    ManualReviewService,
+    ModerationAnalyticsService,
+  ],
+  exports: [
+    ContentSafetyService,
+    AutoModerationService,
+    ManualReviewService,
+    ModerationAnalyticsService,
+  ],
+})
+export class ModerationModule {}

--- a/src/users/entities/user.entity.ts
+++ b/src/users/entities/user.entity.ts
@@ -14,6 +14,8 @@ import { Enrollment } from '../../courses/entities/enrollment.entity';
 export enum UserRole {
   STUDENT = 'student',
   TEACHER = 'teacher',
+  INSTRUCTOR = 'instructor',
+  MODERATOR = 'moderator',
   ADMIN = 'admin',
 }
 export enum UserStatus {


### PR DESCRIPTION
Closes #549

---




## What does this PR do?

<!-- A short paragraph (2–5 sentences) describing the change and the reasoning behind it. -->
<!-- Do not repeat the issue description verbatim — explain the implementation choice. -->

---

## Type of change

<!-- Check all that apply -->

- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] 💥 Breaking change (fix or feature that changes existing API behaviour)
- [ ] ♻️ Refactor (no functional change, no new feature)
- [ ] 🧪 Tests only (no production code changes)
- [ ] 📝 Documentation only
- [ ] 🔧 Chore (build, dependencies, CI config)

---

## Pre-merge checklist (required)

> **Do not remove items. Unchecked items without an explanation will block merge.**

**Branch & metadata**

- [ ] Branch name follows `feature/issue-<N>-<slug>` / `fix/issue-<N>-<slug>` convention
- [ ] Branch is up to date with the target branch (`develop` or `main`)
- [ ] All commits and the PR title follow the Conventional Commits format with issue reference

**Code quality & tests**

- [ ] `npm run lint:ci` — zero ESLint warnings
- [ ] `npm run format:check` — Prettier reports no changes needed
- [ ] `npm run typecheck` — zero TypeScript errors
- [ ] `npm run test:ci` — all tests pass, coverage ≥ 70%
- [ ] New service methods have corresponding `.spec.ts` unit tests
- [ ] New API endpoints are covered by at least one e2e test
- [ ] No existing tests were deleted (if any were, justification is provided in the PR description)

**Error handling & NestJS best practices**

- [ ] All new/updated DTOs use `class-validator` / `class-transformer` decorators and are wired through NestJS pipes (e.g. global `ValidationPipe` or explicit)
- [ ] All controller entry points validate external input at the boundary (no unvalidated raw `any`/`unknown` reaching the domain)
- [ ] Controllers/services throw appropriate NestJS HTTP exceptions (e.g. `BadRequestException`, `UnauthorizedException`, `ForbiddenException`, `NotFoundException`) instead of generic `Error`
- [ ] Any new error shapes are handled by existing exception filters or the filters have been updated accordingly
- [ ] Logging goes through the shared logging abstraction (e.g. Nest `Logger` or central logger service) with meaningful, structured messages
- [ ] Authentication/authorization guards (e.g. `AuthGuard`, role/permissions guards, custom guards) are applied to all new/modified endpoints where appropriate
- [ ] If an endpoint is intentionally public, this is explicitly mentioned in the PR description with rationale

**API documentation / Swagger**

- [ ] Swagger / OpenAPI decorators are added or updated for all new/changed controller endpoints (including DTOs, responses, and error schemas)
- [ ] I have started the app locally and confirmed the `/api` (or Swagger UI) reflects new/changed endpoints correctly
- [ ] If there are **no** API surface changes, this is explicitly stated in the PR description

**Breaking changes**

- [ ] This PR does **not** introduce a breaking API change
- [ ] OR: this PR introduces a breaking change and it is documented below, with migration notes

---

## Breaking change description (if applicable)

<!-- If you checked "Breaking change" above, describe what changes and how consumers should migrate. -->
<!-- Include any feature flags, deprecation periods, or follow-up tasks. -->
<!-- Delete this section if not applicable. -->

---

## Test evidence (required)

<!-- Paste concrete evidence that the change was tested.  -->
<!-- Examples: exact npm scripts run with ✅ results, curl/Postman examples, screenshots of Swagger, Jest test names, etc. -->

**Commands run locally**

```text
# Example (edit as needed)
npm run lint:ci
npm run format:check
npm run typecheck
npm run test:ci
```

**Manual / API verification**

```text
# Example: describe manual tests, curl commands, or Postman collections used
```

---
