### PR TITLE
feat: add user preference management system

### DIFF
--- a/src/user-preferences/dto/update-user-preference.dto.ts
+++ b/src/user-preferences/dto/update-user-preference.dto.ts
@@ -1,0 +1,50 @@
+import { IsOptional, IsEnum, IsBoolean, IsObject } from 'class-validator';
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { AppTheme, AppLanguage } from '../entities/user-preference.entity';
+
+export class UpdateUserPreferenceDto {
+  @ApiPropertyOptional({ enum: AppTheme })
+  @IsOptional()
+  @IsEnum(AppTheme)
+  theme?: AppTheme;
+
+  @ApiPropertyOptional({ enum: AppLanguage })
+  @IsOptional()
+  @IsEnum(AppLanguage)
+  language?: AppLanguage;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsBoolean()
+  emailNotifications?: boolean;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsBoolean()
+  pushNotifications?: boolean;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsBoolean()
+  inAppNotifications?: boolean;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsBoolean()
+  marketingEmails?: boolean;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsBoolean()
+  courseUpdates?: boolean;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsBoolean()
+  weeklyDigest?: boolean;
+
+  @ApiPropertyOptional({ type: Object })
+  @IsOptional()
+  @IsObject()
+  customSettings?: Record<string, unknown>;
+}

--- a/src/user-preferences/entities/user-preference.entity.ts
+++ b/src/user-preferences/entities/user-preference.entity.ts
@@ -1,0 +1,72 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  OneToOne,
+  JoinColumn,
+  CreateDateColumn,
+  UpdateDateColumn,
+  Index,
+} from 'typeorm';
+import { User } from '../../users/entities/user.entity';
+
+export enum AppTheme {
+  LIGHT = 'light',
+  DARK = 'dark',
+  SYSTEM = 'system',
+}
+
+export enum AppLanguage {
+  EN = 'en',
+  FR = 'fr',
+  ES = 'es',
+  DE = 'de',
+  AR = 'ar',
+}
+
+@Entity('user_preferences')
+export class UserPreference {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column()
+  @Index({ unique: true })
+  userId: string;
+
+  @OneToOne(() => User, { onDelete: 'CASCADE' })
+  @JoinColumn()
+  user: User;
+
+  @Column({ type: 'enum', enum: AppTheme, default: AppTheme.SYSTEM })
+  theme: AppTheme;
+
+  @Column({ type: 'enum', enum: AppLanguage, default: AppLanguage.EN })
+  language: AppLanguage;
+
+  @Column({ default: true })
+  emailNotifications: boolean;
+
+  @Column({ default: true })
+  pushNotifications: boolean;
+
+  @Column({ default: true })
+  inAppNotifications: boolean;
+
+  @Column({ default: false })
+  marketingEmails: boolean;
+
+  @Column({ default: true })
+  courseUpdates: boolean;
+
+  @Column({ default: true })
+  weeklyDigest: boolean;
+
+  @Column({ type: 'jsonb', nullable: true })
+  customSettings: Record<string, unknown>;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}

--- a/src/user-preferences/user-preferences.controller.ts
+++ b/src/user-preferences/user-preferences.controller.ts
@@ -1,0 +1,34 @@
+import { Controller, Get, Patch, Delete, Body, Param, UseGuards } from '@nestjs/common';
+import { ApiTags, ApiOperation, ApiBearerAuth } from '@nestjs/swagger';
+import { UserPreferencesService } from './user-preferences.service';
+import { UpdateUserPreferenceDto } from './dto/update-user-preference.dto';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+
+@ApiTags('user-preferences')
+@ApiBearerAuth()
+@UseGuards(JwtAuthGuard)
+@Controller('users/:userId/preferences')
+export class UserPreferencesController {
+  constructor(private readonly userPreferencesService: UserPreferencesService) {}
+
+  @Get()
+  @ApiOperation({ summary: 'Get user preferences' })
+  getPreferences(@Param('userId') userId: string) {
+    return this.userPreferencesService.getPreferences(userId);
+  }
+
+  @Patch()
+  @ApiOperation({ summary: 'Update user preferences' })
+  updatePreferences(
+    @Param('userId') userId: string,
+    @Body() dto: UpdateUserPreferenceDto,
+  ) {
+    return this.userPreferencesService.updatePreferences(userId, dto);
+  }
+
+  @Delete()
+  @ApiOperation({ summary: 'Reset preferences to defaults' })
+  resetPreferences(@Param('userId') userId: string) {
+    return this.userPreferencesService.resetPreferences(userId);
+  }
+}

--- a/src/user-preferences/user-preferences.module.ts
+++ b/src/user-preferences/user-preferences.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { UserPreferencesController } from './user-preferences.controller';
+import { UserPreferencesService } from './user-preferences.service';
+import { UserPreference } from './entities/user-preference.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([UserPreference])],
+  controllers: [UserPreferencesController],
+  providers: [UserPreferencesService],
+  exports: [UserPreferencesService],
+})
+export class UserPreferencesModule {}

--- a/src/user-preferences/user-preferences.service.ts
+++ b/src/user-preferences/user-preferences.service.ts
@@ -1,0 +1,40 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { UserPreference } from './entities/user-preference.entity';
+import { UpdateUserPreferenceDto } from './dto/update-user-preference.dto';
+
+@Injectable()
+export class UserPreferencesService {
+  private readonly logger = new Logger(UserPreferencesService.name);
+
+  constructor(
+    @InjectRepository(UserPreference)
+    private readonly preferenceRepository: Repository<UserPreference>,
+  ) {}
+
+  async getPreferences(userId: string): Promise<UserPreference> {
+    let prefs = await this.preferenceRepository.findOne({ where: { userId } });
+    if (!prefs) {
+      prefs = await this.preferenceRepository.save(
+        this.preferenceRepository.create({ userId }),
+      );
+      this.logger.debug(`Created default preferences for user ${userId}`);
+    }
+    return prefs;
+  }
+
+  async updatePreferences(userId: string, dto: UpdateUserPreferenceDto): Promise<UserPreference> {
+    const prefs = await this.getPreferences(userId);
+    Object.assign(prefs, dto);
+    return this.preferenceRepository.save(prefs);
+  }
+
+  async resetPreferences(userId: string): Promise<UserPreference> {
+    const prefs = await this.getPreferences(userId);
+    await this.preferenceRepository.remove(prefs);
+    return this.preferenceRepository.save(
+      this.preferenceRepository.create({ userId }),
+    );
+  }
+}


### PR DESCRIPTION
## Summary

Implements a user preference management system allowing users to manage notification preferences, language, and theme settings.

## Changes

- src/user-preferences/entities/user-preference.entity.ts - UserPreference entity with theme, language, and notification preference columns
- src/user-preferences/dto/update-user-preference.dto.ts - Validated DTO for partial preference updates
- src/user-preferences/user-preferences.service.ts - Service: get (with auto-create defaults), update, and reset preferences
- src/user-preferences/user-preferences.controller.ts - REST endpoints under users/:userId/preferences (GET, PATCH, DELETE)
- src/user-preferences/user-preferences.module.ts - Module wiring

## Acceptance Criteria

- [x] Preferences table created (user_preferences)
- [x] Settings API endpoints (GET/PATCH/DELETE /users/:userId/preferences)
- [x] Notification preferences (emailNotifications, pushNotifications, inAppNotifications, marketingEmails, courseUpdates, weeklyDigest)
- [x] Language selection (en, fr, es, de, ar)

closes #552