### PR TITLE
feat: implement user profile completeness scoring

### DIFF
--- a/src/profile-completeness/profile-completeness.controller.ts
+++ b/src/profile-completeness/profile-completeness.controller.ts
@@ -1,0 +1,18 @@
+import { Controller, Get, Param, UseGuards } from '@nestjs/common';
+import { ApiTags, ApiOperation, ApiBearerAuth } from '@nestjs/swagger';
+import { ProfileCompletenessService } from './profile-completeness.service';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+
+@ApiTags('profile-completeness')
+@ApiBearerAuth()
+@UseGuards(JwtAuthGuard)
+@Controller('users/:userId/profile-completeness')
+export class ProfileCompletenessController {
+  constructor(private readonly profileCompletenessService: ProfileCompletenessService) {}
+
+  @Get()
+  @ApiOperation({ summary: 'Get profile completeness score and progress for a user' })
+  getScore(@Param('userId') userId: string) {
+    return this.profileCompletenessService.getScore(userId);
+  }
+}

--- a/src/profile-completeness/profile-completeness.module.ts
+++ b/src/profile-completeness/profile-completeness.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { ProfileCompletenessController } from './profile-completeness.controller';
+import { ProfileCompletenessService } from './profile-completeness.service';
+import { User } from '../users/entities/user.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([User])],
+  controllers: [ProfileCompletenessController],
+  providers: [ProfileCompletenessService],
+  exports: [ProfileCompletenessService],
+})
+export class ProfileCompletenessModule {}

--- a/src/profile-completeness/profile-completeness.service.ts
+++ b/src/profile-completeness/profile-completeness.service.ts
@@ -1,0 +1,70 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { User } from '../users/entities/user.entity';
+
+export interface ProfileScoreResult {
+  score: number;
+  maxScore: number;
+  percentage: number;
+  completedFields: string[];
+  missingFields: string[];
+  level: 'starter' | 'intermediate' | 'complete';
+  nextIncentive: string | null;
+}
+
+const SCORED_FIELDS: Array<{ field: keyof User; label: string; points: number }> = [
+  { field: 'firstName', label: 'First name', points: 10 },
+  { field: 'lastName', label: 'Last name', points: 10 },
+  { field: 'username', label: 'Username', points: 10 },
+  { field: 'profilePicture', label: 'Profile picture', points: 20 },
+  { field: 'isEmailVerified', label: 'Email verified', points: 20 },
+  { field: 'role', label: 'Role set', points: 10 },
+  { field: 'lastLoginAt', label: 'Logged in at least once', points: 10 },
+  { field: 'tenantId', label: 'Organisation linked', points: 10 },
+];
+
+const MAX_SCORE = SCORED_FIELDS.reduce((sum, f) => sum + f.points, 0);
+
+@Injectable()
+export class ProfileCompletenessService {
+  constructor(
+    @InjectRepository(User)
+    private readonly userRepository: Repository<User>,
+  ) {}
+
+  async getScore(userId: string): Promise<ProfileScoreResult> {
+    const user = await this.userRepository.findOneOrFail({ where: { id: userId } });
+    return this.calculateScore(user);
+  }
+
+  calculateScore(user: User): ProfileScoreResult {
+    let score = 0;
+    const completedFields: string[] = [];
+    const missingFields: string[] = [];
+
+    for (const { field, label, points } of SCORED_FIELDS) {
+      const value = user[field];
+      const filled = value !== null && value !== undefined && value !== '' && value !== false;
+      if (filled) {
+        score += points;
+        completedFields.push(label);
+      } else {
+        missingFields.push(label);
+      }
+    }
+
+    const percentage = Math.round((score / MAX_SCORE) * 100);
+    const level =
+      percentage >= 80 ? 'complete' : percentage >= 40 ? 'intermediate' : 'starter';
+
+    const nextIncentive =
+      level === 'starter'
+        ? 'Reach 40% to unlock Intermediate badge'
+        : level === 'intermediate'
+        ? 'Reach 80% to unlock Complete Profile badge'
+        : null;
+
+    return { score, maxScore: MAX_SCORE, percentage, completedFields, missingFields, level, nextIncentive };
+  }
+}


### PR DESCRIPTION
## Summary

Implements a profile completeness scoring system that gamifies profile completion to encourage users to fill out their profile information.

## Changes

- src/profile-completeness/profile-completeness.service.ts - Scoring algorithm: evaluates 8 weighted profile fields (firstName, lastName, username, profilePicture, isEmailVerified, role, lastLoginAt, tenantId), returns score, percentage, completed/missing fields, level badge, and next incentive message
- src/profile-completeness/profile-completeness.controller.ts - GET /users/:userId/profile-completeness endpoint (JWT-protected)
- src/profile-completeness/profile-completeness.module.ts - Module wiring

## Scoring Algorithm

| Field | Points |
|---|---|
| First name | 10 |
| Last name | 10 |
| Username | 10 |
| Profile picture | 20 |
| Email verified | 20 |
| Role set | 10 |
| Logged in at least once | 10 |
| Organisation linked | 10 |
| **Total** | **100** |

## Levels & Incentives

- **starter** (0-39%) ? "Reach 40% to unlock Intermediate badge"
- **intermediate** (40-79%) ? "Reach 80% to unlock Complete Profile badge"
- **complete** (80-100%) ? no further incentive

## Acceptance Criteria

- [x] Scoring algorithm defined (weighted field scoring, 100-point max)
- [x] Progress tracking visible (GET /users/:userId/profile-completeness)
- [x] Incentives for completion (level badges + next incentive message)

closes #551