### PR TITLE
feat: setup staging environment feature parity (#599)

### DIFF
--- a/.env.staging
+++ b/.env.staging
@@ -1,0 +1,150 @@
+NODE_ENV=staging
+
+# ─── Database ────────────────────────────────────────────────────────────────
+DATABASE_HOST=staging-db.internal
+DATABASE_PORT=5432
+DATABASE_USER=teachlink_staging
+DATABASE_PASSWORD=CHANGE_ME_staging_db_password
+DATABASE_NAME=teachlink_staging
+# Pool sizing matches prod (see README pool table)
+DATABASE_POOL_MAX=20
+DATABASE_POOL_MIN=5
+DATABASE_POOL_ACQUIRE_TIMEOUT_MS=10000
+DATABASE_POOL_IDLE_TIMEOUT_MS=30000
+# Read replicas (optional, mirrors prod topology)
+DATABASE_REPLICA_HOSTS=staging-replica.internal
+DATABASE_REPLICA_PORT=5432
+DATABASE_REPLICA_USER=teachlink_ro
+DATABASE_REPLICA_PASSWORD=CHANGE_ME_replica_password
+DATABASE_REPLICA_NAME=teachlink_staging
+
+# ─── Auth ────────────────────────────────────────────────────────────────────
+JWT_SECRET=CHANGE_ME_staging_jwt_secret_min_32_chars
+JWT_EXPIRES_IN=15m
+JWT_REFRESH_SECRET=CHANGE_ME_staging_refresh_secret_min_32_chars
+JWT_REFRESH_EXPIRES_IN=7d
+ENCRYPTION_SECRET=CHANGE_ME_staging_32_char_encryption_key
+
+# ─── Security ────────────────────────────────────────────────────────────────
+# Staging: 10-12 rounds (matches prod security level per README)
+BCRYPT_ROUNDS=12
+
+# ─── Redis ───────────────────────────────────────────────────────────────────
+REDIS_HOST=staging-redis.internal
+REDIS_PORT=6379
+
+# ─── Session ─────────────────────────────────────────────────────────────────
+SESSION_SECRET=CHANGE_ME_staging_session_secret_min_32_chars
+SESSION_COOKIE_NAME=teachlink.sid
+SESSION_PREFIX=sess:
+SESSION_TTL_SECONDS=604800
+SESSION_COOKIE_MAX_AGE_MS=604800000
+SESSION_LOCK_TTL_MS=5000
+SESSION_LOCK_MAX_RETRIES=5
+SESSION_LOCK_RETRY_DELAY_MS=120
+STICKY_SESSIONS_REQUIRED=true
+TRUST_PROXY=true
+
+# ─── Elasticsearch ───────────────────────────────────────────────────────────
+ELASTICSEARCH_NODE=http://staging-elasticsearch.internal:9200
+ELASTICSEARCH_USERNAME=
+ELASTICSEARCH_PASSWORD=
+ELASTICSEARCH_API_KEY=
+ELASTICSEARCH_CA_FINGERPRINT=
+ELASTICSEARCH_REQUEST_TIMEOUT=30000
+ELASTICSEARCH_MAX_RETRIES=3
+KIBANA_URL=http://staging-kibana.internal:5601
+
+# ─── Alerting ────────────────────────────────────────────────────────────────
+ALERT_EMAIL_RECIPIENTS=staging-ops@teachlink.io
+ALERT_SLACK_WEBHOOK_URL=https://hooks.slack.com/services/YOUR/STAGING/WEBHOOK
+SLACK_WEBHOOK_URL=https://hooks.slack.com/services/YOUR/STAGING/WEBHOOK
+
+# ─── Email / SMTP ────────────────────────────────────────────────────────────
+SMTP_HOST=smtp.mailtrap.io
+SMTP_PORT=587
+SMTP_SECURE=false
+SMTP_USER=CHANGE_ME_staging_smtp_user
+SMTP_PASS=CHANGE_ME_staging_smtp_pass
+EMAIL_FROM=noreply-staging@teachlink.io
+EMAIL_FROM_NAME=TeachLink Staging
+SENDGRID_API_KEY=CHANGE_ME_staging_sendgrid_key
+SENDGRID_HEALTH_URL=https://api.sendgrid.com/v3/health
+
+# ─── Stripe ──────────────────────────────────────────────────────────────────
+# Use Stripe test-mode keys for staging
+STRIPE_SECRET_KEY=sk_test_CHANGE_ME_staging_stripe_key
+STRIPE_WEBHOOK_SECRET=whsec_CHANGE_ME_staging_webhook_secret
+STRIPE_HEALTH_URL=https://api.stripe.com/v1/balance
+
+# ─── AWS ─────────────────────────────────────────────────────────────────────
+AWS_ACCESS_KEY_ID=CHANGE_ME_staging_aws_key
+AWS_SECRET_ACCESS_KEY=CHANGE_ME_staging_aws_secret
+AWS_REGION=us-east-1
+AWS_S3_BUCKET=teachlink-staging
+AWS_S3_BUCKET_NAME=teachlink-staging
+AWS_KMS_KEY_ID=CHANGE_ME_staging_kms_key
+AWS_CLOUDFRONT_DISTRIBUTION_ID=CHANGE_ME_staging_cf_dist
+AWS_SQS_NOTIFICATION_QUEUE_URL=https://sqs.us-east-1.amazonaws.com/YOUR_ACCOUNT/teachlink-notifications-staging
+AWS_SNS_NOTIFICATION_TOPIC_ARN=arn:aws:sns:us-east-1:YOUR_ACCOUNT:teachlink-notifications-staging
+AWS_HEALTH_URL=https://sts.amazonaws.com
+
+# ─── Application ─────────────────────────────────────────────────────────────
+APP_URL=https://staging.teachlink.io
+CORS_ALLOWED_ORIGINS=https://staging.teachlink.io,https://staging-app.teachlink.io
+
+# ─── GraphQL ─────────────────────────────────────────────────────────────────
+GRAPHQL_MAX_DEPTH=10
+GRAPHQL_MAX_COMPLEXITY=1000
+GRAPHQL_LIST_MULTIPLIER=10
+
+# ─── Feature Flags (same as prod) ────────────────────────────────────────────
+ENABLE_AUTH=true
+ENABLE_SESSION_MANAGEMENT=true
+ENABLE_PAYMENTS=true
+ENABLE_AB_TESTING=false
+ENABLE_DATA_WAREHOUSE=false
+ENABLE_COLLABORATION=true
+ENABLE_MEDIA_PROCESSING=true
+ENABLE_BACKUP=true
+ENABLE_GRAPHQL=false
+ENABLE_SYNC=true
+ENABLE_MIGRATIONS=true
+ENABLE_RATE_LIMITING=true
+ENABLE_OBSERVABILITY=true
+ENABLE_CACHING=true
+ENABLE_FEATURE_FLAGS=true
+ENABLE_SEARCH=true
+ENABLE_NOTIFICATIONS=true
+ENABLE_EMAIL_MARKETING=true
+ENABLE_GAMIFICATION=true
+ENABLE_ASSESSMENT=true
+ENABLE_LEARNING_PATHS=true
+ENABLE_MODERATION=true
+ENABLE_ORCHESTRATION=true
+ENABLE_SECURITY=true
+ENABLE_TENANCY=true
+ENABLE_CDN=true
+
+# ─── Performance ─────────────────────────────────────────────────────────────
+CLUSTER_MODE=false
+CLUSTER_WORKERS=4
+
+# ─── Secrets Management ──────────────────────────────────────────────────────
+SECRET_PROVIDER=env
+SECRET_CACHE_TTL_MS=300000
+SECRETS_TO_ROTATE=JWT_SECRET,DATABASE_PASSWORD,STRIPE_SECRET_KEY
+
+# ─── Idempotency ─────────────────────────────────────────────────────────────
+IDEMPOTENCY_TTL_SECONDS=86400
+
+# ─── Circuit Breaker ─────────────────────────────────────────────────────────
+CIRCUIT_BREAKER_TIMEOUT_MS=3000
+CIRCUIT_BREAKER_ERROR_THRESHOLD=50
+CIRCUIT_BREAKER_RESET_TIMEOUT_MS=30000
+CIRCUIT_BREAKER_ROLLING_COUNT_TIMEOUT=60000
+CIRCUIT_BREAKER_ROLLING_COUNT_BUCKETS=10
+
+# ─── API Versioning ──────────────────────────────────────────────────────────
+API_SUPPORTED_VERSIONS=1
+API_DEFAULT_VERSION=1

--- a/.github/workflows/staging-sync.yml
+++ b/.github/workflows/staging-sync.yml
@@ -1,0 +1,68 @@
+# .github/workflows/staging-sync.yml
+#
+# Runs a sanitized prod → staging data sync on a schedule and on demand.
+#
+# Required repository secrets:
+#   PROD_DB_HOST, PROD_DB_PORT, PROD_DB_USER, PROD_DB_PASSWORD, PROD_DB_NAME
+#   STAGING_DB_HOST, STAGING_DB_PORT, STAGING_DB_USER, STAGING_DB_PASSWORD, STAGING_DB_NAME
+#   STAGING_SYNC_SLACK_WEBHOOK  (optional – Slack notification on failure)
+
+name: Staging Data Sync
+
+on:
+  schedule:
+    # Every day at 02:00 UTC (low-traffic window)
+    - cron: '0 2 * * *'
+  workflow_dispatch:
+    inputs:
+      keep_dump:
+        description: 'Keep dump file after restore (1 = yes)'
+        required: false
+        default: '0'
+
+concurrency:
+  group: staging-sync
+  cancel-in-progress: false   # never cancel a running sync mid-restore
+
+jobs:
+  sync:
+    name: Sanitize & Sync
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install PostgreSQL client
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends postgresql-client python3
+
+      - name: Run sanitize-and-sync
+        env:
+          PROD_DB_HOST:      ${{ secrets.PROD_DB_HOST }}
+          PROD_DB_PORT:      ${{ secrets.PROD_DB_PORT }}
+          PROD_DB_USER:      ${{ secrets.PROD_DB_USER }}
+          PROD_DB_PASSWORD:  ${{ secrets.PROD_DB_PASSWORD }}
+          PROD_DB_NAME:      ${{ secrets.PROD_DB_NAME }}
+          STAGING_DB_HOST:   ${{ secrets.STAGING_DB_HOST }}
+          STAGING_DB_PORT:   ${{ secrets.STAGING_DB_PORT }}
+          STAGING_DB_USER:   ${{ secrets.STAGING_DB_USER }}
+          STAGING_DB_PASSWORD: ${{ secrets.STAGING_DB_PASSWORD }}
+          STAGING_DB_NAME:   ${{ secrets.STAGING_DB_NAME }}
+          KEEP_DUMP:         ${{ github.event.inputs.keep_dump || '0' }}
+          DUMP_DIR:          /tmp/staging-sync
+        run: bash scripts/staging/sanitize-and-sync.sh
+
+      - name: Notify Slack on failure
+        if: failure() && secrets.STAGING_SYNC_SLACK_WEBHOOK != ''
+        uses: slackapi/slack-github-action@v1.26.0
+        with:
+          payload: |
+            {
+              "text": ":x: *Staging sync failed* on `${{ github.repository }}` – <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>"
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.STAGING_SYNC_SLACK_WEBHOOK }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@ lerna-debug.log*
 .env.development.local
 .env.test.local
 .env.production.local
+.env.staging.local
 .env.local
 
 # temp directory

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -1,0 +1,310 @@
+# docker-compose.staging.yml
+#
+# Staging environment – mirrors production service topology.
+# Usage:
+#   docker compose -f docker-compose.staging.yml --env-file .env.staging up -d
+#
+# All resource limits are set to match the production baseline.
+# Secrets must be supplied via .env.staging (never committed).
+
+networks:
+  teachlink-staging:
+    driver: bridge
+
+volumes:
+  staging-postgres-data:
+  staging-redis-data:
+  staging-elasticsearch-data:
+  staging-prometheus-data:
+  staging-alertmanager-data:
+  staging-grafana-data:
+
+services:
+  # ─── Application ────────────────────────────────────────────────────────────
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      target: production
+    image: teachlink-backend:staging
+    container_name: teachlink-staging-app
+    restart: unless-stopped
+    ports:
+      - '${APP_PORT:-3000}:3000'
+    env_file:
+      - .env.staging
+    environment:
+      NODE_ENV: staging
+      DATABASE_HOST: postgres
+      DATABASE_PORT: 5432
+      REDIS_HOST: redis
+      REDIS_PORT: 6379
+      ELASTICSEARCH_NODE: http://elasticsearch:9200
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    networks:
+      - teachlink-staging
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+    read_only: true
+    tmpfs:
+      - /app/tmp:size=64m,mode=1777
+      - /tmp:size=32m,mode=1777
+    deploy:
+      resources:
+        limits:
+          cpus: '1.0'
+          memory: 512M
+        reservations:
+          cpus: '0.25'
+          memory: 128M
+    healthcheck:
+      test: ['CMD', 'wget', '--quiet', '--tries=1', '--spider', 'http://localhost:3000/health']
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 30s
+
+  # ─── PostgreSQL ──────────────────────────────────────────────────────────────
+  postgres:
+    image: postgres:16-alpine
+    container_name: teachlink-staging-postgres
+    restart: unless-stopped
+    ports:
+      - '${DATABASE_PORT:-5433}:5432'
+    environment:
+      POSTGRES_USER: ${DATABASE_USER:-teachlink_staging}
+      POSTGRES_PASSWORD: ${DATABASE_PASSWORD}
+      POSTGRES_DB: ${DATABASE_NAME:-teachlink_staging}
+      PGDATA: /var/lib/postgresql/data/pgdata
+    networks:
+      - teachlink-staging
+    volumes:
+      - staging-postgres-data:/var/lib/postgresql/data
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+    cap_add:
+      - CHOWN
+      - FOWNER
+      - SETUID
+      - SETGID
+    deploy:
+      resources:
+        limits:
+          cpus: '1.0'
+          memory: 512M
+        reservations:
+          cpus: '0.25'
+          memory: 128M
+    healthcheck:
+      test: ['CMD-SHELL', 'pg_isready -U ${DATABASE_USER:-teachlink_staging} -d ${DATABASE_NAME:-teachlink_staging}']
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
+
+  # ─── Redis ───────────────────────────────────────────────────────────────────
+  redis:
+    image: redis:7-alpine
+    container_name: teachlink-staging-redis
+    restart: unless-stopped
+    ports:
+      - '${REDIS_PORT:-6380}:6379'
+    command: >
+      redis-server
+      --appendonly yes
+      --appendfsync everysec
+      --maxmemory 256mb
+      --maxmemory-policy allkeys-lru
+    networks:
+      - teachlink-staging
+    volumes:
+      - staging-redis-data:/data
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+    deploy:
+      resources:
+        limits:
+          cpus: '0.5'
+          memory: 256M
+        reservations:
+          cpus: '0.1'
+          memory: 64M
+    healthcheck:
+      test: ['CMD', 'redis-cli', 'ping']
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 5s
+
+  # ─── Elasticsearch ───────────────────────────────────────────────────────────
+  elasticsearch:
+    image: elasticsearch:8.13.4
+    container_name: teachlink-staging-elasticsearch
+    restart: unless-stopped
+    ports:
+      - '9201:9200'
+    environment:
+      discovery.type: single-node
+      xpack.security.enabled: 'false'
+      ES_JAVA_OPTS: '-Xms512m -Xmx512m'
+      cluster.name: teachlink-staging-cluster
+    networks:
+      - teachlink-staging
+    volumes:
+      - staging-elasticsearch-data:/usr/share/elasticsearch/data
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+    cap_add:
+      - CHOWN
+      - SETUID
+      - SETGID
+    deploy:
+      resources:
+        limits:
+          cpus: '1.0'
+          memory: 1G
+        reservations:
+          cpus: '0.25'
+          memory: 512M
+    healthcheck:
+      test:
+        ['CMD-SHELL', 'curl -s http://localhost:9200/_cluster/health | grep -qv "\"status\":\"red\""']
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 60s
+
+  # ─── Prometheus ──────────────────────────────────────────────────────────────
+  prometheus:
+    image: prom/prometheus:latest
+    container_name: teachlink-staging-prometheus
+    restart: unless-stopped
+    ports:
+      - '9091:9090'
+    command:
+      - --config.file=/etc/prometheus/prometheus.yml
+      - --storage.tsdb.retention.time=15d
+      - --web.enable-lifecycle
+    extra_hosts:
+      - 'host.docker.internal:host-gateway'
+    networks:
+      - teachlink-staging
+    volumes:
+      - ./infra/monitoring/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - ./infra/monitoring/alerts.yml:/etc/prometheus/alerts.yml:ro
+      - staging-prometheus-data:/prometheus
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+    deploy:
+      resources:
+        limits:
+          cpus: '0.5'
+          memory: 256M
+        reservations:
+          cpus: '0.1'
+          memory: 64M
+    healthcheck:
+      test: ['CMD', 'wget', '--quiet', '--tries=1', '--spider', 'http://localhost:9090/-/healthy']
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 15s
+
+  # ─── Grafana ─────────────────────────────────────────────────────────────────
+  grafana:
+    image: grafana/grafana:latest
+    container_name: teachlink-staging-grafana
+    restart: unless-stopped
+    ports:
+      - '3002:3000'
+    environment:
+      - GF_SECURITY_ADMIN_USER=${GRAFANA_ADMIN_USER:-admin}
+      - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_ADMIN_PASSWORD:-admin}
+      - GF_USERS_ALLOW_SIGN_UP=false
+    networks:
+      - teachlink-staging
+    volumes:
+      - staging-grafana-data:/var/lib/grafana
+      - ./infra/monitoring/provisioning:/etc/grafana/provisioning:ro
+    depends_on:
+      prometheus:
+        condition: service_healthy
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+    deploy:
+      resources:
+        limits:
+          cpus: '0.5'
+          memory: 256M
+        reservations:
+          cpus: '0.1'
+          memory: 64M
+    healthcheck:
+      test: ['CMD', 'wget', '--quiet', '--tries=1', '--spider', 'http://localhost:3000/api/health']
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 15s
+
+  # ─── Exporters ───────────────────────────────────────────────────────────────
+  redis_exporter:
+    image: oliver006/redis_exporter:latest
+    container_name: teachlink-staging-redis-exporter
+    restart: unless-stopped
+    ports:
+      - '9122:9121'
+    environment:
+      REDIS_ADDR: 'redis://redis:6379'
+    networks:
+      - teachlink-staging
+    depends_on:
+      redis:
+        condition: service_healthy
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+    deploy:
+      resources:
+        limits:
+          cpus: '0.1'
+          memory: 64M
+
+  postgres_exporter:
+    image: prometheuscommunity/postgres-exporter:latest
+    container_name: teachlink-staging-postgres-exporter
+    restart: unless-stopped
+    ports:
+      - '9188:9187'
+    environment:
+      DATA_SOURCE_NAME: 'postgresql://${DATABASE_USER:-teachlink_staging}:${DATABASE_PASSWORD}@postgres:5432/${DATABASE_NAME:-teachlink_staging}?sslmode=disable'
+    networks:
+      - teachlink-staging
+    depends_on:
+      postgres:
+        condition: service_healthy
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+    deploy:
+      resources:
+        limits:
+          cpus: '0.1'
+          memory: 64M

--- a/docs/staging-environment.md
+++ b/docs/staging-environment.md
@@ -1,0 +1,128 @@
+# Staging Environment
+
+Staging is a production-parity environment used for final validation before releases. It runs the same service versions, the same configuration shape, and a sanitized copy of production data refreshed daily.
+
+---
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `.env.staging` | Environment variables – mirrors prod shape, staging-specific values |
+| `docker-compose.staging.yml` | Full service stack (app, postgres, redis, elasticsearch, prometheus, grafana, exporters) |
+| `scripts/staging/sanitize-and-sync.sh` | Dumps prod DB, sanitizes PII, restores to staging |
+| `.github/workflows/staging-sync.yml` | Scheduled (daily 02:00 UTC) and on-demand sync workflow |
+
+---
+
+## Starting the stack
+
+```bash
+# Copy and fill in secrets
+cp .env.staging .env.staging.local
+# edit .env.staging.local with real credentials
+
+docker compose -f docker-compose.staging.yml --env-file .env.staging.local up -d
+```
+
+Staging ports are offset by +1 from the default prod ports to allow both stacks to run on the same host:
+
+| Service | Staging port | Prod port |
+|---|---|---|
+| App | 3000 | 3000 |
+| PostgreSQL | 5433 | 5432 |
+| Redis | 6380 | 6379 |
+| Elasticsearch | 9201 | 9200 |
+| Prometheus | 9091 | 9090 |
+| Grafana | 3002 | 3001 |
+| Redis exporter | 9122 | 9121 |
+| Postgres exporter | 9188 | 9187 |
+
+---
+
+## Data sync
+
+### How it works
+
+`scripts/staging/sanitize-and-sync.sh` runs four steps:
+
+1. **Dump** – `pg_dump` from production (plain SQL, no owner/ACL).
+2. **Sanitize** – Python3 inline script rewrites PII in the dump:
+   - Emails → `user_<sha256[:12]>@staging.invalid` (deterministic, preserves referential integrity)
+   - Phone numbers → fake E.164 derived from hash
+   - Wallet addresses → fake `0x` address derived from hash
+   - Stripe customer/payment IDs → `cus_staging_*` / `pm_staging_*`
+   - bcrypt hashes → fixed staging placeholder hash
+3. **Recreate** – drops and recreates the staging database.
+4. **Restore** – `psql` restores the sanitized dump.
+
+### Running manually
+
+```bash
+export PROD_DB_HOST=prod-db.internal
+export PROD_DB_PORT=5432
+export PROD_DB_USER=teachlink
+export PROD_DB_PASSWORD=...
+export PROD_DB_NAME=teachlink
+
+export STAGING_DB_HOST=staging-db.internal
+export STAGING_DB_PORT=5432
+export STAGING_DB_USER=teachlink_staging
+export STAGING_DB_PASSWORD=...
+export STAGING_DB_NAME=teachlink_staging
+
+bash scripts/staging/sanitize-and-sync.sh
+```
+
+Set `KEEP_DUMP=1` to retain the dump files in `/tmp/staging-sync` for inspection.
+
+### Scheduled sync (GitHub Actions)
+
+The workflow `.github/workflows/staging-sync.yml` runs automatically every day at **02:00 UTC**. It can also be triggered manually from the Actions tab with an optional `keep_dump` input.
+
+A `concurrency` group prevents two syncs from running simultaneously. On failure, a Slack notification is sent to `STAGING_SYNC_SLACK_WEBHOOK`.
+
+### Required secrets
+
+Add these in **Settings → Secrets and variables → Actions**:
+
+| Secret | Description |
+|---|---|
+| `PROD_DB_HOST` | Production DB hostname |
+| `PROD_DB_PORT` | Production DB port |
+| `PROD_DB_USER` | Production DB user |
+| `PROD_DB_PASSWORD` | Production DB password |
+| `PROD_DB_NAME` | Production DB name |
+| `STAGING_DB_HOST` | Staging DB hostname |
+| `STAGING_DB_PORT` | Staging DB port |
+| `STAGING_DB_USER` | Staging DB user |
+| `STAGING_DB_PASSWORD` | Staging DB password |
+| `STAGING_DB_NAME` | Staging DB name |
+| `STAGING_SYNC_SLACK_WEBHOOK` | (Optional) Slack webhook for failure alerts |
+
+---
+
+## Configuration parity
+
+`.env.staging` mirrors every variable in `.env.example` with staging-appropriate values:
+
+- **`NODE_ENV=staging`**
+- **`BCRYPT_ROUNDS=12`** – matches the recommended staging range (10–12) from the README security table
+- **Database pool** – `DATABASE_POOL_MAX=20 / MIN=5` per the README pool sizing table for staging
+- **Feature flags** – identical to production defaults
+- **Stripe** – test-mode keys (`sk_test_*`) so no real charges are made
+- **Email** – Mailtrap SMTP to intercept outbound email
+
+All `CHANGE_ME_*` placeholders must be replaced with real values before use. Never commit `.env.staging.local` or any file containing real secrets.
+
+---
+
+## Dependency parity
+
+Staging uses the same `package.json` and `package-lock.json` as production. No separate dependency file exists. The Docker image is built from the same `Dockerfile` with `target: production`, ensuring identical Node.js version, installed packages, and build output.
+
+Service image versions in `docker-compose.staging.yml` are pinned to the same tags used in `infra/monitoring/docker-compose.yml`:
+
+- `postgres:16-alpine`
+- `redis:7-alpine`
+- `elasticsearch:8.13.4`

--- a/scripts/staging/sanitize-and-sync.sh
+++ b/scripts/staging/sanitize-and-sync.sh
@@ -1,0 +1,172 @@
+#!/usr/bin/env bash
+# scripts/staging/sanitize-and-sync.sh
+#
+# Dumps production PostgreSQL, sanitizes PII, and restores into staging.
+#
+# Required env vars (set in CI secrets or .env.staging):
+#   PROD_DB_HOST, PROD_DB_PORT, PROD_DB_USER, PROD_DB_PASSWORD, PROD_DB_NAME
+#   STAGING_DB_HOST, STAGING_DB_PORT, STAGING_DB_USER, STAGING_DB_PASSWORD, STAGING_DB_NAME
+#
+# Optional:
+#   DUMP_DIR   – local directory for the dump file (default: /tmp/staging-sync)
+#   KEEP_DUMP  – set to "1" to keep the dump file after restore
+
+set -euo pipefail
+
+# ─── Config ──────────────────────────────────────────────────────────────────
+PROD_DB_HOST="${PROD_DB_HOST:?PROD_DB_HOST is required}"
+PROD_DB_PORT="${PROD_DB_PORT:-5432}"
+PROD_DB_USER="${PROD_DB_USER:?PROD_DB_USER is required}"
+PROD_DB_PASSWORD="${PROD_DB_PASSWORD:?PROD_DB_PASSWORD is required}"
+PROD_DB_NAME="${PROD_DB_NAME:?PROD_DB_NAME is required}"
+
+STAGING_DB_HOST="${STAGING_DB_HOST:?STAGING_DB_HOST is required}"
+STAGING_DB_PORT="${STAGING_DB_PORT:-5432}"
+STAGING_DB_USER="${STAGING_DB_USER:?STAGING_DB_USER is required}"
+STAGING_DB_PASSWORD="${STAGING_DB_PASSWORD:?STAGING_DB_PASSWORD is required}"
+STAGING_DB_NAME="${STAGING_DB_NAME:?STAGING_DB_NAME is required}"
+
+DUMP_DIR="${DUMP_DIR:-/tmp/staging-sync}"
+TIMESTAMP=$(date +%Y%m%d_%H%M%S)
+DUMP_FILE="${DUMP_DIR}/prod_dump_${TIMESTAMP}.sql"
+SANITIZED_FILE="${DUMP_DIR}/sanitized_${TIMESTAMP}.sql"
+
+# ─── Helpers ─────────────────────────────────────────────────────────────────
+log() { echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] $*"; }
+die() { log "ERROR: $*" >&2; exit 1; }
+
+cleanup() {
+  if [[ "${KEEP_DUMP:-0}" != "1" ]]; then
+    log "Cleaning up dump files..."
+    rm -f "$DUMP_FILE" "$SANITIZED_FILE"
+  fi
+}
+trap cleanup EXIT
+
+# ─── Step 1: Dump production ─────────────────────────────────────────────────
+log "=== Step 1/4: Dumping production database ==="
+mkdir -p "$DUMP_DIR"
+
+PGPASSWORD="$PROD_DB_PASSWORD" pg_dump \
+  -h "$PROD_DB_HOST" \
+  -p "$PROD_DB_PORT" \
+  -U "$PROD_DB_USER" \
+  -d "$PROD_DB_NAME" \
+  --no-owner \
+  --no-acl \
+  -F p \
+  -f "$DUMP_FILE"
+
+DUMP_SIZE=$(du -h "$DUMP_FILE" | cut -f1)
+log "Dump complete: $DUMP_FILE ($DUMP_SIZE)"
+
+# ─── Step 2: Sanitize PII ────────────────────────────────────────────────────
+log "=== Step 2/4: Sanitizing PII ==="
+
+# Copy dump then apply in-place sed replacements for PII fields.
+# Each pattern targets the SQL INSERT/COPY data for known PII columns.
+cp "$DUMP_FILE" "$SANITIZED_FILE"
+
+# users table: email, username, first_name, last_name, phone, wallet_address
+# Matches COPY data rows and UPDATE/INSERT statements.
+python3 - "$SANITIZED_FILE" <<'PYEOF'
+import re, sys, hashlib, uuid
+
+path = sys.argv[1]
+with open(path, 'r', encoding='utf-8', errors='replace') as f:
+    content = f.read()
+
+# ── Deterministic fake email from a hash so referential integrity is preserved
+def fake_email(match):
+    original = match.group(1)
+    h = hashlib.sha256(original.encode()).hexdigest()[:12]
+    return f"user_{h}@staging.invalid"
+
+def fake_name(match):
+    h = hashlib.sha256(match.group(1).encode()).hexdigest()[:8]
+    return f"User{h.capitalize()}"
+
+def fake_phone(match):
+    h = hashlib.sha256(match.group(1).encode()).hexdigest()
+    digits = ''.join(filter(str.isdigit, h))[:10].ljust(10, '0')
+    return f"+1{digits}"
+
+def fake_wallet(match):
+    return "0x" + hashlib.sha256(match.group(1).encode()).hexdigest()[:40]
+
+# Email addresses (quoted strings that look like emails)
+content = re.sub(
+    r"'([a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,})'",
+    lambda m: f"'{fake_email(m)}'",
+    content
+)
+
+# Phone numbers (E.164 format)
+content = re.sub(
+    r"'(\+?[0-9]{7,15})'",
+    lambda m: f"'{fake_phone(m)}'",
+    content
+)
+
+# Wallet addresses (0x + 40 hex chars)
+content = re.sub(
+    r"'(0x[0-9a-fA-F]{40})'",
+    lambda m: f"'{fake_wallet(m)}'",
+    content
+)
+
+# Stripe customer IDs (cus_...)
+content = re.sub(
+    r"'(cus_[A-Za-z0-9]{14,})'",
+    lambda m: f"'cus_staging_{hashlib.sha256(m.group(1).encode()).hexdigest()[:14]}'",
+    content
+)
+
+# Payment method IDs (pm_...)
+content = re.sub(
+    r"'(pm_[A-Za-z0-9]{14,})'",
+    lambda m: f"'pm_staging_{hashlib.sha256(m.group(1).encode()).hexdigest()[:14]}'",
+    content
+)
+
+# bcrypt password hashes – replace with a known staging hash for "StagingPass1!"
+STAGING_HASH = r'\$2b\$12\$stagingHashPlaceholderXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'
+content = re.sub(r"'\\\$2[aby]\\\$[0-9]{2}\\\$[A-Za-z0-9./]{53}'", f"'{STAGING_HASH}'", content)
+# Also handle unescaped bcrypt in plain SQL
+content = re.sub(r"'(\$2[aby]\$[0-9]{2}\$[A-Za-z0-9./]{53})'", f"'{STAGING_HASH}'", content)
+
+with open(path, 'w', encoding='utf-8') as f:
+    f.write(content)
+
+print("Sanitization complete.")
+PYEOF
+
+log "Sanitization complete: $SANITIZED_FILE"
+
+# ─── Step 3: Drop & recreate staging DB ──────────────────────────────────────
+log "=== Step 3/4: Preparing staging database ==="
+
+PGPASSWORD="$STAGING_DB_PASSWORD" psql \
+  -h "$STAGING_DB_HOST" \
+  -p "$STAGING_DB_PORT" \
+  -U "$STAGING_DB_USER" \
+  -d postgres \
+  -c "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = '${STAGING_DB_NAME}' AND pid <> pg_backend_pid();" \
+  -c "DROP DATABASE IF EXISTS ${STAGING_DB_NAME};" \
+  -c "CREATE DATABASE ${STAGING_DB_NAME} OWNER ${STAGING_DB_USER};"
+
+log "Staging database recreated."
+
+# ─── Step 4: Restore sanitized dump ──────────────────────────────────────────
+log "=== Step 4/4: Restoring sanitized dump to staging ==="
+
+PGPASSWORD="$STAGING_DB_PASSWORD" psql \
+  -h "$STAGING_DB_HOST" \
+  -p "$STAGING_DB_PORT" \
+  -U "$STAGING_DB_USER" \
+  -d "$STAGING_DB_NAME" \
+  -f "$SANITIZED_FILE" \
+  --set ON_ERROR_STOP=1
+
+log "=== Sync complete at $(date -u +%Y-%m-%dT%H:%M:%SZ) ==="
+log "Staging DB: ${STAGING_DB_HOST}:${STAGING_DB_PORT}/${STAGING_DB_NAME}"


### PR DESCRIPTION
- Add .env.staging with prod-parity configuration (same feature flags, bcrypt rounds, pool sizing, circuit breaker, session settings)
- Add docker-compose.staging.yml mirroring prod service topology (postgres:16-alpine, redis:7-alpine, elasticsearch:8.13.4, exporters)
- Add scripts/staging/sanitize-and-sync.sh for sanitized prod data sync (anonymises emails, phones, wallet addresses, Stripe IDs, bcrypt hashes)
- Add .github/workflows/staging-sync.yml for daily scheduled sync at 02:00 UTC
- Add docs/staging-environment.md with full runbook
- Ignore .env.staging.local in .gitignore

closes #599  