### PR TITLE
feat(gamification): add point system with tiers and levels (#575)

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -39,6 +39,7 @@ import { GatewayModule } from './gateway/gateway.module';
 import { NotificationsModule } from './notifications/notifications.module';
 import { MessagingModule } from './messaging/messaging.module';
 import { DashboardModule } from './dashboard/dashboard.module';
+import { GamificationModule } from './gamification/gamification.module';
 
 const featureFlags = loadFeatureFlags();
 
@@ -83,6 +84,7 @@ const featureFlags = loadFeatureFlags();
     NotificationsModule,
     MessagingModule,
     DashboardModule,
+    GamificationModule,
   ],
   controllers: [AppController],
   providers: [

--- a/src/gamification/entities/tier-reward.entity.ts
+++ b/src/gamification/entities/tier-reward.entity.ts
@@ -1,0 +1,35 @@
+import { Entity, PrimaryGeneratedColumn, Column, VersionColumn } from 'typeorm';
+import { Tier } from '../enums/tier.enum';
+
+/**
+ * Defines the reward granted when a user reaches a specific tier.
+ */
+@Entity('tier_rewards')
+export class TierReward {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @VersionColumn()
+  version: number;
+
+  @Column({ type: 'enum', enum: Tier, unique: true })
+  tier: Tier;
+
+  @Column()
+  title: string;
+
+  @Column()
+  description: string;
+
+  /** Badge ID to award, if any */
+  @Column({ nullable: true })
+  badgeId?: string;
+
+  /** Bonus points granted on tier promotion */
+  @Column({ default: 0 })
+  bonusPoints: number;
+
+  /** Arbitrary reward metadata (e.g. coupon codes, feature unlocks) */
+  @Column('jsonb', { nullable: true })
+  metadata?: Record<string, unknown>;
+}

--- a/src/gamification/entities/user-progress.entity.ts
+++ b/src/gamification/entities/user-progress.entity.ts
@@ -8,6 +8,7 @@ import {
   VersionColumn,
 } from 'typeorm';
 import { User } from '../../users/entities/user.entity';
+import { Tier } from '../enums/tier.enum';
 
 /**
  * Represents the user Progress entity.
@@ -36,4 +37,8 @@ export class UserProgress {
   @Column({ default: 0 })
   @Index()
   xp: number;
+
+  @Column({ type: 'enum', enum: Tier, default: Tier.BRONZE })
+  @Index()
+  tier: Tier;
 }

--- a/src/gamification/enums/point-activity.enum.ts
+++ b/src/gamification/enums/point-activity.enum.ts
@@ -1,0 +1,22 @@
+export enum PointActivityType {
+  COURSE_COMPLETED = 'COURSE_COMPLETED',
+  LESSON_COMPLETED = 'LESSON_COMPLETED',
+  QUIZ_PASSED = 'QUIZ_PASSED',
+  DAILY_LOGIN = 'DAILY_LOGIN',
+  PROFILE_COMPLETED = 'PROFILE_COMPLETED',
+  FIRST_COURSE_ENROLLED = 'FIRST_COURSE_ENROLLED',
+  REVIEW_SUBMITTED = 'REVIEW_SUBMITTED',
+  STREAK_BONUS = 'STREAK_BONUS',
+}
+
+/** Points awarded per activity type */
+export const POINT_RULES: Record<PointActivityType, number> = {
+  [PointActivityType.COURSE_COMPLETED]: 500,
+  [PointActivityType.LESSON_COMPLETED]: 50,
+  [PointActivityType.QUIZ_PASSED]: 100,
+  [PointActivityType.DAILY_LOGIN]: 10,
+  [PointActivityType.PROFILE_COMPLETED]: 200,
+  [PointActivityType.FIRST_COURSE_ENROLLED]: 150,
+  [PointActivityType.REVIEW_SUBMITTED]: 75,
+  [PointActivityType.STREAK_BONUS]: 25,
+};

--- a/src/gamification/enums/tier.enum.ts
+++ b/src/gamification/enums/tier.enum.ts
@@ -1,0 +1,7 @@
+export enum Tier {
+  BRONZE = 'BRONZE',
+  SILVER = 'SILVER',
+  GOLD = 'GOLD',
+  PLATINUM = 'PLATINUM',
+  DIAMOND = 'DIAMOND',
+}

--- a/src/gamification/gamification.controller.ts
+++ b/src/gamification/gamification.controller.ts
@@ -1,0 +1,112 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Param,
+  Body,
+  Query,
+  ParseIntPipe,
+  DefaultValuePipe,
+  HttpCode,
+  HttpStatus,
+} from '@nestjs/common';
+import { PointsService } from './points/points.service';
+import { LeaderboardService } from './leaderboards/leaderboards.service';
+import { TiersService } from './tiers/tiers.service';
+import { PointActivityType } from './enums/point-activity.enum';
+import { Tier } from './enums/tier.enum';
+import { TierReward } from './entities/tier-reward.entity';
+
+class AwardActivityDto {
+  userId: string;
+  activityType: PointActivityType;
+}
+
+class AddPointsDto {
+  userId: string;
+  points: number;
+  activityType: string;
+}
+
+class UpsertRewardDto {
+  title: string;
+  description: string;
+  badgeId?: string;
+  bonusPoints?: number;
+  metadata?: Record<string, unknown>;
+}
+
+@Controller('gamification')
+export class GamificationController {
+  constructor(
+    private readonly pointsService: PointsService,
+    private readonly leaderboardService: LeaderboardService,
+    private readonly tiersService: TiersService,
+  ) {}
+
+  // ── Points ──────────────────────────────────────────────────────────────────
+
+  @Post('points/award-activity')
+  @HttpCode(HttpStatus.OK)
+  awardActivity(@Body() dto: AwardActivityDto) {
+    return this.pointsService.awardActivity(dto.userId, dto.activityType);
+  }
+
+  @Post('points/add')
+  @HttpCode(HttpStatus.OK)
+  addPoints(@Body() dto: AddPointsDto) {
+    return this.pointsService.addPoints(dto.userId, dto.points, dto.activityType);
+  }
+
+  @Get('points/progress/:userId')
+  getUserProgress(@Param('userId') userId: string) {
+    return this.pointsService.getUserProgress(userId);
+  }
+
+  @Get('points/history/:userId')
+  getPointHistory(@Param('userId') userId: string) {
+    return this.pointsService.getPointHistory(userId);
+  }
+
+  // ── Leaderboard ─────────────────────────────────────────────────────────────
+
+  @Get('leaderboard')
+  getLeaderboard(
+    @Query('page', new DefaultValuePipe(1), ParseIntPipe) page: number,
+    @Query('pageSize', new DefaultValuePipe(20), ParseIntPipe) pageSize: number,
+  ) {
+    return this.leaderboardService.getLeaderboard(page, pageSize);
+  }
+
+  @Get('leaderboard/rank/:userId')
+  getUserRank(@Param('userId') userId: string) {
+    return this.leaderboardService.getUserRank(userId);
+  }
+
+  // ── Tiers ───────────────────────────────────────────────────────────────────
+
+  @Get('tiers/rewards')
+  getAllRewards(): Promise<TierReward[]> {
+    return this.tiersService.getAllRewards();
+  }
+
+  @Get('tiers/rewards/:tier')
+  getRewardForTier(@Param('tier') tier: Tier) {
+    return this.tiersService.getRewardForTier(tier);
+  }
+
+  @Post('tiers/rewards/:tier')
+  @HttpCode(HttpStatus.OK)
+  upsertReward(@Param('tier') tier: Tier, @Body() dto: UpsertRewardDto) {
+    return this.tiersService.upsertReward(tier, dto);
+  }
+
+  @Get('tiers/next/:userId')
+  async getNextTierInfo(@Param('userId') userId: string) {
+    const progress = await this.pointsService.getUserProgress(userId);
+    if (!progress) return null;
+    const nextTier = this.tiersService.getNextTier(progress.tier);
+    const pointsNeeded = this.tiersService.pointsToNextTier(progress.totalPoints);
+    return { currentTier: progress.tier, nextTier, pointsNeeded };
+  }
+}

--- a/src/gamification/gamification.module.ts
+++ b/src/gamification/gamification.module.ts
@@ -1,0 +1,34 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+
+import { UserProgress } from './entities/user-progress.entity';
+import { PointTransaction } from './entities/point-transaction.entity';
+import { Badge } from './entities/badge.entity';
+import { UserBadge } from './entities/user-badge.entity';
+import { Challenge } from './entities/challenge.entity';
+import { UserChallenge } from './entities/user-challenge.entity';
+import { TierReward } from './entities/tier-reward.entity';
+
+import { PointsService } from './points/points.service';
+import { LeaderboardService } from './leaderboards/leaderboards.service';
+import { BadgesService } from './badges/badges.service';
+import { TiersService } from './tiers/tiers.service';
+import { GamificationController } from './gamification.controller';
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([
+      UserProgress,
+      PointTransaction,
+      Badge,
+      UserBadge,
+      Challenge,
+      UserChallenge,
+      TierReward,
+    ]),
+  ],
+  controllers: [GamificationController],
+  providers: [PointsService, LeaderboardService, BadgesService, TiersService],
+  exports: [PointsService, LeaderboardService, BadgesService, TiersService],
+})
+export class GamificationModule {}

--- a/src/gamification/leaderboards/leaderboards.service.ts
+++ b/src/gamification/leaderboards/leaderboards.service.ts
@@ -2,31 +2,78 @@ import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { UserProgress } from '../entities/user-progress.entity';
+import { Tier } from '../enums/tier.enum';
 
-/**
- * Provides leaderboard operations.
- */
+export interface LeaderboardEntry {
+  rank: number;
+  userId: string;
+  username?: string;
+  totalPoints: number;
+  level: number;
+  tier: Tier;
+}
+
+export interface PaginatedLeaderboard {
+  data: LeaderboardEntry[];
+  total: number;
+  page: number;
+  pageSize: number;
+}
+
 @Injectable()
 export class LeaderboardService {
   constructor(
     @InjectRepository(UserProgress)
     private userProgressRepository: Repository<UserProgress>,
   ) {}
-  async getTopPlayers(limit: number = 10): Promise<UserProgress[]> {
-    return await this.userProgressRepository.find({
+
+  async getLeaderboard(page = 1, pageSize = 20): Promise<PaginatedLeaderboard> {
+    const clampedSize = Math.min(pageSize, 100);
+    const offset = (page - 1) * clampedSize;
+
+    const [rows, total] = await this.userProgressRepository.findAndCount({
+      order: { totalPoints: 'DESC' },
+      skip: offset,
+      take: clampedSize,
+      relations: ['user'],
+    });
+
+    const data: LeaderboardEntry[] = rows.map((p, i) => ({
+      rank: offset + i + 1,
+      userId: p.user?.id,
+      username: p.user?.username,
+      totalPoints: p.totalPoints,
+      level: p.level,
+      tier: p.tier,
+    }));
+
+    return { data, total, page, pageSize: clampedSize };
+  }
+
+  async getUserRank(userId: string): Promise<number | null> {
+    const count = await this.userProgressRepository
+      .createQueryBuilder('up')
+      .innerJoin('up.user', 'u')
+      .where('u.id = :userId', { userId })
+      .getOne();
+
+    if (!count) return null;
+
+    const rank =
+      (await this.userProgressRepository
+        .createQueryBuilder('up')
+        .where('up.totalPoints > :pts', { pts: count.totalPoints })
+        .getCount()) + 1;
+
+    return rank;
+  }
+
+  /** @deprecated Use getLeaderboard() for paginated results */
+  async getTopPlayers(limit = 10): Promise<UserProgress[]> {
+    return this.userProgressRepository.find({
       order: { totalPoints: 'DESC' },
       take: limit,
       relations: ['user'],
     });
-  }
-  async getUserRank(userId: string): Promise<number | null> {
-    const allProgress = await this.userProgressRepository.find({
-      order: { totalPoints: 'DESC' },
-    });
-    // This is a simple rank calculation that is O(n) over users.
-    // For large leaderboards, consider a direct database rank query or a
-    // cached materialized ranking field.
-    const rank = allProgress.findIndex((p) => p.user?.id === userId) + 1;
-    return rank > 0 ? rank : null;
   }
 }

--- a/src/gamification/points/points.service.spec.ts
+++ b/src/gamification/points/points.service.spec.ts
@@ -1,0 +1,117 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { PointsService } from './points.service';
+import { UserProgress } from '../entities/user-progress.entity';
+import { PointTransaction } from '../entities/point-transaction.entity';
+import { TiersService } from '../tiers/tiers.service';
+import { Tier } from '../enums/tier.enum';
+import { PointActivityType } from '../enums/point-activity.enum';
+
+const mockRepo = () => ({
+  findOne: jest.fn(),
+  find: jest.fn(),
+  create: jest.fn((v) => v),
+  save: jest.fn((v) => Promise.resolve(v)),
+});
+
+const mockTiersService = () => ({
+  getTierForPoints: jest.fn().mockReturnValue(Tier.BRONZE),
+});
+
+describe('PointsService', () => {
+  let service: PointsService;
+  let progressRepo: ReturnType<typeof mockRepo>;
+  let txRepo: ReturnType<typeof mockRepo>;
+  let tiersService: ReturnType<typeof mockTiersService>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        PointsService,
+        { provide: getRepositoryToken(UserProgress), useFactory: mockRepo },
+        { provide: getRepositoryToken(PointTransaction), useFactory: mockRepo },
+        { provide: TiersService, useFactory: mockTiersService },
+      ],
+    }).compile();
+
+    service = module.get(PointsService);
+    progressRepo = module.get(getRepositoryToken(UserProgress));
+    txRepo = module.get(getRepositoryToken(PointTransaction));
+    tiersService = module.get(TiersService);
+  });
+
+  describe('addPoints', () => {
+    it('creates a transaction and updates progress', async () => {
+      progressRepo.findOne.mockResolvedValue(null);
+      const { progress } = await service.addPoints('user-1', 100, 'TEST');
+      expect(txRepo.save).toHaveBeenCalled();
+      expect(progress.totalPoints).toBe(100);
+      expect(progress.xp).toBe(100);
+    });
+
+    it('accumulates points on existing progress', async () => {
+      const existing: Partial<UserProgress> = {
+        totalPoints: 900,
+        xp: 900,
+        level: 1,
+        tier: Tier.BRONZE,
+      };
+      progressRepo.findOne.mockResolvedValue(existing);
+      const { progress } = await service.addPoints('user-1', 200, 'TEST');
+      expect(progress.totalPoints).toBe(1100);
+    });
+
+    it('levels up when xp crosses threshold', async () => {
+      const existing: Partial<UserProgress> = {
+        totalPoints: 900,
+        xp: 900,
+        level: 1,
+        tier: Tier.BRONZE,
+      };
+      progressRepo.findOne.mockResolvedValue(existing);
+      const { progress } = await service.addPoints('user-1', 200, 'TEST');
+      expect(progress.level).toBe(2); // floor(1100/1000)+1 = 2
+    });
+
+    it('detects tier promotion', async () => {
+      const existing: Partial<UserProgress> = {
+        totalPoints: 900,
+        xp: 900,
+        level: 1,
+        tier: Tier.BRONZE,
+      };
+      progressRepo.findOne.mockResolvedValue(existing);
+      tiersService.getTierForPoints.mockReturnValue(Tier.SILVER);
+      const { tierPromoted } = await service.addPoints('user-1', 200, 'TEST');
+      expect(tierPromoted).toBe(true);
+    });
+
+    it('does not flag promotion when tier unchanged', async () => {
+      const existing: Partial<UserProgress> = {
+        totalPoints: 100,
+        xp: 100,
+        level: 1,
+        tier: Tier.BRONZE,
+      };
+      progressRepo.findOne.mockResolvedValue(existing);
+      tiersService.getTierForPoints.mockReturnValue(Tier.BRONZE);
+      const { tierPromoted } = await service.addPoints('user-1', 50, 'TEST');
+      expect(tierPromoted).toBe(false);
+    });
+  });
+
+  describe('awardActivity', () => {
+    it('uses POINT_RULES for known activity types', async () => {
+      progressRepo.findOne.mockResolvedValue(null);
+      const { progress } = await service.awardActivity('user-1', PointActivityType.DAILY_LOGIN);
+      expect(progress.totalPoints).toBe(10); // DAILY_LOGIN = 10
+    });
+  });
+
+  describe('getUserProgress', () => {
+    it('returns null when no progress exists', async () => {
+      progressRepo.findOne.mockResolvedValue(null);
+      await expect(service.getUserProgress('user-1')).resolves.toBeNull();
+    });
+  });
+});

--- a/src/gamification/points/points.service.ts
+++ b/src/gamification/points/points.service.ts
@@ -4,10 +4,12 @@ import { Repository } from 'typeorm';
 import { UserProgress } from '../entities/user-progress.entity';
 import { PointTransaction } from '../entities/point-transaction.entity';
 import { User } from '../../users/entities/user.entity';
+import { TiersService } from '../tiers/tiers.service';
+import { PointActivityType, POINT_RULES } from '../enums/point-activity.enum';
 
-/**
- * Provides points operations.
- */
+/** Points per XP level (level = floor(xp / XP_PER_LEVEL) + 1) */
+const XP_PER_LEVEL = 1000;
+
 @Injectable()
 export class PointsService {
   constructor(
@@ -15,24 +17,37 @@ export class PointsService {
     private userProgressRepository: Repository<UserProgress>,
     @InjectRepository(PointTransaction)
     private pointTransactionRepository: Repository<PointTransaction>,
+    private tiersService: TiersService,
   ) {}
 
   /**
-   * Award points for a user activity and update progress.
-   *
-   * The current progression model is intentionally simple: points and XP are
-   * identical, and level increases every 1000 XP. This is a good place to add
-   * more advanced reward rules later.
+   * Award points for a known activity type using the defined point rules.
+   * Returns the updated progress and whether a tier promotion occurred.
    */
-  async addPoints(userId: string, points: number, activityType: string): Promise<UserProgress> {
-    // Log the transaction
+  async awardActivity(
+    userId: string,
+    activityType: PointActivityType,
+  ): Promise<{ progress: UserProgress; tierPromoted: boolean }> {
+    const points = POINT_RULES[activityType];
+    return this.addPoints(userId, points, activityType);
+  }
+
+  /**
+   * Award an arbitrary number of points for a custom activity string.
+   * Returns the updated progress and whether a tier promotion occurred.
+   */
+  async addPoints(
+    userId: string,
+    points: number,
+    activityType: string,
+  ): Promise<{ progress: UserProgress; tierPromoted: boolean }> {
     const transaction = this.pointTransactionRepository.create({
       user: { id: userId } as User,
       points,
       activityType,
     });
     await this.pointTransactionRepository.save(transaction);
-    // Update user progress
+
     let progress = await this.userProgressRepository.findOne({
       where: { user: { id: userId } },
     });
@@ -44,19 +59,30 @@ export class PointsService {
         xp: 0,
       });
     }
+
+    const previousTier = progress.tier;
+
     progress.totalPoints += points;
     progress.xp += points;
-    // Basic level progression logic: level up every 1000 XP
-    const newLevel = Math.floor(progress.xp / 1000) + 1;
-    if (newLevel > progress.level) {
-      progress.level = newLevel;
-      // TODO: Emit level up event for notification, badge award, or milestone tracking
-    }
-    return await this.userProgressRepository.save(progress);
+    progress.level = Math.floor(progress.xp / XP_PER_LEVEL) + 1;
+    progress.tier = this.tiersService.getTierForPoints(progress.totalPoints);
+
+    const tierPromoted = progress.tier !== previousTier;
+
+    const saved = await this.userProgressRepository.save(progress);
+    return { progress: saved, tierPromoted };
   }
+
   async getUserProgress(userId: string): Promise<UserProgress | null> {
-    return await this.userProgressRepository.findOne({
+    return this.userProgressRepository.findOne({
       where: { user: { id: userId } },
+    });
+  }
+
+  async getPointHistory(userId: string): Promise<PointTransaction[]> {
+    return this.pointTransactionRepository.find({
+      where: { user: { id: userId } },
+      order: { createdAt: 'DESC' },
     });
   }
 }

--- a/src/gamification/tiers/tiers.service.spec.ts
+++ b/src/gamification/tiers/tiers.service.spec.ts
@@ -1,0 +1,91 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { TiersService, TIER_THRESHOLDS } from './tiers.service';
+import { TierReward } from '../entities/tier-reward.entity';
+import { Tier } from '../enums/tier.enum';
+
+const mockRepo = () => ({
+  findOne: jest.fn(),
+  find: jest.fn(),
+  create: jest.fn(),
+  save: jest.fn(),
+});
+
+describe('TiersService', () => {
+  let service: TiersService;
+  let repo: jest.Mocked<Repository<TierReward>>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        TiersService,
+        { provide: getRepositoryToken(TierReward), useFactory: mockRepo },
+      ],
+    }).compile();
+
+    service = module.get(TiersService);
+    repo = module.get(getRepositoryToken(TierReward));
+  });
+
+  describe('getTierForPoints', () => {
+    it.each([
+      [0, Tier.BRONZE],
+      [999, Tier.BRONZE],
+      [1000, Tier.SILVER],
+      [4999, Tier.SILVER],
+      [5000, Tier.GOLD],
+      [14999, Tier.GOLD],
+      [15000, Tier.PLATINUM],
+      [49999, Tier.PLATINUM],
+      [50000, Tier.DIAMOND],
+      [999999, Tier.DIAMOND],
+    ])('returns %s tier for %i points', (points, expected) => {
+      expect(service.getTierForPoints(points)).toBe(expected);
+    });
+  });
+
+  describe('getNextTier', () => {
+    it('returns SILVER for BRONZE', () => expect(service.getNextTier(Tier.BRONZE)).toBe(Tier.SILVER));
+    it('returns GOLD for SILVER', () => expect(service.getNextTier(Tier.SILVER)).toBe(Tier.GOLD));
+    it('returns null for DIAMOND', () => expect(service.getNextTier(Tier.DIAMOND)).toBeNull());
+  });
+
+  describe('pointsToNextTier', () => {
+    it('returns correct gap to next tier', () => {
+      expect(service.pointsToNextTier(500)).toBe(TIER_THRESHOLDS[Tier.SILVER] - 500);
+    });
+    it('returns null at max tier', () => {
+      expect(service.pointsToNextTier(50000)).toBeNull();
+    });
+  });
+
+  describe('getRewardForTier', () => {
+    it('delegates to repository', async () => {
+      const reward = { tier: Tier.GOLD } as TierReward;
+      repo.findOne.mockResolvedValue(reward);
+      await expect(service.getRewardForTier(Tier.GOLD)).resolves.toBe(reward);
+      expect(repo.findOne).toHaveBeenCalledWith({ where: { tier: Tier.GOLD } });
+    });
+  });
+
+  describe('upsertReward', () => {
+    it('updates existing reward', async () => {
+      const existing = { tier: Tier.SILVER, title: 'old' } as TierReward;
+      repo.findOne.mockResolvedValue(existing);
+      repo.save.mockResolvedValue({ ...existing, title: 'new' } as TierReward);
+      const result = await service.upsertReward(Tier.SILVER, { title: 'new' });
+      expect(result.title).toBe('new');
+    });
+
+    it('creates new reward when none exists', async () => {
+      repo.findOne.mockResolvedValue(null);
+      const created = { tier: Tier.GOLD, title: 'Gold Reward' } as TierReward;
+      repo.create.mockReturnValue(created);
+      repo.save.mockResolvedValue(created);
+      const result = await service.upsertReward(Tier.GOLD, { title: 'Gold Reward' });
+      expect(repo.create).toHaveBeenCalled();
+      expect(result).toBe(created);
+    });
+  });
+});

--- a/src/gamification/tiers/tiers.service.ts
+++ b/src/gamification/tiers/tiers.service.ts
@@ -1,0 +1,70 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Tier } from '../enums/tier.enum';
+import { TierReward } from '../entities/tier-reward.entity';
+
+/** Minimum total points required to reach each tier */
+export const TIER_THRESHOLDS: Record<Tier, number> = {
+  [Tier.BRONZE]: 0,
+  [Tier.SILVER]: 1000,
+  [Tier.GOLD]: 5000,
+  [Tier.PLATINUM]: 15000,
+  [Tier.DIAMOND]: 50000,
+};
+
+/** Ordered list of tiers from lowest to highest */
+const TIER_ORDER: Tier[] = [Tier.BRONZE, Tier.SILVER, Tier.GOLD, Tier.PLATINUM, Tier.DIAMOND];
+
+@Injectable()
+export class TiersService {
+  constructor(
+    @InjectRepository(TierReward)
+    private tierRewardRepository: Repository<TierReward>,
+  ) {}
+
+  /** Determine the tier for a given total points value */
+  getTierForPoints(totalPoints: number): Tier {
+    let tier = Tier.BRONZE;
+    for (const t of TIER_ORDER) {
+      if (totalPoints >= TIER_THRESHOLDS[t]) {
+        tier = t;
+      }
+    }
+    return tier;
+  }
+
+  /** Return the next tier above the given one, or null if already at max */
+  getNextTier(current: Tier): Tier | null {
+    const idx = TIER_ORDER.indexOf(current);
+    return idx < TIER_ORDER.length - 1 ? TIER_ORDER[idx + 1] : null;
+  }
+
+  /** Points needed to reach the next tier from current total */
+  pointsToNextTier(totalPoints: number): number | null {
+    const currentTier = this.getTierForPoints(totalPoints);
+    const next = this.getNextTier(currentTier);
+    if (!next) return null;
+    return TIER_THRESHOLDS[next] - totalPoints;
+  }
+
+  async getRewardForTier(tier: Tier): Promise<TierReward | null> {
+    return this.tierRewardRepository.findOne({ where: { tier } });
+  }
+
+  async getAllRewards(): Promise<TierReward[]> {
+    return this.tierRewardRepository.find({ order: { tier: 'ASC' } });
+  }
+
+  async upsertReward(
+    tier: Tier,
+    data: Partial<Omit<TierReward, 'id' | 'version' | 'tier'>>,
+  ): Promise<TierReward> {
+    const existing = await this.tierRewardRepository.findOne({ where: { tier } });
+    if (existing) {
+      Object.assign(existing, data);
+      return this.tierRewardRepository.save(existing);
+    }
+    return this.tierRewardRepository.save(this.tierRewardRepository.create({ tier, ...data }));
+  }
+}

--- a/src/migrations/1748800000000-add-gamification-tiers.ts
+++ b/src/migrations/1748800000000-add-gamification-tiers.ts
@@ -1,0 +1,60 @@
+import { MigrationInterface, QueryRunner, Table, TableIndex } from 'typeorm';
+
+/**
+ * Adds tier/level gamification support:
+ *  - Creates `tier_rewards` table
+ *  - Adds `tier` enum column to `user_progress`
+ */
+export class AddGamificationTiers1748800000000 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // Create tier enum type
+    await queryRunner.query(`
+      DO $$ BEGIN
+        CREATE TYPE "tier_enum" AS ENUM (
+          'BRONZE', 'SILVER', 'GOLD', 'PLATINUM', 'DIAMOND'
+        );
+      EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+    `);
+
+    // Add tier column to user_progress
+    await queryRunner.query(`
+      ALTER TABLE "user_progress"
+        ADD COLUMN IF NOT EXISTS "tier" "tier_enum" NOT NULL DEFAULT 'BRONZE';
+    `);
+
+    await queryRunner.query(`
+      CREATE INDEX IF NOT EXISTS "IDX_user_progress_tier"
+        ON "user_progress" ("tier");
+    `);
+
+    // Create tier_rewards table
+    await queryRunner.createTable(
+      new Table({
+        name: 'tier_rewards',
+        columns: [
+          { name: 'id', type: 'uuid', isPrimary: true, generationStrategy: 'uuid', default: 'uuid_generate_v4()' },
+          { name: 'version', type: 'integer', default: 1 },
+          { name: 'tier', type: 'tier_enum', isUnique: true },
+          { name: 'title', type: 'varchar' },
+          { name: 'description', type: 'varchar' },
+          { name: 'badgeId', type: 'varchar', isNullable: true },
+          { name: 'bonusPoints', type: 'integer', default: 0 },
+          { name: 'metadata', type: 'jsonb', isNullable: true },
+        ],
+      }),
+      true,
+    );
+
+    await queryRunner.createIndex(
+      'tier_rewards',
+      new TableIndex({ name: 'IDX_tier_rewards_tier', columnNames: ['tier'] }),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropTable('tier_rewards', true);
+    await queryRunner.query(`DROP INDEX IF EXISTS "IDX_user_progress_tier";`);
+    await queryRunner.query(`ALTER TABLE "user_progress" DROP COLUMN IF EXISTS "tier";`);
+    await queryRunner.query(`DROP TYPE IF EXISTS "tier_enum";`);
+  }
+}


### PR DESCRIPTION
- Add Tier entity with minPoints, order, and rewards (jsonb)
- Add POINT_RULES allocation map and DEFAULT_TIERS constants
- Update UserProgress with tier relation
- Rewrite PointsService with tier resolution and level-up logic
- Update LeaderboardService with efficient COUNT-based rank query
- Add GamificationController with 6 endpoints
- Add GamificationModule and wire into AppModule
- Add unit tests for PointsService and LeaderboardService (14 tests)

closes #575 