### PR TITLE
[644] Add correlation ID propagation middleware

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -43,6 +43,7 @@ import { RecommendationsModule } from './recommendations/recommendations.module'
 import { GamificationModule } from './gamification/gamification.module';
 import { I18nModule as AppI18nModule } from './i18n/i18n.module';
 import { AchievementsModule } from './achievements/achievements.module';
+import { CorrelationIdModule } from './middleware/correlation-id';
 
 const featureFlags = loadFeatureFlags();
 
@@ -51,6 +52,7 @@ const featureFlags = loadFeatureFlags();
     ConfigModule.forRoot({ isGlobal: true }),
     TypeOrmModule.forRoot(getDatabaseConfig()),
     ScheduleModule.forRoot(),
+    CorrelationIdModule,
 
     SessionModule,
     SearchModule,

--- a/src/common/utils/correlation.utils.spec.ts
+++ b/src/common/utils/correlation.utils.spec.ts
@@ -1,0 +1,130 @@
+import {
+  correlationMiddleware,
+  CORRELATION_ID_HEADER,
+  extractCorrelationIdFromRequest,
+  generateCorrelationId,
+  getCorrelationId,
+  injectCorrelationIdToHeaders,
+  runWithCorrelationId,
+  X_CORRELATION_ID_HEADER,
+} from './correlation.utils';
+import { Request, Response } from 'express';
+
+function buildResponse(): {
+  res: Response;
+  headers: Record<string, string>;
+} {
+  const headers: Record<string, string> = {};
+  const res = {
+    setHeader: jest.fn((name: string, value: string) => {
+      headers[name.toLowerCase()] = value;
+    }),
+    getHeader: (name: string) => headers[name.toLowerCase()],
+  } as unknown as Response;
+
+  return { res, headers };
+}
+
+describe('correlation.utils', () => {
+  it('generates and propagates correlation ID through middleware', (done) => {
+    const req = { method: 'GET', url: '/test', headers: {} } as Request;
+    const { res } = buildResponse();
+
+    correlationMiddleware(req, res, () => {
+      const id = getCorrelationId();
+      expect(typeof id).toBe('string');
+      expect(res.getHeader(X_CORRELATION_ID_HEADER)).toBe(id);
+      expect(res.getHeader(CORRELATION_ID_HEADER)).toBe(id);
+      done();
+    });
+  });
+
+  it('respects incoming x-correlation-id header', (done) => {
+    const incomingId = 'client-correlation-id';
+    const req = {
+      method: 'GET',
+      url: '/test',
+      headers: { [X_CORRELATION_ID_HEADER]: incomingId },
+    } as unknown as Request;
+    const { res } = buildResponse();
+
+    correlationMiddleware(req, res, () => {
+      expect(getCorrelationId()).toBe(incomingId);
+      expect(res.getHeader(X_CORRELATION_ID_HEADER)).toBe(incomingId);
+      done();
+    });
+  });
+
+  it('respects incoming legacy x-request-id header', (done) => {
+    const incomingId = 'legacy-request-id';
+    const req = {
+      method: 'GET',
+      url: '/test',
+      headers: { [CORRELATION_ID_HEADER]: incomingId },
+    } as unknown as Request;
+    const { res } = buildResponse();
+
+    correlationMiddleware(req, res, () => {
+      expect(getCorrelationId()).toBe(incomingId);
+      expect(res.getHeader(CORRELATION_ID_HEADER)).toBe(incomingId);
+      done();
+    });
+  });
+
+  it('prefers x-correlation-id over x-request-id when both are present', () => {
+    const req = {
+      headers: {
+        [X_CORRELATION_ID_HEADER]: 'canonical-id',
+        [CORRELATION_ID_HEADER]: 'legacy-id',
+      },
+    } as unknown as Request;
+
+    expect(extractCorrelationIdFromRequest(req)).toBe('canonical-id');
+  });
+
+  it('injects correlation headers into outbound request headers', () => {
+    const custom = injectCorrelationIdToHeaders({ Authorization: 'Bearer token' }, 'cid-1');
+    expect(custom[X_CORRELATION_ID_HEADER]).toBe('cid-1');
+    expect(custom[CORRELATION_ID_HEADER]).toBe('cid-1');
+    expect(custom.Authorization).toBe('Bearer token');
+  });
+
+  it('uses AsyncLocalStorage context for injectCorrelationIdToHeaders', () => {
+    let injected: Record<string, unknown> = {};
+    runWithCorrelationId(() => {
+      injected = injectCorrelationIdToHeaders();
+    }, 'als-id');
+
+    expect(injected[X_CORRELATION_ID_HEADER]).toBe('als-id');
+    expect(injected[CORRELATION_ID_HEADER]).toBe('als-id');
+  });
+
+  it('does not leak correlation ID outside request scope', async () => {
+    const req = { method: 'GET', url: '/test', headers: {} } as Request;
+    const { res } = buildResponse();
+
+    await new Promise<void>((resolve) => {
+      correlationMiddleware(req, res, () => resolve());
+    });
+
+    expect(getCorrelationId()).toBeUndefined();
+  });
+
+  it('generates correlation IDs with the expected prefix', () => {
+    expect(generateCorrelationId()).toMatch(/^cid-/);
+  });
+
+  it('processes 10k middleware invocations within performance budget', () => {
+    const iterations = 10_000;
+    const start = performance.now();
+
+    for (let index = 0; index < iterations; index += 1) {
+      const req = { method: 'GET', url: '/perf', headers: {} } as Request;
+      const { res } = buildResponse();
+      correlationMiddleware(req, res, () => undefined);
+    }
+
+    const elapsedMs = performance.now() - start;
+    expect(elapsedMs).toBeLessThan(2000);
+  });
+});

--- a/src/common/utils/correlation.utils.ts
+++ b/src/common/utils/correlation.utils.ts
@@ -1,5 +1,10 @@
 import { AsyncLocalStorage } from 'async_hooks';
 import { Request, Response, NextFunction } from 'express';
+
+/** Canonical correlation header used across services. */
+export const X_CORRELATION_ID_HEADER = 'x-correlation-id';
+
+/** Legacy alias kept for backward compatibility with existing clients. */
 export const CORRELATION_ID_HEADER = 'x-request-id';
 
 export interface ICorrelationContext {
@@ -26,17 +31,31 @@ export function getCorrelationId(): string | undefined {
 }
 
 /**
- * Sets correlation Id.
+ * Extracts an inbound correlation ID from request headers.
+ * Accepts both canonical and legacy header names.
+ */
+export function extractCorrelationIdFromRequest(req: Request): string | undefined {
+  const canonical = req.headers[X_CORRELATION_ID_HEADER] as string | undefined;
+  const legacy = req.headers[CORRELATION_ID_HEADER] as string | undefined;
+  const incoming = (canonical || legacy)?.trim();
+  return incoming && incoming.length > 0 ? incoming : undefined;
+}
+
+/**
+ * Sets correlation Id on the request and response headers.
  * @param req The req.
  * @param res The res.
  * @param correlationId The correlation identifier.
  */
 export function setCorrelationId(req: Request, res: Response, correlationId: string): void {
-  (
-    req as Request & {
-      correlationId?: string;
-    }
-  ).correlationId = correlationId;
+  const extendedReq = req as Request & { correlationId?: string; requestId?: string };
+  extendedReq.correlationId = correlationId;
+  extendedReq.requestId = correlationId;
+
+  req.headers[X_CORRELATION_ID_HEADER] = correlationId;
+  req.headers[CORRELATION_ID_HEADER] = correlationId;
+
+  res.setHeader(X_CORRELATION_ID_HEADER, correlationId);
   res.setHeader(CORRELATION_ID_HEADER, correlationId);
 }
 
@@ -47,9 +66,7 @@ export function setCorrelationId(req: Request, res: Response, correlationId: str
  * @param next The next.
  */
 export function correlationMiddleware(req: Request, res: Response, next: NextFunction): void {
-  const incoming =
-    (req.headers[CORRELATION_ID_HEADER] as string) || (req.headers['x-correlation-id'] as string);
-  const correlationId = incoming || generateCorrelationId();
+  const correlationId = extractCorrelationIdFromRequest(req) || generateCorrelationId();
   correlationStorage.run({ correlationId }, () => {
     setCorrelationId(req, res, correlationId);
     next();
@@ -68,18 +85,19 @@ export function runWithCorrelationId<T>(callback: () => T, correlationId?: strin
 }
 
 /**
- * Executes inject Correlation Id To Headers.
+ * Injects the active correlation ID into outbound HTTP headers.
  * @param headers The headers.
  * @param correlationId The correlation identifier.
  * @returns The resulting record<string, any>.
  */
 export function injectCorrelationIdToHeaders(
-  headers: Record<string, any> = {},
+  headers: Record<string, unknown> = {},
   correlationId?: string,
-): Record<string, any> {
+): Record<string, unknown> {
   const id = correlationId || getCorrelationId() || generateCorrelationId();
   return {
     ...headers,
+    [X_CORRELATION_ID_HEADER]: id,
     [CORRELATION_ID_HEADER]: id,
   };
 }

--- a/src/gateway/interceptors/request-transform.interceptor.ts
+++ b/src/gateway/interceptors/request-transform.interceptor.ts
@@ -1,7 +1,11 @@
 import { CallHandler, ExecutionContext, Injectable, Logger, NestInterceptor } from '@nestjs/common';
 import type { Request } from 'express';
 import { Observable } from 'rxjs';
-import { v4 as uuidv4 } from 'uuid';
+import {
+  extractCorrelationIdFromRequest,
+  generateCorrelationId,
+  X_CORRELATION_ID_HEADER,
+} from '../../common/utils/correlation.utils';
 
 /**
  * Normalises inbound requests before they reach the gateway controller:
@@ -27,9 +31,8 @@ export class RequestTransformInterceptor implements NestInterceptor {
   intercept(context: ExecutionContext, next: CallHandler): Observable<unknown> {
     const req = context.switchToHttp().getRequest<Request>();
 
-    // Assign correlation id
-    if (!req.headers['x-correlation-id']) {
-      req.headers['x-correlation-id'] = uuidv4();
+    if (!extractCorrelationIdFromRequest(req)) {
+      req.headers[X_CORRELATION_ID_HEADER] = generateCorrelationId();
     }
 
     // Remove hop-by-hop headers
@@ -42,7 +45,9 @@ export class RequestTransformInterceptor implements NestInterceptor {
     // Tag the request as coming through the gateway
     req.headers['x-gateway-version'] = '1';
 
-    this.logger.debug(`[${req.headers['x-correlation-id']}] ${req.method} ${req.path}`);
+    this.logger.debug(
+      `[${req.headers[X_CORRELATION_ID_HEADER]}] ${req.method} ${req.path}`,
+    );
 
     return next.handle();
   }

--- a/src/gateway/services/gateway-routing.service.ts
+++ b/src/gateway/services/gateway-routing.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, Logger, NotFoundException } from '@nestjs/common';
 import { HttpService } from '@nestjs/axios';
 import { firstValueFrom } from 'rxjs';
+import { injectCorrelationIdToHeaders } from '../../common/utils/correlation.utils';
 import type { RouteConfig, ProxyResponse } from '../interfaces/gateway.interfaces';
 
 @Injectable()
@@ -66,7 +67,12 @@ export class GatewayRoutingService {
     this.logger.debug(`Proxying ${method} ${url}`);
 
     const response = await firstValueFrom(
-      this.http.request<T>({ method, url, headers, data: body }),
+      this.http.request<T>({
+        method,
+        url,
+        headers: injectCorrelationIdToHeaders(headers) as Record<string, string>,
+        data: body,
+      }),
     );
 
     return {

--- a/src/logging/request-id.middleware.ts
+++ b/src/logging/request-id.middleware.ts
@@ -1,25 +1,25 @@
 import { type Request, type Response, type NextFunction } from 'express';
+import { getCorrelationId } from '../common/utils/correlation.utils';
 
 function makeId(): string {
-  // simple fast random id
   return Math.random().toString(36).slice(2, 10);
 }
 
 export function requestIdMiddleware(req: Request, res: Response, next: NextFunction): void {
   const header = req.headers['x-request-id'] as string | undefined;
-  const requestId = header || `${Date.now().toString(36)}-${makeId()}`;
-  // attach to request for handlers
-  (req as any).requestId = requestId;
-  res.setHeader('x-request-id', requestId);
+  const requestId = getCorrelationId() || header || `${Date.now().toString(36)}-${makeId()}`;
+  (req as Request & { requestId?: string }).requestId = requestId;
 
   const started = Date.now();
   const remoteAddr = req.headers['x-forwarded-for'] || req.socket.remoteAddress;
+  const correlationId = getCorrelationId() || requestId;
 
   console.info({
     event: 'request_start',
     method: req.method,
     url: req.originalUrl || req.url,
     requestId,
+    correlationId,
     remoteAddr,
   });
 
@@ -32,6 +32,7 @@ export function requestIdMiddleware(req: Request, res: Response, next: NextFunct
       statusCode: res.statusCode,
       durationMs: duration,
       requestId,
+      correlationId,
     });
   });
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -10,7 +10,7 @@ import Redis from 'ioredis';
 
 import { AppModule } from './app.module';
 
-import { correlationMiddleware } from './common/utils/correlation.utils';
+import { CorrelationIdMiddleware } from './middleware/correlation-id';
 import { createSessionConfig } from './config/cache.config';
 import { SESSION_REDIS_CLIENT } from './session/session.constants';
 import helmet from 'helmet';
@@ -189,9 +189,9 @@ async function bootstrapWorker(): Promise<void> {
     expressApp.set('trust proxy', 1);
   }
 
-  // attach request id and basic HTTP access logs
+  const correlationIdMiddleware = new CorrelationIdMiddleware();
+  app.use(correlationIdMiddleware.use.bind(correlationIdMiddleware));
   app.use(requestIdMiddleware);
-  app.use(correlationMiddleware);
 
   const auditLogService = app.get(AuditLogService);
   app.use(createAuditLoggerMiddleware(auditLogService));

--- a/src/middleware/correlation-id/correlation-id-http.interceptor.spec.ts
+++ b/src/middleware/correlation-id/correlation-id-http.interceptor.spec.ts
@@ -1,0 +1,57 @@
+import { HttpService } from '@nestjs/axios';
+import { Test, TestingModule } from '@nestjs/testing';
+import { CorrelationIdHttpInterceptor } from './correlation-id-http.interceptor';
+import {
+  CORRELATION_ID_HEADER,
+  runWithCorrelationId,
+  X_CORRELATION_ID_HEADER,
+} from '../../common/utils/correlation.utils';
+
+describe('CorrelationIdHttpInterceptor', () => {
+  let interceptor: CorrelationIdHttpInterceptor;
+  let requestUse: jest.Mock;
+
+  beforeEach(async () => {
+    requestUse = jest.fn().mockReturnValue(0);
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        CorrelationIdHttpInterceptor,
+        {
+          provide: HttpService,
+          useValue: {
+            axiosRef: {
+              interceptors: {
+                request: {
+                  use: requestUse,
+                },
+              },
+            },
+          },
+        },
+      ],
+    }).compile();
+
+    interceptor = module.get(CorrelationIdHttpInterceptor);
+    interceptor.onModuleInit();
+  });
+
+  it('registers an axios request interceptor', () => {
+    expect(requestUse).toHaveBeenCalledTimes(1);
+  });
+
+  it('injects correlation headers into outbound axios config', () => {
+    const handler = requestUse.mock.calls[0][0] as (config: {
+      headers: Record<string, string>;
+    }) => { headers: Record<string, string> };
+
+    let updated: { headers: Record<string, string> } = { headers: {} };
+    runWithCorrelationId(() => {
+      updated = handler({ headers: { Authorization: 'Bearer token' } });
+    }, 'outbound-id');
+
+    expect(updated.headers[X_CORRELATION_ID_HEADER]).toBe('outbound-id');
+    expect(updated.headers[CORRELATION_ID_HEADER]).toBe('outbound-id');
+    expect(updated.headers.Authorization).toBe('Bearer token');
+  });
+});

--- a/src/middleware/correlation-id/correlation-id-http.interceptor.ts
+++ b/src/middleware/correlation-id/correlation-id-http.interceptor.ts
@@ -1,0 +1,21 @@
+import { HttpService } from '@nestjs/axios';
+import { Injectable, OnModuleInit } from '@nestjs/common';
+import { injectCorrelationIdToHeaders } from '../../common/utils/correlation.utils';
+
+/**
+ * Attaches the active correlation ID to every outbound axios request
+ * made through the injected HttpService instance.
+ */
+@Injectable()
+export class CorrelationIdHttpInterceptor implements OnModuleInit {
+  constructor(private readonly httpService: HttpService) {}
+
+  onModuleInit(): void {
+    this.httpService.axiosRef.interceptors.request.use((config) => {
+      config.headers = injectCorrelationIdToHeaders(
+        (config.headers ?? {}) as Record<string, unknown>,
+      ) as typeof config.headers;
+      return config;
+    });
+  }
+}

--- a/src/middleware/correlation-id/correlation-id.middleware.spec.ts
+++ b/src/middleware/correlation-id/correlation-id.middleware.spec.ts
@@ -1,0 +1,62 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { CorrelationIdMiddleware } from './correlation-id.middleware';
+import {
+  CORRELATION_ID_HEADER,
+  getCorrelationId,
+  X_CORRELATION_ID_HEADER,
+} from '../../common/utils/correlation.utils';
+import { Request, Response } from 'express';
+
+describe('CorrelationIdMiddleware', () => {
+  let middleware: CorrelationIdMiddleware;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [CorrelationIdMiddleware],
+    }).compile();
+
+    middleware = module.get(CorrelationIdMiddleware);
+  });
+
+  it('should be defined', () => {
+    expect(middleware).toBeDefined();
+  });
+
+  it('generates a correlation ID when inbound headers are absent', (done) => {
+    const headers: Record<string, string> = {};
+    const req = { method: 'GET', url: '/health', headers: {} } as Request;
+    const res = {
+      setHeader: (name: string, value: string) => {
+        headers[name.toLowerCase()] = value;
+      },
+    } as unknown as Response;
+
+    middleware.use(req, res, () => {
+      expect(getCorrelationId()).toBeDefined();
+      expect(headers[X_CORRELATION_ID_HEADER]).toBeDefined();
+      expect(headers[CORRELATION_ID_HEADER]).toBe(headers[X_CORRELATION_ID_HEADER]);
+      done();
+    });
+  });
+
+  it('preserves an inbound correlation ID', (done) => {
+    const incoming = 'existing-correlation-id';
+    const headers: Record<string, string> = {};
+    const req = {
+      method: 'POST',
+      url: '/courses',
+      headers: { [X_CORRELATION_ID_HEADER]: incoming },
+    } as unknown as Request;
+    const res = {
+      setHeader: (name: string, value: string) => {
+        headers[name.toLowerCase()] = value;
+      },
+    } as unknown as Response;
+
+    middleware.use(req, res, () => {
+      expect(getCorrelationId()).toBe(incoming);
+      expect(headers[X_CORRELATION_ID_HEADER]).toBe(incoming);
+      done();
+    });
+  });
+});

--- a/src/middleware/correlation-id/correlation-id.middleware.ts
+++ b/src/middleware/correlation-id/correlation-id.middleware.ts
@@ -1,0 +1,29 @@
+import { Injectable, Logger, NestMiddleware } from '@nestjs/common';
+import { NextFunction, Request, Response } from 'express';
+import {
+  correlationMiddleware,
+  getCorrelationId,
+} from '../../common/utils/correlation.utils';
+
+/**
+ * Propagates correlation IDs for every inbound HTTP request.
+ *
+ * - Reads `x-correlation-id` or legacy `x-request-id` from inbound headers
+ * - Generates a new ID when absent
+ * - Stores the ID in AsyncLocalStorage for downstream handlers
+ * - Echoes the ID on the response for client-side tracing
+ */
+@Injectable()
+export class CorrelationIdMiddleware implements NestMiddleware {
+  private readonly logger = new Logger(CorrelationIdMiddleware.name);
+
+  use(req: Request, res: Response, next: NextFunction): void {
+    correlationMiddleware(req, res, () => {
+      const correlationId = getCorrelationId();
+      if (correlationId) {
+        this.logger.debug(`[${correlationId}] ${req.method} ${req.originalUrl || req.url}`);
+      }
+      next();
+    });
+  }
+}

--- a/src/middleware/correlation-id/correlation-id.module.ts
+++ b/src/middleware/correlation-id/correlation-id.module.ts
@@ -1,0 +1,12 @@
+import { Global, Module } from '@nestjs/common';
+import { HttpModule } from '@nestjs/axios';
+import { CorrelationIdHttpInterceptor } from './correlation-id-http.interceptor';
+import { CorrelationIdMiddleware } from './correlation-id.middleware';
+
+@Global()
+@Module({
+  imports: [HttpModule],
+  providers: [CorrelationIdMiddleware, CorrelationIdHttpInterceptor],
+  exports: [CorrelationIdMiddleware, HttpModule],
+})
+export class CorrelationIdModule {}

--- a/src/middleware/correlation-id/index.ts
+++ b/src/middleware/correlation-id/index.ts
@@ -1,0 +1,3 @@
+export { CorrelationIdMiddleware } from './correlation-id.middleware';
+export { CorrelationIdHttpInterceptor } from './correlation-id-http.interceptor';
+export { CorrelationIdModule } from './correlation-id.module';


### PR DESCRIPTION
close #644 
## Summary
- Adds CorrelationIdMiddleware with AsyncLocalStorage-backed request scoping
- Propagates x-correlation-id and legacy x-request-id on inbound/outbound requests
- Integrates correlation IDs into access logs and gateway proxy calls
- Adds unit tests including outbound header injection and performance verification

Closes 644

## Test plan
- [x] npm run build
- [x] Correlation middleware and utility unit tests pass
- [x] Gateway correlation interceptor tests pass

Made with [Cursor](https://cursor.com)