### PR TITLE
feat(pagination): add cursor pagination utils and optimize query indexes

### DIFF
--- a/src/common/interfaces/pagination.interface.ts
+++ b/src/common/interfaces/pagination.interface.ts
@@ -1,0 +1,22 @@
+export interface PageInfo {
+  hasNextPage: boolean;
+  hasPreviousPage: boolean;
+  startCursor: string | null;
+  endCursor: string | null;
+}
+
+export interface CursorPaginatedResponse<T> {
+  data: T[];
+  pageInfo: PageInfo;
+  total?: number;
+}
+
+export interface OffsetPaginatedResponse<T> {
+  data: T[];
+  total: number;
+  page: number;
+  limit: number;
+  totalPages: number;
+  hasNextPage: boolean;
+  hasPreviousPage: boolean;
+}

--- a/src/common/utils/pagination.utils.ts
+++ b/src/common/utils/pagination.utils.ts
@@ -1,0 +1,71 @@
+import { APP_CONSTANTS } from '../constants/app.constants';
+import {
+  CursorPaginatedResponse,
+  OffsetPaginatedResponse,
+} from '../interfaces/pagination.interface';
+
+const { MAX_PAGE_SIZE } = APP_CONSTANTS;
+
+export function clampLimit(limit: number | undefined, max = MAX_PAGE_SIZE): number {
+  const value = limit ?? APP_CONSTANTS.DEFAULT_PAGE_SIZE;
+  return Math.min(Math.max(1, value), max);
+}
+
+export function encodeCursor(id: string, date: Date): string {
+  const payload = JSON.stringify({ id, date: date.toISOString() });
+  return Buffer.from(payload, 'utf8').toString('base64url');
+}
+
+export function decodeCursor(cursor: string): { id: string; date: Date } | null {
+  try {
+    const payload = Buffer.from(cursor, 'base64url').toString('utf8');
+    const parsed = JSON.parse(payload) as { id: string; date: string };
+    return { id: parsed.id, date: new Date(parsed.date) };
+  } catch {
+    return null;
+  }
+}
+
+export function buildCursorResponse<T extends { id: string; createdAt: Date }>(
+  items: T[],
+  requestedLimit: number,
+): CursorPaginatedResponse<T> {
+  const limit = clampLimit(requestedLimit);
+  const hasNextPage = items.length > limit;
+  const data = hasNextPage ? items.slice(0, limit) : items;
+
+  const startCursor = data.length > 0 ? encodeCursor(data[0].id, data[0].createdAt) : null;
+  const endCursor =
+    data.length > 0
+      ? encodeCursor(data[data.length - 1].id, data[data.length - 1].createdAt)
+      : null;
+
+  return {
+    data,
+    pageInfo: {
+      hasNextPage,
+      hasPreviousPage: false,
+      startCursor,
+      endCursor,
+    },
+  };
+}
+
+export function buildOffsetResponse<T>(
+  data: T[],
+  total: number,
+  page: number,
+  limit: number,
+): OffsetPaginatedResponse<T> {
+  const clampedLimit = clampLimit(limit);
+  const totalPages = Math.ceil(total / clampedLimit);
+  return {
+    data,
+    total,
+    page,
+    limit: clampedLimit,
+    totalPages,
+    hasNextPage: page < totalPages,
+    hasPreviousPage: page > 1,
+  };
+}

--- a/src/courses/entities/course.entity.ts
+++ b/src/courses/entities/course.entity.ts
@@ -31,6 +31,8 @@ export enum CourseStatus {
  * Represents the course entity.
  */
 @Entity()
+@Index(['status', 'createdAt'])
+@Index(['instructorId', 'createdAt'])
 export class Course {
   @PrimaryGeneratedColumn('uuid')
   id: string;
@@ -95,6 +97,7 @@ export class Course {
   submissionNote?: string;
 
   @CreateDateColumn()
+  @Index()
   createdAt: Date;
 
   @UpdateDateColumn()

--- a/src/courses/entities/enrollment.entity.ts
+++ b/src/courses/entities/enrollment.entity.ts
@@ -18,6 +18,8 @@ import { Course } from './course.entity';
 @Entity()
 @Index(['userId', 'status'])
 @Index(['courseId', 'status'])
+@Index(['userId', 'enrolledAt'])
+@Index(['courseId', 'enrolledAt'])
 export class Enrollment {
   @PrimaryGeneratedColumn('uuid')
   id: string;
@@ -47,6 +49,7 @@ export class Enrollment {
   status: string;
 
   @CreateDateColumn()
+  @Index()
   enrolledAt: Date;
 
   @UpdateDateColumn()


### PR DESCRIPTION
## Summary

Adds reusable cursor-based pagination utilities and database indexes to make paginated queries efficient at scale.

### What's changed

**New files**
- src/common/interfaces/pagination.interface.ts - CursorPaginatedResponse and OffsetPaginatedResponse TypeScript interfaces
- src/common/utils/pagination.utils.ts - encodeCursor, decodeCursor, uildCursorResponse, uildOffsetResponse, clampLimit helpers

**Database indexes**
- Course: composite indexes on [status, createdAt] and [instructorId, createdAt]; individual index on createdAt
- Enrollment: composite indexes on [userId, enrolledAt] and [courseId, enrolledAt]; individual index on enrolledAt

### Why
createdAt is the default sort column in PaginationQueryDto but had no index, causing full-table scans on every paginated listing. The composite indexes cover the most common filtered + sorted query patterns.

closes #524