### PR TITLE
perf: add N+1 query detector and document eager-loading strategies

### DIFF
--- a/src/database/n1-query-detector.service.spec.ts
+++ b/src/database/n1-query-detector.service.spec.ts
@@ -1,0 +1,112 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { N1QueryDetectorService } from './n1-query-detector.service';
+
+describe('N1QueryDetectorService', () => {
+  let service: N1QueryDetectorService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [N1QueryDetectorService],
+    }).compile();
+
+    service = module.get<N1QueryDetectorService>(N1QueryDetectorService);
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('detectPatterns', () => {
+    it('returns an empty array when no queries are provided', () => {
+      expect(service.detectPatterns([])).toEqual([]);
+    });
+
+    it('returns an empty array when all queries are structurally unique', () => {
+      const queries = [
+        `SELECT * FROM "users" WHERE "id" = $1`,
+        `SELECT * FROM "courses" WHERE "id" = $2`,
+        `SELECT * FROM "enrollments" WHERE "userId" = $3`,
+      ];
+
+      expect(service.detectPatterns(queries)).toEqual([]);
+    });
+
+    it('detects repeated structural queries as an N+1 pattern', () => {
+      const queries = [
+        `SELECT * FROM "users" WHERE "id" = $1`,
+        `SELECT * FROM "users" WHERE "id" = $2`,
+        `SELECT * FROM "users" WHERE "id" = $3`,
+      ];
+
+      const reports = service.detectPatterns(queries);
+
+      expect(reports).toHaveLength(1);
+      expect(reports[0]).toMatchObject({
+        severity: 'low',
+        recommendation: expect.stringContaining('JOIN'),
+      });
+    });
+
+    it('assigns medium severity when a query template repeats 4 to 10 times', () => {
+      const queries = Array.from(
+        { length: 5 },
+        (_v, i) => `SELECT * FROM "courses" WHERE "instructorId" = $${i + 1}`,
+      );
+
+      const reports = service.detectPatterns(queries);
+
+      expect(reports).toHaveLength(1);
+      expect(reports[0].severity).toBe('medium');
+    });
+
+    it('assigns high severity when a query template repeats more than 10 times', () => {
+      const queries = Array.from(
+        { length: 12 },
+        (_v, i) => `SELECT * FROM "courses" WHERE "instructorId" = $${i + 1}`,
+      );
+
+      const reports = service.detectPatterns(queries);
+
+      expect(reports).toHaveLength(1);
+      expect(reports[0].severity).toBe('high');
+    });
+
+    it('groups mixed query types and reports each N+1 pattern separately', () => {
+      const queries = [
+        `SELECT * FROM "users" WHERE "id" = $1`,
+        `SELECT * FROM "users" WHERE "id" = $2`,
+        `SELECT * FROM "courses" WHERE "id" = $3`,
+        `SELECT * FROM "courses" WHERE "id" = $4`,
+      ];
+
+      const reports = service.detectPatterns(queries);
+
+      expect(reports).toHaveLength(2);
+    });
+  });
+
+  describe('getRecommendedStrategies', () => {
+    it('returns a non-empty list of relation load strategies', () => {
+      const strategies = service.getRecommendedStrategies();
+
+      expect(strategies.length).toBeGreaterThan(0);
+    });
+
+    it('marks all recommended strategies as eager-loading', () => {
+      const strategies = service.getRecommendedStrategies();
+
+      for (const strategy of strategies) {
+        expect(strategy.useEagerLoading).toBe(true);
+      }
+    });
+
+    it('includes known problem relations for TeachLink', () => {
+      const relations = service.getRecommendedStrategies().map((s) => s.relation);
+
+      expect(relations).toContain('courses.instructor');
+      expect(relations).toContain('enrollments.course');
+    });
+  });
+});

--- a/src/database/n1-query-detector.service.ts
+++ b/src/database/n1-query-detector.service.ts
@@ -1,0 +1,85 @@
+import { Injectable, Logger } from '@nestjs/common';
+
+export interface N1QueryReport {
+  location: string;
+  description: string;
+  recommendation: string;
+  severity: 'low' | 'medium' | 'high';
+}
+
+export interface RelationLoadStrategy {
+  relation: string;
+  useEagerLoading: boolean;
+  joinType: 'leftJoin' | 'innerJoin';
+}
+
+/**
+ * Detects N+1 query patterns by analysing a batch of SQL strings captured
+ * during a single request lifecycle.
+ *
+ * Usage: enable TypeORM query logging, collect emitted SQL strings per
+ * request, then pass them to `detectPatterns` to surface repeated queries.
+ */
+@Injectable()
+export class N1QueryDetectorService {
+  private readonly logger = new Logger(N1QueryDetectorService.name);
+
+  /**
+   * Groups queries by their normalised template and flags any template
+   * executed more than once — the hallmark of an N+1 problem.
+   */
+  detectPatterns(queries: string[]): N1QueryReport[] {
+    const reports: N1QueryReport[] = [];
+    const queryMap = new Map<string, number>();
+
+    for (const query of queries) {
+      const template = this.normalise(query);
+      const count = (queryMap.get(template) ?? 0) + 1;
+      queryMap.set(template, count);
+    }
+
+    for (const [template, count] of queryMap.entries()) {
+      if (count < 2) {
+        continue;
+      }
+      reports.push({
+        location: template,
+        description: `Query executed ${count}x -- N+1 pattern likely.`,
+        recommendation: 'Replace with a single JOIN or TypeORM eager loading.',
+        severity: count > 10 ? 'high' : count > 3 ? 'medium' : 'low',
+      });
+    }
+
+    if (reports.length === 0) {
+      this.logger.debug('No N+1 patterns detected in the provided query set.');
+    }
+
+    return reports;
+  }
+
+  /**
+   * Returns recommended eager-load strategies for entity relations known to
+   * cause N+1 problems in TeachLink when accessed without explicit joins.
+   */
+  getRecommendedStrategies(): RelationLoadStrategy[] {
+    return [
+      { relation: 'courses.instructor', useEagerLoading: true, joinType: 'leftJoin' },
+      { relation: 'enrollments.course', useEagerLoading: true, joinType: 'leftJoin' },
+      { relation: 'payments.transaction', useEagerLoading: true, joinType: 'leftJoin' },
+      { relation: 'users.roles', useEagerLoading: true, joinType: 'leftJoin' },
+    ];
+  }
+
+  /**
+   * Replaces literals (positional params, quoted strings, bare numbers) with
+   * placeholders so structurally identical queries with different values are
+   * treated as the same template.
+   */
+  private normalise(sql: string): string {
+    return sql
+      .toLowerCase()
+      .replace(/\$\d+/g, '$?')
+      .replace(/'[^']*'/g, "'?'")
+      .replace(/\b\d+\b/g, '?');
+  }
+}


### PR DESCRIPTION
## Summary

Addresses the N+1 query problem by introducing a runtime query-pattern detector and documenting proven eager-loading strategies for the four entity relations most commonly responsible for excessive DB round-trips.

**Changes:**

### `src/database/n1-query-detector.service.ts` (new)
`N1QueryDetectorService` — injectable NestJS service that:
- **`detectPatterns(queries: string[])`** — normalises raw SQL strings (positional params, quoted literals, bare numbers → placeholders) and groups structurally identical queries. Any template executed ≥2 times is reported as an N+1 candidate with:
  - `location` — normalised query template
  - `description` — repeat count
  - `severity` — `'low'` (2–3×) | `'medium'` (4–10×) | `'high'` (11×+)
  - `recommendation` — suggests JOIN or TypeORM eager loading
- **`getRecommendedStrategies()`** — returns the four known problem relations in TeachLink:
  - `courses.instructor` — fetching instructor per course list item
  - `enrollments.course` — fetching course per enrollment record
  - `payments.transaction` — fetching transaction per payment
  - `users.roles` — fetching roles per user record

### `src/database/n1-query-detector.service.spec.ts` (new)
9 unit tests covering all branches:
- Empty input, unique queries (no reports)
- Low / medium / high severity thresholds
- Multiple distinct templates reported separately
- Strategy list completeness assertions

## How to integrate

1. Enable TypeORM query logging per-request (e.g. via `DataSource` event listeners or a custom logger interceptor).
2. Collect SQL strings emitted during a single HTTP request.
3. After the request completes, call `n1QueryDetectorService.detectPatterns(collectedSql)`.
4. Use `getRecommendedStrategies()` to guide which `relations` arrays to add to `Repository.find()` calls.

## Test Plan

- [ ] `pnpm test src/database/n1-query-detector` — all 9 tests pass
- [ ] No lint warnings (`pnpm run lint:ci`)
- [ ] Build passes (`pnpm run build`)

closes #513