### PR TITLE
fix(auth): add firstName/lastName validation to RegisterDto and socia…

### DIFF
--- a/src/auth/dto/register.dto.spec.ts
+++ b/src/auth/dto/register.dto.spec.ts
@@ -1,16 +1,78 @@
-import 'reflect-metadata';
 import { validate } from 'class-validator';
 import { plainToInstance } from 'class-transformer';
 import { RegisterDto } from './register.dto';
 
-describe('RegisterDto', () => {
-  it('should be defined', () => {
-    const dto = plainToInstance(RegisterDto, {});
-    expect(dto).toBeDefined();
+function buildValid(overrides: Partial<RegisterDto> = {}): RegisterDto {
+  return plainToInstance(RegisterDto, {
+    firstName: 'Jane',
+    lastName: 'Doe',
+    username: 'janedoe42',
+    email: 'jane@example.com',
+    password: 'Secure@123',
+    ...overrides,
+  });
+}
+
+async function errorsFor(overrides: Partial<RegisterDto>) {
+  const errors = await validate(buildValid(overrides));
+  return errors.flatMap((e) => Object.values(e.constraints ?? {}));
+}
+
+describe('RegisterDto – firstName / lastName validation', () => {
+  it('passes with valid names', async () => {
+    const errors = await validate(buildValid());
+    expect(errors).toHaveLength(0);
   });
 
-  it('rejects an empty registration', async () => {
-    const errors = await validate(plainToInstance(RegisterDto, {}));
-    expect(errors.length).toBeGreaterThan(0);
+  // firstName
+  it('rejects empty firstName', async () => {
+    const messages = await errorsFor({ firstName: '' });
+    expect(messages.some((m) => /first name is required/i.test(m))).toBe(true);
+  });
+
+  it('rejects whitespace-only firstName', async () => {
+    const messages = await errorsFor({ firstName: '   ' });
+    expect(messages.some((m) => /first name is required/i.test(m))).toBe(true);
+  });
+
+  it('rejects firstName exceeding 50 characters', async () => {
+    const messages = await errorsFor({ firstName: 'A'.repeat(51) });
+    expect(messages.some((m) => /first name cannot exceed/i.test(m))).toBe(true);
+  });
+
+  it('accepts firstName exactly 50 characters', async () => {
+    const messages = await errorsFor({ firstName: 'A'.repeat(50) });
+    expect(messages.some((m) => /first name/i.test(m))).toBe(false);
+  });
+
+  it('trims leading/trailing whitespace from firstName', () => {
+    const dto = buildValid({ firstName: '  Jane  ' });
+    expect(dto.firstName).toBe('Jane');
+  });
+
+  // lastName
+  it('rejects empty lastName', async () => {
+    const messages = await errorsFor({ lastName: '' });
+    expect(messages.some((m) => /last name is required/i.test(m))).toBe(true);
+  });
+
+  it('rejects whitespace-only lastName', async () => {
+    const messages = await errorsFor({ lastName: '   ' });
+    expect(messages.some((m) => /last name is required/i.test(m))).toBe(true);
+  });
+
+  it('rejects lastName exceeding 50 characters', async () => {
+    const messages = await errorsFor({ lastName: 'B'.repeat(51) });
+    expect(messages.some((m) => /last name cannot exceed/i.test(m))).toBe(true);
+  });
+
+  it('accepts lastName exactly 50 characters', async () => {
+    const messages = await errorsFor({ lastName: 'B'.repeat(50) });
+    expect(messages.some((m) => /last name/i.test(m))).toBe(false);
+  });
+
+  it('trims leading/trailing whitespace from lastName', () => {
+    const dto = buildValid({ lastName: '  Doe  ' });
+    expect(dto.lastName).toBe('Doe');
   });
 });

--- a/src/auth/dto/register.dto.ts
+++ b/src/auth/dto/register.dto.ts
@@ -18,6 +18,20 @@ import { Transform } from 'class-transformer';
  * digit, and special character) to meet the platform's security policy.
  */
 export class RegisterDto {
+  @ApiProperty({ example: 'Jane', description: 'First name (max 50 chars)' })
+  @IsString({ message: 'First name must be a string' })
+  @IsNotEmpty({ message: 'First name is required' })
+  @MaxLength(50, { message: 'First name cannot exceed 50 characters' })
+  @Transform(({ value }) => value?.trim())
+  firstName: string;
+
+  @ApiProperty({ example: 'Doe', description: 'Last name (max 50 chars)' })
+  @IsString({ message: 'Last name must be a string' })
+  @IsNotEmpty({ message: 'Last name is required' })
+  @MaxLength(50, { message: 'Last name cannot exceed 50 characters' })
+  @Transform(({ value }) => value?.trim())
+  lastName: string;
+
   /**
    * Unique username displayed across the platform.
    * Only letters, numbers, underscores, and hyphens are allowed.

--- a/src/auth/services/social-auth.service.spec.ts
+++ b/src/auth/services/social-auth.service.spec.ts
@@ -1,0 +1,136 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { ConflictException } from '@nestjs/common';
+import { SocialAuthService, SocialProfile } from './social-auth.service';
+import { User } from '../../users/entities/user.entity';
+
+function makeUser(overrides: Partial<User> = {}): User {
+  return {
+    id: 'user-1',
+    email: 'existing@example.com',
+    firstName: 'Old',
+    lastName: 'Name',
+    provider: 'google',
+    providerId: 'google-123',
+    providerAccessToken: null,
+    providerRefreshToken: null,
+    profilePicture: null,
+    isEmailVerified: true,
+    ...overrides,
+  } as User;
+}
+
+function makeProfile(overrides: Partial<SocialProfile> = {}): SocialProfile {
+  return {
+    provider: 'google',
+    providerId: 'google-999',
+    email: 'new@example.com',
+    firstName: 'Jane',
+    lastName: 'Doe',
+    ...overrides,
+  };
+}
+
+const mockRepo = {
+  findOne: jest.fn(),
+  create: jest.fn(),
+  save: jest.fn(),
+  findOneOrFail: jest.fn(),
+};
+
+describe('SocialAuthService – name fallback', () => {
+  let service: SocialAuthService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        SocialAuthService,
+        { provide: getRepositoryToken(User), useValue: mockRepo },
+      ],
+    }).compile();
+
+    service = module.get<SocialAuthService>(SocialAuthService);
+    jest.clearAllMocks();
+  });
+
+  describe('findOrCreateFromProvider – new user creation', () => {
+    beforeEach(() => {
+      // No existing user by provider or email
+      mockRepo.findOne.mockResolvedValue(null);
+      mockRepo.create.mockImplementation((data) => ({ ...data }));
+      mockRepo.save.mockImplementation((u) => Promise.resolve({ id: 'new-id', ...u }));
+    });
+
+    it('uses provider firstName/lastName when present', async () => {
+      await service.findOrCreateFromProvider(makeProfile({ firstName: 'Jane', lastName: 'Doe' }));
+
+      expect(mockRepo.create).toHaveBeenCalledWith(
+        expect.objectContaining({ firstName: 'Jane', lastName: 'Doe' }),
+      );
+    });
+
+    it('falls back to email local-part as firstName when provider omits names', async () => {
+      await service.findOrCreateFromProvider(
+        makeProfile({ firstName: undefined, lastName: undefined, email: 'jdoe@example.com' }),
+      );
+
+      expect(mockRepo.create).toHaveBeenCalledWith(
+        expect.objectContaining({ firstName: 'jdoe', lastName: '' }),
+      );
+    });
+
+    it('falls back to providerId as firstName when both name and email are absent', async () => {
+      await service.findOrCreateFromProvider(
+        makeProfile({ firstName: undefined, lastName: undefined, email: undefined }),
+      );
+
+      expect(mockRepo.create).toHaveBeenCalledWith(
+        expect.objectContaining({ firstName: 'google-999' }),
+      );
+    });
+
+    it('trims whitespace-only firstName and falls back', async () => {
+      await service.findOrCreateFromProvider(
+        makeProfile({ firstName: '   ', lastName: '   ', email: 'trimmed@example.com' }),
+      );
+
+      expect(mockRepo.create).toHaveBeenCalledWith(
+        expect.objectContaining({ firstName: 'trimmed', lastName: '' }),
+      );
+    });
+
+    it('does not produce empty-string firstName', async () => {
+      await service.findOrCreateFromProvider(
+        makeProfile({ firstName: '', lastName: '', email: 'user@example.com' }),
+      );
+
+      const created = mockRepo.create.mock.calls[0][0];
+      expect(created.firstName).not.toBe('');
+    });
+  });
+
+  describe('findOrCreateFromProvider – existing provider account', () => {
+    it('returns existing user without creating a new one', async () => {
+      const existing = makeUser();
+      mockRepo.findOne.mockResolvedValueOnce(existing);
+
+      const result = await service.findOrCreateFromProvider(makeProfile());
+
+      expect(result).toBe(existing);
+      expect(mockRepo.create).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('findOrCreateFromProvider – email conflict', () => {
+    it('throws ConflictException when email is registered under a different provider', async () => {
+      // No provider match
+      mockRepo.findOne.mockResolvedValueOnce(null);
+      // Email match with different provider
+      mockRepo.findOne.mockResolvedValueOnce(makeUser({ provider: 'github' }));
+
+      await expect(
+        service.findOrCreateFromProvider(makeProfile({ provider: 'google' })),
+      ).rejects.toThrow(ConflictException);
+    });
+  });
+});

--- a/src/auth/services/social-auth.service.spec.ts
+++ b/src/auth/services/social-auth.service.spec.ts
@@ -43,10 +43,7 @@ describe('SocialAuthService – name fallback', () => {
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [
-        SocialAuthService,
-        { provide: getRepositoryToken(User), useValue: mockRepo },
-      ],
+      providers: [SocialAuthService, { provide: getRepositoryToken(User), useValue: mockRepo }],
     }).compile();
 
     service = module.get<SocialAuthService>(SocialAuthService);

--- a/src/auth/services/social-auth.service.ts
+++ b/src/auth/services/social-auth.service.ts
@@ -46,10 +46,16 @@ export class SocialAuthService {
       }
     }
 
+    // Derive a username-like base from the email local part for fallback names.
+    const emailLocalPart = profile.email ? profile.email.split('@')[0] : profile.providerId;
+
+    const firstName = profile.firstName?.trim() || emailLocalPart;
+    const lastName = profile.lastName?.trim() || '';
+
     const user = this.users.create({
       email: profile.email,
-      firstName: profile.firstName ?? '',
-      lastName: profile.lastName ?? '',
+      firstName,
+      lastName,
       profilePicture: profile.picture,
       provider: profile.provider,
       providerId: profile.providerId,


### PR DESCRIPTION
…l auth fallback

- Add @IsString, @IsNotEmpty, @MaxLength(50), @Transform(trim) for firstName and lastName in RegisterDto (closes #874)
- Replace empty-string fallback in SocialAuthService with email local-part or providerId so non-nullable DB columns are never blank
- Add unit tests covering empty, whitespace-only, and over-limit names for both RegisterDto and SocialAuthService