### PR TITLE
fix(auth): reject token refresh and access validation for non-active users

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4851,6 +4851,24 @@
         }
       }
     },
+    "node_modules/@nestjs/schematics/node_modules/chokidar": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@nestjs/schematics/node_modules/jsonc-parser": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
@@ -4879,6 +4897,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/@nestjs/schematics/node_modules/readdirp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 14.18.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@nestjs/schematics/node_modules/rxjs": {

--- a/src/auth/auth.service.spec.ts
+++ b/src/auth/auth.service.spec.ts
@@ -134,6 +134,20 @@ describe('AuthService', () => {
       expect(mockUserRepo.update).toHaveBeenCalledWith('user-1', { refreshToken: null });
     });
 
+    it('throws UnauthorizedException when the user status is SUSPENDED', async () => {
+      mockJwtService.verify.mockReturnValue(validDecoded);
+      mockUserRepo.findOneBy.mockResolvedValue(makeUser({ status: UserStatus.SUSPENDED }));
+
+      await expect(service.refreshTokens('token')).rejects.toThrow(UnauthorizedException);
+    });
+
+    it('throws UnauthorizedException when the user status is INACTIVE', async () => {
+      mockJwtService.verify.mockReturnValue(validDecoded);
+      mockUserRepo.findOneBy.mockResolvedValue(makeUser({ status: UserStatus.INACTIVE }));
+
+      await expect(service.refreshTokens('token')).rejects.toThrow(UnauthorizedException);
+    });
+
     it('issues new tokens when the refresh token is valid and not blacklisted', async () => {
       mockJwtService.verify.mockReturnValue(validDecoded);
       mockUserRepo.findOneBy.mockResolvedValue(makeUser());

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -4,7 +4,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { v4 as uuidv4 } from 'uuid';
 import * as bcrypt from 'bcrypt';
-import { User } from '../users/entities/user.entity';
+import { User, UserStatus } from '../users/entities/user.entity';
 import { TokenBlacklistService } from './services/token-blacklist.service';
 
 @Injectable()
@@ -49,6 +49,10 @@ export class AuthService {
 
     if (!user || !user.refreshToken) {
       throw new UnauthorizedException('Access Denied');
+    }
+
+    if (user.status !== UserStatus.ACTIVE) {
+      throw new UnauthorizedException('User is not active');
     }
 
     const refreshTokenMatches = await bcrypt.compare(refreshToken, user.refreshToken);

--- a/src/auth/jwt.strategy.spec.ts
+++ b/src/auth/jwt.strategy.spec.ts
@@ -14,10 +14,7 @@ describe('JwtStrategy', () => {
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [
-        JwtStrategy,
-        { provide: getRepositoryToken(User), useValue: mockUserRepo },
-      ],
+      providers: [JwtStrategy, { provide: getRepositoryToken(User), useValue: mockUserRepo }],
     }).compile();
 
     strategy = module.get<JwtStrategy>(JwtStrategy);
@@ -48,9 +45,7 @@ describe('JwtStrategy', () => {
       roles: [
         {
           name: 'student',
-          permissions: [
-            { resource: 'course', action: 'read' },
-          ],
+          permissions: [{ resource: 'course', action: 'read' }],
         },
       ],
     };

--- a/src/auth/jwt.strategy.spec.ts
+++ b/src/auth/jwt.strategy.spec.ts
@@ -1,0 +1,103 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { UnauthorizedException } from '@nestjs/common';
+import { JwtStrategy, JwtPayload } from './jwt.strategy';
+import { User, UserStatus } from '../users/entities/user.entity';
+
+describe('JwtStrategy', () => {
+  let strategy: JwtStrategy;
+
+  const mockUserRepo = {
+    findOneBy: jest.fn(),
+    createQueryBuilder: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        JwtStrategy,
+        { provide: getRepositoryToken(User), useValue: mockUserRepo },
+      ],
+    }).compile();
+
+    strategy = module.get<JwtStrategy>(JwtStrategy);
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  it('should be defined', () => {
+    expect(strategy).toBeDefined();
+  });
+
+  describe('validate', () => {
+    const payload: JwtPayload = {
+      sub: 'user-1',
+      email: 'test@example.com',
+      roles: [],
+      permissions: [],
+    };
+
+    const mockUser = {
+      id: 'user-1',
+      email: 'test@example.com',
+      status: UserStatus.ACTIVE,
+    };
+
+    const mockUserWithRolesAndPermissions = {
+      ...mockUser,
+      roles: [
+        {
+          name: 'student',
+          permissions: [
+            { resource: 'course', action: 'read' },
+          ],
+        },
+      ],
+    };
+
+    it('should successfully validate and return payload with roles and permissions if user is active', async () => {
+      mockUserRepo.findOneBy.mockResolvedValue(mockUser);
+
+      const mockQueryBuilder = {
+        leftJoinAndSelect: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        getOne: jest.fn().mockResolvedValue(mockUserWithRolesAndPermissions),
+      };
+      mockUserRepo.createQueryBuilder.mockReturnValue(mockQueryBuilder);
+
+      const result = await strategy.validate(payload);
+
+      expect(mockUserRepo.findOneBy).toHaveBeenCalledWith({ id: 'user-1' });
+      expect(result).toEqual({
+        sub: 'user-1',
+        email: 'test@example.com',
+        roles: ['student'],
+        permissions: ['course:read'],
+      });
+    });
+
+    it('should throw UnauthorizedException if the user is suspended', async () => {
+      mockUserRepo.findOneBy.mockResolvedValue({
+        ...mockUser,
+        status: UserStatus.SUSPENDED,
+      });
+
+      await expect(strategy.validate(payload)).rejects.toThrow(UnauthorizedException);
+    });
+
+    it('should throw UnauthorizedException if the user is inactive', async () => {
+      mockUserRepo.findOneBy.mockResolvedValue({
+        ...mockUser,
+        status: UserStatus.INACTIVE,
+      });
+
+      await expect(strategy.validate(payload)).rejects.toThrow(UnauthorizedException);
+    });
+
+    it('should throw an error if the user is not found', async () => {
+      mockUserRepo.findOneBy.mockResolvedValue(null);
+
+      await expect(strategy.validate(payload)).rejects.toThrow(Error);
+    });
+  });
+});

--- a/src/auth/jwt.strategy.ts
+++ b/src/auth/jwt.strategy.ts
@@ -1,9 +1,9 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, UnauthorizedException } from '@nestjs/common';
 import { PassportStrategy } from '@nestjs/passport';
 import { ExtractJwt, Strategy } from 'passport-jwt';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
-import { User } from '../users/entities/user.entity';
+import { User, UserStatus } from '../users/entities/user.entity';
 
 export interface JwtPayload {
   sub: string;
@@ -37,6 +37,10 @@ export class JwtStrategy extends PassportStrategy(Strategy, 'jwt') {
     const user = await this.userRepository.findOneBy({ id: payload.sub });
     if (!user) {
       throw new Error('User not found');
+    }
+
+    if (user.status !== UserStatus.ACTIVE) {
+      throw new UnauthorizedException('User is not active');
     }
 
     // Fetch roles and permissions for the user


### PR DESCRIPTION
Closes #802 

# Description

This PR resolves issue #802 by ensuring that user suspension (`UserStatus.SUSPENDED`) and inactivity (`UserStatus.INACTIVE`) statuses are validated during both token refresh and access token validation. Previously, inactive or suspended users could continuously refresh their tokens and remain authenticated indefinitely.

## Changes

### 1. [auth.service.ts](file:///c:/Users/USER/Desktop/teachLink_backend/src/auth/auth.service.ts)
- Imported `UserStatus`.
- Added a validation check in `refreshTokens()` to throw an `UnauthorizedException` if the user status is not `ACTIVE`.

### 2. [jwt.strategy.ts](file:///c:/Users/USER/Desktop/teachLink_backend/src/auth/jwt.strategy.ts)
- Imported `UserStatus` and `UnauthorizedException`.
- Added a check in `validate()` to throw an `UnauthorizedException` if the validating user status is not `ACTIVE`.

### 3. Unit Tests
- Updated [auth.service.spec.ts](file:///c:/Users/USER/Desktop/teachLink_backend/src/auth/auth.service.spec.ts) with test cases covering token refresh attempts from `SUSPENDED` and `INACTIVE` users.
- Created [jwt.strategy.spec.ts](file:///c:/Users/USER/Desktop/teachLink_backend/src/auth/jwt.strategy.spec.ts) to verify access token validation logic for active, inactive, suspended, and non-existent users.

## Verification

- **TypeScript Compilation:** Ran `npm run typecheck` successfully without errors.
- **Unit Tests:** Ran the unit tests sequential-in-band:
  ```bash
  npx jest --runInBand src/auth/auth.service.spec.ts src/auth/jwt.strategy.spec.ts