### PR TITLE
perf: add database indexes on users.emailVerificationToken and users.passwordResetToken

### DIFF
--- a/src/migrations/1783000000002-add-auth-token-indexes.ts
+++ b/src/migrations/1783000000002-add-auth-token-indexes.ts
@@ -1,0 +1,65 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Issue #832 — Add database indexes on `users.emailVerificationToken` and
+ * `users.passwordResetToken`.
+ *
+ * ## Context
+ *
+ * The auth-token consumption flows (`AuthTokensService.consumePasswordReset`
+ * and `AuthTokensService.consumeEmailVerification`) look up users by these
+ * columns:
+ *
+ * ```ts
+ * this.users.findOne({ where: { passwordResetToken: tokenHash } });
+ * this.users.findOne({ where: { emailVerificationToken: tokenHash } });
+ * ```
+ *
+ * Neither column had a database index, causing the query planner to perform
+ * a **sequential scan (full table scan)** on every token-validation request.
+ * This migration adds standard B-tree indexes so lookups execute in O(log n)
+ * time via an index scan.
+ *
+ * ## Design Notes
+ *
+ * - **B-tree** indexes are the PostgreSQL default and are optimal for equality
+ *   lookups (`WHERE col = $1`), which is exactly how these columns are queried.
+ * - **Partial indexes** (e.g. `WHERE col IS NOT NULL`) were considered but
+ *   rejected: the columns are NULL for the vast majority of rows (only active
+ *   token holders have non-NULL values), but TypeORM's auto-generated queries
+ *   would not match a partial-index predicate and the query planner might
+ *   fall back to a seq scan.
+ * - **These columns store SHA-256 hashes** of the raw tokens (see Issue #801
+ *   and {@link AuthTokensService.hashToken}). The tokens themselves are
+ *   high-entropy 256-bit random secrets that are hashed before storage.
+ *   The raw token is delivered to the user once via email and never persisted.
+ * - Indexing a hash column is safe because hash collisions on SHA-256 are
+ *   negligible; the index does not increase the attack surface.
+ *
+ * ## Verification
+ *
+ * After applying the migration, run:
+ * ```sql
+ * EXPLAIN ANALYZE
+ *   SELECT * FROM users
+ *    WHERE "emailVerificationToken" = '<some-hash>'
+ *      AND "emailVerificationExpires" > NOW();
+ * ```
+ *
+ * Expected output: `Index Scan using ... on users` (not `Seq Scan`).
+ */
+export class AddAuthTokenIndexes1783000000002 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE INDEX "IDX_users_emailVerificationToken" ON users ("emailVerificationToken")
+    `);
+    await queryRunner.query(`
+      CREATE INDEX "IDX_users_passwordResetToken" ON users ("passwordResetToken")
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query('DROP INDEX "IDX_users_emailVerificationToken"');
+    await queryRunner.query('DROP INDEX "IDX_users_passwordResetToken"');
+  }
+}

--- a/src/users/entities/user.entity.ts
+++ b/src/users/entities/user.entity.ts
@@ -91,12 +91,14 @@ export class User {
   isEmailVerified: boolean;
 
   @Column({ nullable: true })
+  @Index()
   emailVerificationToken?: string;
 
   @Column({ type: 'timestamp', nullable: true })
   emailVerificationExpires?: Date;
 
   @Column({ nullable: true })
+  @Index()
   passwordResetToken?: string;
 
   @Column({ type: 'timestamp', nullable: true })


### PR DESCRIPTION
# PR Title

perf: add database indexes on users.emailVerificationToken and users.passwordResetToken

Closes #832

---

## Summary

Every password-reset and email-verification request triggers a `findOne` query against `users.emailVerificationToken` or `users.passwordResetToken`. Neither column had a database index, so PostgreSQL performed a **sequential scan (full table scan)** on the entire `users` table for every single token-validation request. As the user base grows, this becomes a linear degradation: 100k users = ~100k rows scanned on every password reset click.

This PR adds B-tree indexes on both columns so token lookups execute via an **index scan** in O(log n) time — regardless of table size.

---

## Problem

### Where it hurts

The hot paths are in `AuthTokensService` (`src/auth/services/auth-tokens.service.ts`):

```ts
// consumePasswordReset — called on every password-reset link click
const user = await this.users.findOne({
  where: {
    passwordResetToken: tokenHash,
    passwordResetExpires: MoreThan(new Date()),
  },
});

// consumeEmailVerification — called on every email-verification link click
const user = await this.users.findOne({
  where: {
    emailVerificationToken: tokenHash,
    emailVerificationExpires: MoreThan(new Date()),
  },
});
```

TypeORM translates these into:

```sql
SELECT * FROM users
 WHERE "passwordResetToken" = $1
   AND "passwordResetExpires" > NOW()
 LIMIT 1;
```

Without an index, PostgreSQL has no choice but to scan every row in `users` looking for a match.

### Impact at scale

| Users table size | Rows scanned per request | Latency impact |
|------------------|--------------------------|----------------|
| 10k              | ~10,000                  | Negligible |
| 100k             | ~100,000                 | Noticeable (~10-50ms) |
| 1M               | ~1,000,000               | Problematic (50-200ms+) |
| 10M              | ~10,000,000              | Unacceptable |

These tokens are used in user-facing flows (clicking a link in an email), so latency directly impacts UX. Additionally, these full scans consume shared buffer cache and CPU on the primary database, competing with other queries.

---

## Solution

### 1. Entity decorators — `src/users/entities/user.entity.ts`

Added `@Index()` decorator to both columns, following the existing entity convention (`@Column` first, then `@Index`):

```diff
  @Column({ nullable: true })
+ @Index()
  emailVerificationToken?: string;

  @Column({ nullable: true })
+ @Index()
  passwordResetToken?: string;
```

This keeps the TypeORM entity definition in sync with the physical schema — if `synchronize: true` is ever used in a dev environment, TypeORM will auto-create these indexes from the decorators.

### 2. Database migration — `src/migrations/1783000000002-add-auth-token-indexes.ts`

New migration following the project's raw-SQL convention (all existing migrations use `queryRunner.query()`):

```ts
// up()
CREATE INDEX "IDX_users_emailVerificationToken"
  ON users ("emailVerificationToken");

CREATE INDEX "IDX_users_passwordResetToken"
  ON users ("passwordResetToken");

// down()
DROP INDEX "IDX_users_emailVerificationToken";
DROP INDEX "IDX_users_passwordResetToken";
```

The migration is **fully reversible** — `.down()` drops both indexes cleanly.

---

## Design Decisions

### Why B-tree?

B-tree is the PostgreSQL default index type and is **optimal for equality lookups** (`WHERE col = 'value'`). Both token columns are queried exclusively with equality predicates — no range scans, no prefix matching, no full-text search. B-tree provides O(log n) lookup without the overhead of Hash or GiST indexes.

### Why not partial indexes?

A partial index like `CREATE INDEX ... WHERE "emailVerificationToken" IS NOT NULL` was considered. The vast majority of rows have NULL for these columns (only users with an active password-reset or email-verification flow have a non-NULL value).

**Rejected** because TypeORM's query builder generates a plain `WHERE "emailVerificationToken" = $1` without an explicit `IS NOT NULL` clause. PostgreSQL's query planner only matches a partial index when the query's WHERE clause logically implies the index's predicate. While `col = 'value'` *should* imply `col IS NOT NULL`, the planner can miss this optimisation in edge cases (e.g., with parameterised queries or when statistics are stale). A full index avoids this risk entirely and the storage overhead is negligible — these are hash strings (~64 bytes each) with very few non-NULL rows.

### Index naming convention

Index names follow the TypeORM default convention: `IDX_<table>_<column>`. This matches what TypeORM's `@Index()` decorator would auto-generate if the indexes were created via `synchronize`. The names are descriptive and consistent with other indexes on the `users` table.

### Relationship to Issue #801 (token hashing)

These columns store **SHA-256 hashes** of the raw tokens, not the tokens themselves. Per Issue #801 (`AuthTokensService.hashToken`), the raw token is a 256-bit cryptographic random secret that is hashed before storage and delivered to the user once via email. The index operates on the hash column, which is safe because:

- SHA-256 is deterministic (`hashToken('abc')` always produces the same output), so the index correctly accelerates equality lookups.
- Hash collision probability on SHA-256 is ~1 in 2^128, which is negligible — the index won't return false positives in practice.
- The index does not increase the attack surface: an attacker who compromises the database already has access to the hashes; without the index they could still scan the table.

---

## Files Changed

| File | Change | Lines |
|------|--------|-------|
| `src/users/entities/user.entity.ts` | Added `@Index()` decorator on `emailVerificationToken` and `passwordResetToken` | +2 |
| `src/migrations/1783000000002-add-auth-token-indexes.ts` | New migration: creates B-tree indexes on both columns | +66 (new file) |

---

## CI Results

All checks pass cleanly. The only warning is a pre-existing `@typescript-eslint/no-unused-vars` in `src/auth/auth.service.ts` (unrelated to this PR).

| Check | Command | Result |
|-------|---------|--------|
| Formatting | `pnpm run format:check` | ✅ All files use Prettier code style |
| TypeScript | `pnpm run typecheck` (`tsc --project tsconfig.build.json --noEmit`) | ✅ 0 errors |
| ESLint | `pnpm run lint:ci` | ✅ 0 errors, 1 pre-existing warning |
| Unit tests (auth-tokens) | `jest --testPathPattern='auth-tokens'` | ✅ 18/18 passed |
| Unit tests (user.entity) | `jest --testPathPattern='user.entity'` | ✅ 5/5 passed |

---

## Verification

### Before migration (current state)

```sql
-- Confirm no indexes exist on these columns
SELECT indexname, indexdef
  FROM pg_indexes
 WHERE tablename = 'users'
   AND indexdef LIKE '%emailVerificationToken%'
    OR indexdef LIKE '%passwordResetToken%';
-- Expected: 0 rows
```

### After migration

```sql
-- Verify indexes exist
SELECT indexname, indexdef
  FROM pg_indexes
 WHERE tablename = 'users'
   AND indexname IN (
     'IDX_users_emailVerificationToken',
     'IDX_users_passwordResetToken'
   );
-- Expected: 2 rows, both showing CREATE INDEX ... USING btree

-- Verify index scan (not seq scan) for token lookups
EXPLAIN ANALYZE
  SELECT * FROM users
   WHERE "emailVerificationToken" = '<any-64-char-hex-hash>'
     AND "emailVerificationExpires" > NOW();
-- Expected: Index Scan using "IDX_users_emailVerificationToken" on users
--           (cost=... rows=... width=...) (actual time=...)
```

If you see `Seq Scan on users`, the index is not being used — verify the migration applied and run `ANALYZE users` to refresh planner statistics.

---

## Migration Application Notes

- **Idempotency**: The schema-migration service tracks applied migrations and will not re-run this migration. If re-applied manually, `CREATE INDEX` will fail with a "relation already exists" error (safe failure — no data loss).
- **Zero-downtime**: `CREATE INDEX` in PostgreSQL acquires a `ShareLock` on the table, which allows concurrent reads but blocks concurrent writes. On a table with millions of rows, index creation can take seconds to minutes. For large production deployments, consider `CREATE INDEX CONCURRENTLY` instead — this requires running outside a transaction (not compatible with the migration framework) and should be done as a separate manual step.
- **Rollback safety**: The `.down()` method drops both indexes. If a rollback is needed after the migration has been applied, token lookups will revert to sequential scans. No data is lost.

---

## Related

- **Issue #801** — Plaintext → SHA-256 hashing of auth tokens (the columns this PR indexes)
- **Issue #799** — Re-encryption of OAuth provider tokens (preceding migration `1783000000001`)
- **`AuthTokensService`** — `src/auth/services/auth-tokens.service.ts` (the service whose queries benefit from these indexes)