### PR TITLE
feat(session): add configurable max concurrent sessions with LRU evic…

### DIFF
--- a/src/session/session.service.spec.ts
+++ b/src/session/session.service.spec.ts
@@ -12,7 +12,9 @@ const mockRedis = {
   multi: jest.fn(),
   zadd: jest.fn().mockResolvedValue(1),
   zrem: jest.fn().mockResolvedValue(1),
+  zcard: jest.fn().mockResolvedValue(0),
   zrange: jest.fn().mockResolvedValue([]),
+  zremrangebyrank: jest.fn().mockResolvedValue(1),
   scan: jest.fn(),
   status: 'ready',
   quit: jest.fn(),
@@ -34,6 +36,7 @@ const mockConfigService = {
       SESSION_LOCK_TTL_MS: '5000',
       SESSION_LOCK_MAX_RETRIES: '5',
       SESSION_LOCK_RETRY_DELAY_MS: '120',
+      MAX_SESSIONS_PER_USER: '2',
     };
     return values[key] ?? defaultVal ?? '';
   }),
@@ -89,6 +92,17 @@ describe('SessionService', () => {
       expect(payload.userId).toBe('user-456');
       expect(payload.metadata.plan).toBe('premium');
       expect(payload.version).toBe(1);
+    });
+
+    it('should evict the oldest session when the user exceeds the max session limit', async () => {
+      mockRedis.set.mockResolvedValue('OK');
+      mockRedis.zcard.mockResolvedValue(3);
+      mockRedis.zrange.mockResolvedValue(['oldest-session']);
+
+      await service.createSession('user-789', { role: 'teacher' });
+
+      expect(mockRedis.del).toHaveBeenCalledWith('auth:sess:oldest-session');
+      expect(mockRedis.zremrangebyrank).toHaveBeenCalledWith('user:sessions:user-789', 0, 0);
     });
   });
 

--- a/src/session/session.service.ts
+++ b/src/session/session.service.ts
@@ -25,6 +25,7 @@ export class SessionService implements OnModuleDestroy {
   private readonly lockTtlMs: number;
   private readonly lockRetries: number;
   private readonly lockRetryDelayMs: number;
+  private readonly maxSessionsPerUser: number;
 
   constructor(
     @Inject(SESSION_REDIS_CLIENT) private readonly redis: Redis,
@@ -46,6 +47,14 @@ export class SessionService implements OnModuleDestroy {
       this.configService.get<string>('SESSION_LOCK_RETRY_DELAY_MS') || '120',
       10,
     );
+    const configuredMaxSessionsPerUser = parseInt(
+      this.configService.get<string>('MAX_SESSIONS_PER_USER') || '5',
+      10,
+    );
+    this.maxSessionsPerUser =
+      Number.isFinite(configuredMaxSessionsPerUser) && configuredMaxSessionsPerUser > 0
+        ? configuredMaxSessionsPerUser
+        : 5;
 
     const jwtRefreshExpiresIn = this.configService.get<string>('JWT_REFRESH_EXPIRES_IN') || '7d';
     const jwtRefreshExpirySeconds = SessionService.parseDurationToSeconds(jwtRefreshExpiresIn);
@@ -119,7 +128,8 @@ export class SessionService implements OnModuleDestroy {
       'EX',
       this.sessionTtlSeconds,
     );
-    await this.addSessionToUserIndex(userId, sid);
+    await this.addSessionToUserIndex(userId, sid, now);
+    await this.trimUserSessions(userId);
     return sid;
   }
 
@@ -208,16 +218,16 @@ export class SessionService implements OnModuleDestroy {
     return deletedCount;
   }
 
-  async addSessionToUserIndex(userId: string, sid: string): Promise<void> {
-    await this.redis.zadd(`user:sessions:${userId}`, Date.now(), sid);
+  async addSessionToUserIndex(userId: string, sid: string, createdAt = Date.now()): Promise<void> {
+    await this.redis.zadd(this.userSessionIndexKey(userId), createdAt, sid);
   }
 
   async removeSessionFromUserIndex(userId: string, sid: string): Promise<void> {
-    await this.redis.zrem(`user:sessions:${userId}`, sid);
+    await this.redis.zrem(this.userSessionIndexKey(userId), sid);
   }
 
   async getUserSessionIds(userId: string): Promise<string[]> {
-    return this.redis.zrange(`user:sessions:${userId}`, 0, -1);
+    return this.redis.zrange(this.userSessionIndexKey(userId), 0, -1);
   }
 
   /**
@@ -318,6 +328,26 @@ export class SessionService implements OnModuleDestroy {
     return migrated;
   }
 
+  private async trimUserSessions(userId: string): Promise<void> {
+    const indexKey = this.userSessionIndexKey(userId);
+    const sessionCount = await this.redis.zcard(indexKey);
+    const overflow = sessionCount - this.maxSessionsPerUser;
+
+    if (overflow <= 0) {
+      return;
+    }
+
+    const evictedSessionIds = await this.redis.zrange(indexKey, 0, overflow - 1);
+    if (evictedSessionIds.length > 0) {
+      await this.redis.zremrangebyrank(indexKey, 0, overflow - 1);
+      await Promise.all(evictedSessionIds.map((sid) => this.deleteSessionRecord(sid)));
+    }
+  }
+
+  private async deleteSessionRecord(sid: string): Promise<void> {
+    await this.redis.del(this.sessionKey(sid));
+  }
+
   private async releaseLock(lockKey: string, lockToken: string): Promise<void> {
     const releaseScript = `
       if redis.call('GET', KEYS[1]) == ARGV[1] then
@@ -330,6 +360,10 @@ export class SessionService implements OnModuleDestroy {
 
   private sessionKey(sid: string): string {
     return `${this.sessionPrefix}${sid}`;
+  }
+
+  private userSessionIndexKey(userId: string): string {
+    return `user:sessions:${userId}`;
   }
 
   private async delay(ms: number): Promise<void> {


### PR DESCRIPTION
Summary

Closes #849 Adds a configurable limit on concurrent active sessions per user, with LRU eviction of the oldest session when the limit is exceeded. This prevents an attacker with a stolen credential from maintaining unlimited parallel sessions indefinitely.

## Changes

- **\`src/session/session.service.ts\`**
  - Sessions per user are now tracked in a Redis Sorted Set keyed by \`user:sessions:{userId}\`, scored by \`createdAt\`.
  - After \`createSession()\` saves a new session, the sorted set is trimmed to the configured maximum, and any evicted session's Redis key is deleted so it can no longer be used for authentication.
  - The max session count is read from \`ConfigService\` via \`MAX_SESSIONS_PER_USER\`, defaulting to \`5\` when not set — no code changes needed to adjust the limit.

- **\`src/session/session.service.spec.ts\`**
  - Added a unit test covering eviction: creating session N+1 for a user beyond the configured max evicts the oldest session.

## Acceptance Criteria

- [x] Creating session N+1 evicts the oldest session
- [x] Evicted session cannot be used for authentication
- [x] Max session count is configurable without code changes (\`MAX_SESSIONS_PER_USER\` via \`ConfigService\`, default 5)

## Testing

Ran the full spec file locally:

\`\`\`
npx jest src/session/session.service.spec.ts --runInBand
\`\`\`

24/24 tests passing, including the new eviction test. Also verified with \`--detectOpenHandles\` to rule out teardown/leak issues — no open handles reported.

## Notes

- Only \`session.service.ts\` and its spec were touched, per the issue's impacted files list.
- \`package-lock.json\` changes from local dependency drift were excluded from this PR since they're unrelated to this feature." --base main --head fix/849-max-concurrent-sessions