### PR TITLE
fix(users): mask PII in search endpoint response

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -39,6 +39,7 @@ import { AuthModule } from './auth/auth.module';
 import { CohortsModule } from './cohorts/cohorts.module';
 import { LoggingModule } from './logging/logging.module';
 import { FeatureFlagAuditModule } from './config/feature-flag-audit.module';
+import { UsersModule } from './users/users.module';
 
 const featureFlags = loadFeatureFlags();
 
@@ -76,6 +77,7 @@ const featureFlags = loadFeatureFlags();
     ...(featureFlags.ENABLE_AUTH ? [AuthModule] : []),
     CoursesModule,
     CohortsModule,
+    UsersModule,
     FeatureFlagAuditModule,
   ],
   controllers: [AppController],

--- a/src/users/dto/user-admin.dto.ts
+++ b/src/users/dto/user-admin.dto.ts
@@ -1,0 +1,19 @@
+import { Exclude, Expose } from 'class-transformer';
+import { ApiProperty } from '@nestjs/swagger';
+import { UserStatus } from '../entities/user.entity';
+import { UserPublicDto } from './user-public.dto';
+
+@Exclude()
+export class UserAdminDto extends UserPublicDto {
+  @Expose()
+  @ApiProperty({ example: 'jane.smith@example.com' })
+  email: string;
+
+  @Expose()
+  @ApiProperty({ enum: UserStatus })
+  status: UserStatus;
+
+  @Expose()
+  @ApiProperty({ example: true })
+  isEmailVerified: boolean;
+}

--- a/src/users/dto/user-public.dto.ts
+++ b/src/users/dto/user-public.dto.ts
@@ -1,0 +1,22 @@
+import { Exclude, Expose } from 'class-transformer';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { UserRole } from '../entities/user.entity';
+
+@Exclude()
+export class UserPublicDto {
+  @Expose()
+  @ApiProperty({ example: '550e8400-e29b-41d4-a716-446655440001' })
+  id: string;
+
+  @Expose()
+  @ApiPropertyOptional({ example: 'Jane Smith' })
+  displayName?: string;
+
+  @Expose()
+  @ApiPropertyOptional({ example: 'https://cdn.teachlink.com/avatars/jane.jpg' })
+  avatarUrl?: string;
+
+  @Expose()
+  @ApiProperty({ enum: UserRole })
+  role: UserRole;
+}

--- a/src/users/users.controller.spec.ts
+++ b/src/users/users.controller.spec.ts
@@ -1,0 +1,80 @@
+import { UserRole, UserStatus } from './entities/user.entity';
+import { UsersController } from './users.controller';
+import { UserSearchResult, UsersService } from './users.service';
+
+const makeUser = (overrides: Partial<UserSearchResult> = {}) =>
+  ({
+    id: 'user-1',
+    displayName: 'Jane Doe',
+    avatarUrl: 'https://cdn.example.com/avatar.png',
+    role: UserRole.STUDENT,
+    ...overrides,
+  }) as UserSearchResult;
+
+describe('UsersController', () => {
+  let controller: UsersController;
+  let usersService: Partial<UsersService>;
+
+  beforeEach(() => {
+    usersService = {
+      searchUsers: jest.fn(),
+    };
+    controller = new UsersController(usersService as UsersService);
+  });
+
+  it('returns public fields and omits email for non-admin users', async () => {
+    (usersService.searchUsers as jest.Mock).mockResolvedValue([makeUser()]);
+
+    const response = await controller.search(
+      { user: { role: UserRole.STUDENT } },
+      undefined,
+      undefined,
+      '1',
+      '20',
+    );
+
+    expect(Array.isArray(response)).toBe(true);
+    expect(response).toEqual([
+      {
+        id: 'user-1',
+        displayName: 'Jane Doe',
+        avatarUrl: 'https://cdn.example.com/avatar.png',
+        role: UserRole.STUDENT,
+      },
+    ]);
+    expect((response as any)[0].email).toBeUndefined();
+    expect((response as any)[0].refreshToken).toBeUndefined();
+    expect((response as any)[0].passwordHistory).toBeUndefined();
+  });
+
+  it('returns admin fields for admin users', async () => {
+    (usersService.searchUsers as jest.Mock).mockResolvedValue([
+      makeUser({
+        role: UserRole.ADMIN,
+        email: 'admin@example.com',
+        status: UserStatus.ACTIVE,
+        isEmailVerified: true,
+      }),
+    ]);
+
+    const response = await controller.search(
+      { user: { role: UserRole.ADMIN } },
+      undefined,
+      undefined,
+      '1',
+      '20',
+    );
+
+    expect(response).toEqual([
+      {
+        id: 'user-1',
+        displayName: 'Jane Doe',
+        avatarUrl: 'https://cdn.example.com/avatar.png',
+        role: UserRole.ADMIN,
+        email: 'admin@example.com',
+        status: UserStatus.ACTIVE,
+        isEmailVerified: true,
+      },
+    ]);
+  });
+});

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -1,0 +1,55 @@
+import { Controller, Get, Query, Request, UseGuards } from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiQuery, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { instanceToPlain, plainToInstance } from 'class-transformer';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { UserRole } from './entities/user.entity';
+import { UsersService } from './users.service';
+import { UserAdminDto } from './dto/user-admin.dto';
+import { UserPublicDto } from './dto/user-public.dto';
+
+@ApiTags('Users')
+@Controller('users')
+@UseGuards(JwtAuthGuard)
+@ApiBearerAuth()
+export class UsersController {
+  constructor(private readonly usersService: UsersService) {}
+
+  @Get()
+  @ApiOperation({ summary: 'Search users' })
+  @ApiQuery({ name: 'q', required: false, description: 'Search by name, username, or email' })
+  @ApiQuery({
+    name: 'role',
+    required: false,
+    description: 'Filter by user role',
+    enum: [
+      UserRole.STUDENT,
+      UserRole.TEACHER,
+      UserRole.INSTRUCTOR,
+      UserRole.MODERATOR,
+      UserRole.ADMIN,
+    ],
+  })
+  @ApiQuery({ name: 'page', required: false, description: 'Page number', example: 1 })
+  @ApiQuery({ name: 'limit', required: false, description: 'Items per page', example: 20 })
+  @ApiResponse({ status: 200, description: 'Search results for users' })
+  async search(
+    @Request() req: { user?: { role?: string } },
+    @Query('q') query?: string,
+    @Query('role') role?: string,
+    @Query('page') page = '1',
+    @Query('limit') limit = '20',
+  ): Promise<unknown> {
+    const pageNum = Number(page) > 0 ? Number(page) : 1;
+    const limitNum = Number(limit) > 0 ? Number(limit) : 20;
+    const searchRole = role ? role.toLowerCase() : undefined;
+
+    const results = await this.usersService.searchUsers(query, searchRole, pageNum, limitNum);
+    const isAdmin = req.user?.role === UserRole.ADMIN;
+
+    return instanceToPlain(
+      plainToInstance(isAdmin ? UserAdminDto : UserPublicDto, results, {
+        excludeExtraneousValues: true,
+      }),
+    );
+  }
+}

--- a/src/users/users.module.ts
+++ b/src/users/users.module.ts
@@ -2,14 +2,18 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { User } from './entities/user.entity';
 import { UserActivityController } from './controllers/user-activity.controller';
+import { UsersController } from './users.controller';
+import { UsersService } from './users.service';
 import { AuditLogModule } from '../audit-log/audit-log.module';
 
 /**
  * Users module to handle user-specific operations.
- * Currently focuses on providing user activity timeline and history.
+ * Currently focuses on user search, activity timeline, and history.
  */
 @Module({
   imports: [TypeOrmModule.forFeature([User]), AuditLogModule],
-  controllers: [UserActivityController],
+  controllers: [UserActivityController, UsersController],
+  providers: [UsersService],
+  exports: [UsersService],
 })
 export class UsersModule {}

--- a/src/users/users.service.spec.ts
+++ b/src/users/users.service.spec.ts
@@ -1,0 +1,81 @@
+import { User, UserRole, UserStatus } from './entities/user.entity';
+import { UsersService } from './users.service';
+
+const makeMockQueryBuilder = () => ({
+  leftJoinAndSelect: jest.fn().mockReturnThis(),
+  distinct: jest.fn().mockReturnThis(),
+  select: jest.fn().mockReturnThis(),
+  andWhere: jest.fn().mockReturnThis(),
+  orderBy: jest.fn().mockReturnThis(),
+  skip: jest.fn().mockReturnThis(),
+  take: jest.fn().mockReturnThis(),
+  getMany: jest.fn().mockResolvedValue([]),
+});
+
+describe('UsersService', () => {
+  let service: UsersService;
+  let mockUserRepo: any;
+  let mockQueryBuilder: ReturnType<typeof makeMockQueryBuilder>;
+
+  beforeEach(() => {
+    mockQueryBuilder = makeMockQueryBuilder();
+    mockUserRepo = {
+      createQueryBuilder: jest.fn().mockReturnValue(mockQueryBuilder),
+    };
+    service = new UsersService(mockUserRepo);
+  });
+
+  it('loads joined role fields and returns the user role', async () => {
+    const users = [
+      {
+        id: 'user-1',
+        firstName: 'Jane',
+        lastName: 'Doe',
+        username: 'jdoe',
+        profilePicture: 'https://cdn.example.com/avatar.png',
+        email: 'jane.doe@example.com',
+        status: UserStatus.ACTIVE,
+        isEmailVerified: true,
+        roles: [{ id: 'role-1', name: UserRole.ADMIN }],
+      } as User,
+    ];
+
+    mockQueryBuilder.getMany.mockResolvedValue(users);
+
+    const results = await service.searchUsers('jane', UserRole.ADMIN, 2, 10);
+
+    expect(mockUserRepo.createQueryBuilder).toHaveBeenCalledWith('user');
+    expect(mockQueryBuilder.leftJoinAndSelect).toHaveBeenCalledWith('user.roles', 'role');
+    expect(mockQueryBuilder.select).toHaveBeenCalledWith(
+      expect.arrayContaining(['role.id', 'role.name']),
+    );
+    expect(mockQueryBuilder.andWhere).toHaveBeenCalledWith('role.name = :role', {
+      role: UserRole.ADMIN,
+    });
+    expect(mockQueryBuilder.skip).toHaveBeenCalledWith(10);
+    expect(mockQueryBuilder.take).toHaveBeenCalledWith(10);
+
+    expect(results).toEqual([
+      {
+        id: 'user-1',
+        displayName: 'jdoe',
+        avatarUrl: 'https://cdn.example.com/avatar.png',
+        role: UserRole.ADMIN,
+        email: 'jane.doe@example.com',
+        status: UserStatus.ACTIVE,
+        isEmailVerified: true,
+      },
+    ]);
+  });
+
+  it('passes a well-formed search query string to andWhere when q is provided', async () => {
+    mockQueryBuilder.getMany.mockResolvedValue([]);
+
+    await service.searchUsers('jane', undefined, 1, 20);
+
+    expect(mockQueryBuilder.andWhere).toHaveBeenCalledWith(
+      '(user.email ILIKE :search OR user.firstName ILIKE :search OR user.lastName ILIKE :search OR user.username ILIKE :search)',
+      { search: '%jane%' },
+    );
+  });
+});

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -1,0 +1,78 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { User, UserRole } from './entities/user.entity';
+
+export interface UserSearchResult {
+  id: string;
+  displayName: string;
+  avatarUrl?: string;
+  role: UserRole;
+  email?: string;
+  status?: string;
+  isEmailVerified?: boolean;
+}
+
+@Injectable()
+export class UsersService {
+  constructor(@InjectRepository(User) private readonly userRepository: Repository<User>) {}
+
+  async searchUsers(
+    query?: string,
+    role?: string,
+    page = 1,
+    limit = 20,
+  ): Promise<UserSearchResult[]> {
+    const qb = this.userRepository
+      .createQueryBuilder('user')
+      .leftJoinAndSelect('user.roles', 'role')
+      .distinct(true)
+      .select([
+        'user.id',
+        'user.firstName',
+        'user.lastName',
+        'user.username',
+        'user.profilePicture',
+        'user.email',
+        'user.status',
+        'user.isEmailVerified',
+        'role.id',
+        'role.name',
+      ]);
+
+    if (query) {
+      const search = `%${query.trim()}%`;
+      qb.andWhere(
+        '(user.email ILIKE :search OR user.firstName ILIKE :search OR user.lastName ILIKE :search OR user.username ILIKE :search)',
+        { search },
+      );
+    }
+
+    if (role) {
+      qb.andWhere('role.name = :role', { role: role.toLowerCase() });
+    }
+
+    qb.orderBy('user.createdAt', 'DESC')
+      .skip((page - 1) * limit)
+      .take(limit);
+
+    const users = await qb.getMany();
+
+    return users.map((user) => {
+      const joinedRole =
+        user.roles && user.roles.length > 0 ? (user.roles[0].name as UserRole) : undefined;
+
+      return {
+        id: user.id,
+        displayName:
+          user.username?.trim() ||
+          `${user.firstName?.trim() ?? ''} ${user.lastName?.trim() ?? ''}`.trim(),
+        avatarUrl: user.profilePicture,
+        role: joinedRole ?? UserRole.STUDENT,
+        email: user.email,
+        status: user.status,
+        isEmailVerified: user.isEmailVerified,
+      };
+    });
+  }
+}


### PR DESCRIPTION
- Add UserPublicDto exposing only id, displayName, avatarUrl, role
- Add UserAdminDto (extends UserPublicDto) for admin-scoped results with email, status, isEmailVerified
- Add UsersController with GET /users search endpoint, role-gated DTO selection
- Add UsersService.searchUsers with query builder, fix role relation join and search predicate
- Register UsersModule in AppModule
- Add unit tests verifying email/refreshToken/passwordHistory absence for non-admin results and presence of admin fields for admin results

Closes #879