### PR TITLE
fix(payouts,caching,tracing,queues): close Blaqkenny issues #809 #812 #828 #829

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -206,6 +206,9 @@ importers:
       date-fns:
         specifier: ^4.4.0
         version: 4.4.0
+      decimal.js:
+        specifier: ^10.6.0
+        version: 10.6.0
       express:
         specifier: ^5.2.1
         version: 5.2.1
@@ -260,6 +263,9 @@ importers:
       opossum:
         specifier: ^9.0.0
         version: 9.0.0
+      otplib:
+        specifier: ^13.4.1
+        version: 13.4.1
       passport:
         specifier: ^0.7.0
         version: 0.7.0
@@ -281,6 +287,9 @@ importers:
       prom-client:
         specifier: ^15.1.3
         version: 15.1.3
+      qrcode:
+        specifier: ^1.5.4
+        version: 1.5.4
       reflect-metadata:
         specifier: ^0.2.2
         version: 0.2.2
@@ -387,6 +396,9 @@ importers:
       '@types/passport-jwt':
         specifier: ^4.0.1
         version: 4.0.1
+      '@types/qrcode':
+        specifier: ^1.5.6
+        version: 1.5.6
       '@types/sanitize-html':
         specifier: ^2.16.1
         version: 2.16.1
@@ -1761,6 +1773,10 @@ packages:
     resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
     engines: {node: ^14.21.3 || >=16}
 
+  '@noble/hashes@2.2.0':
+    resolution: {integrity: sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==}
+    engines: {node: '>= 20.19.0'}
+
   '@nodable/entities@2.1.1':
     resolution: {integrity: sha512-Pig3HxDIoMgjdEH8OCf/dkcTmLFjJRjWuq8jSnklu284/TKOPibSRERmOykiwmyXTtv61mP+44f3GMx0tLAyjg==}
 
@@ -2442,6 +2458,24 @@ packages:
     peerDependencies:
       '@opentelemetry/api': ^1.1.0
 
+  '@otplib/core@13.4.1':
+    resolution: {integrity: sha512-KIXgK1hNtWJEBMTastbe1bpmuais+3f+ATeO8TkMs2rNkfGO1FbQy8+/UWVEu3TR/iTJerU0idkPudaPmLP2BA==}
+
+  '@otplib/hotp@13.4.1':
+    resolution: {integrity: sha512-g9q04SwpG5ZtMnVkUcgcoAlwCH4YLROZN1qhyBwgkBzqYYVSYhpP6gSGaxGHwePLt1c+e6NqDlgIZN+e1/XPuA==}
+
+  '@otplib/plugin-base32-scure@13.4.1':
+    resolution: {integrity: sha512-Fs/r5qisC05SRhT6xWXaypB6PVC0vgWf6zztmi0J5RnQ09OJiPDWCJFH6cDm6ANsrdvB9di7X+Jb7L13BoEbUA==}
+
+  '@otplib/plugin-crypto-noble@13.4.1':
+    resolution: {integrity: sha512-PJfVW8/1hdS6CfxLheKPZSLTwDq4TijZbN4yRjxlv0ODdzmxpM+wGwWr1JXMdy0xJPxLziydQD5gdVqrR4/gAg==}
+
+  '@otplib/totp@13.4.1':
+    resolution: {integrity: sha512-QOkBVPrf6AM4qZaReZPSk9/I8ATVdZpIISJz115MqeVtcrbcr5llPZ0J7804tpnjnp1vCRkI5Qjd47HhgVteBQ==}
+
+  '@otplib/uri@13.4.1':
+    resolution: {integrity: sha512-xaIm7bvICMhoB2rZIR5luiaMdssWR5nY5nXnR1fdezUgZuEO58D6zrGzLp7pQuBmlpmL0HagnscDQFoskp9yiA==}
+
   '@paralleldrive/cuid2@2.3.1':
     resolution: {integrity: sha512-XO7cAxhnTZl0Yggq6jOgjiOHhbgcO4NqFqwSmQpjK3b6TEE6Uj/jfSk6wzYyemh3+I0sHirKSetjQwn5cZktFw==}
 
@@ -2514,6 +2548,9 @@ packages:
 
   '@scarf/scarf@1.4.0':
     resolution: {integrity: sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==}
+
+  '@scure/base@2.2.0':
+    resolution: {integrity: sha512-b8XEupJibegiXV+tDUseI8oLQc8ei3d/4Jkb2RpbHh3MfE054ov3uIz2dhFkB3FI8iwYkEh0gGCApkrYggkPNg==}
 
   '@segment/analytics-core@1.8.2':
     resolution: {integrity: sha512-5FDy6l8chpzUfJcNlIcyqYQq4+JTUynlVoCeCUuVz+l+6W0PXg+ljKp34R4yLVCcY5VVZohuW+HH0VLWdwYVAg==}
@@ -2772,6 +2809,9 @@ packages:
 
   '@types/pg@8.15.6':
     resolution: {integrity: sha512-NoaMtzhxOrubeL/7UZuNTrejB4MPAJ0RpxZqXQf2qXuVlTPuG6Y8p4u9dKRaue4yjmC7ZhzVO2/Yyyn25znrPQ==}
+
+  '@types/qrcode@1.5.6':
+    resolution: {integrity: sha512-te7NQcV2BOvdj2b1hCAHzAoMNuj65kNBMz0KBaxM6c3VGBOhU0dURQKOtH8CFNI/dsKkwlv32p26qYQTWoB5bw==}
 
   '@types/qs@6.15.1':
     resolution: {integrity: sha512-GZHUBZR9hckSUhrxmp1nG6NwdpM9fCunJwyThLW1X3AyHgd9IlHb6VANpQQqDr2o/qQp6McZ3y/IA2rVzKzSbw==}
@@ -3456,6 +3496,9 @@ packages:
     resolution: {integrity: sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==}
     engines: {node: '>= 12'}
 
+  cliui@6.0.0:
+    resolution: {integrity: sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==}
+
   cliui@8.0.1:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
     engines: {node: '>=12'}
@@ -3755,6 +3798,13 @@ packages:
       supports-color:
         optional: true
 
+  decamelize@1.2.0:
+    resolution: {integrity: sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==}
+    engines: {node: '>=0.10.0'}
+
+  decimal.js@10.6.0:
+    resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
+
   decompress-response@6.0.0:
     resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
     engines: {node: '>=10'}
@@ -3825,6 +3875,9 @@ packages:
   diff@4.0.4:
     resolution: {integrity: sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==}
     engines: {node: '>=0.3.1'}
+
+  dijkstrajs@1.0.3:
+    resolution: {integrity: sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA==}
 
   doctrine@3.0.0:
     resolution: {integrity: sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==}
@@ -5478,6 +5531,9 @@ packages:
     resolution: {integrity: sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==}
     engines: {node: '>=0.10.0'}
 
+  otplib@13.4.1:
+    resolution: {integrity: sha512-o5CxfDw6bh7hoDv0NUUIcc0RqzJ9ipfUrzeKheKJ+vs4rXZnDlA9n4a/7R1cDjpmLjKLix4BgNVRmoDkm5rLSQ==}
+
   p-limit@2.3.0:
     resolution: {integrity: sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==}
     engines: {node: '>=6'}
@@ -5682,6 +5738,10 @@ packages:
     resolution: {integrity: sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==}
     engines: {node: '>=4'}
 
+  pngjs@5.0.0:
+    resolution: {integrity: sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==}
+    engines: {node: '>=10.13.0'}
+
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
     engines: {node: '>= 0.4'}
@@ -5771,6 +5831,11 @@ packages:
   pure-rand@6.1.0:
     resolution: {integrity: sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==}
 
+  qrcode@1.5.4:
+    resolution: {integrity: sha512-1ca71Zgiu6ORjHqFBDpnSMTR2ReToX4l1Au1VFLyVeBTFavzQnv5JxMFr3ukHVKpSrSA2MCk0lNJSykjUfz7Zg==}
+    engines: {node: '>=10.13.0'}
+    hasBin: true
+
   qs@6.15.2:
     resolution: {integrity: sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==}
     engines: {node: '>=0.6'}
@@ -5853,6 +5918,9 @@ packages:
   require-in-the-middle@8.0.1:
     resolution: {integrity: sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ==}
     engines: {node: '>=9.3.0 || >=8.10.0 <9.0.0'}
+
+  require-main-filename@2.0.0:
+    resolution: {integrity: sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==}
 
   resolve-cwd@3.0.0:
     resolution: {integrity: sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==}
@@ -5967,6 +6035,9 @@ packages:
   serve-static@2.2.1:
     resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
     engines: {node: '>= 18'}
+
+  set-blocking@2.0.0:
+    resolution: {integrity: sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==}
 
   set-function-length@1.2.2:
     resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
@@ -6715,6 +6786,9 @@ packages:
   whatwg-url@5.0.0:
     resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
 
+  which-module@2.0.1:
+    resolution: {integrity: sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==}
+
   which-typed-array@1.1.22:
     resolution: {integrity: sha512-fvO4ExWMFsqyhG3AiPAObMuY1lxaqgYcxbc49CNdWDDECOJNgQyvsOWVwbZc+qf3rzRtxojBK+CMEv0Ld5CYpw==}
     engines: {node: '>= 0.4'}
@@ -6816,6 +6890,9 @@ packages:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
     engines: {node: '>=0.4'}
 
+  y18n@4.0.3:
+    resolution: {integrity: sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==}
+
   y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
     engines: {node: '>=10'}
@@ -6831,9 +6908,17 @@ packages:
     engines: {node: '>= 14.6'}
     hasBin: true
 
+  yargs-parser@18.1.3:
+    resolution: {integrity: sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==}
+    engines: {node: '>=6'}
+
   yargs-parser@21.1.1:
     resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
     engines: {node: '>=12'}
+
+  yargs@15.4.1:
+    resolution: {integrity: sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==}
+    engines: {node: '>=8'}
 
   yargs@17.7.2:
     resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
@@ -8518,6 +8603,8 @@ snapshots:
 
   '@noble/hashes@1.8.0': {}
 
+  '@noble/hashes@2.2.0': {}
+
   '@nodable/entities@2.1.1': {}
 
   '@nodelib/fs.scandir@2.1.5':
@@ -9520,6 +9607,33 @@ snapshots:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
 
+  '@otplib/core@13.4.1': {}
+
+  '@otplib/hotp@13.4.1':
+    dependencies:
+      '@otplib/core': 13.4.1
+      '@otplib/uri': 13.4.1
+
+  '@otplib/plugin-base32-scure@13.4.1':
+    dependencies:
+      '@otplib/core': 13.4.1
+      '@scure/base': 2.2.0
+
+  '@otplib/plugin-crypto-noble@13.4.1':
+    dependencies:
+      '@noble/hashes': 2.2.0
+      '@otplib/core': 13.4.1
+
+  '@otplib/totp@13.4.1':
+    dependencies:
+      '@otplib/core': 13.4.1
+      '@otplib/hotp': 13.4.1
+      '@otplib/uri': 13.4.1
+
+  '@otplib/uri@13.4.1':
+    dependencies:
+      '@otplib/core': 13.4.1
+
   '@paralleldrive/cuid2@2.3.1':
     dependencies:
       '@noble/hashes': 1.8.0
@@ -9578,6 +9692,8 @@ snapshots:
       '@redis/client': 1.6.1
 
   '@scarf/scarf@1.4.0': {}
+
+  '@scure/base@2.2.0': {}
 
   '@segment/analytics-core@1.8.2':
     dependencies:
@@ -9920,6 +10036,10 @@ snapshots:
       '@types/node': 20.19.42
       pg-protocol: 1.14.0
       pg-types: 2.2.0
+
+  '@types/qrcode@1.5.6':
+    dependencies:
+      '@types/node': 20.19.42
 
   '@types/qs@6.15.1': {}
 
@@ -10710,6 +10830,12 @@ snapshots:
 
   cli-width@4.1.0: {}
 
+  cliui@6.0.0:
+    dependencies:
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wrap-ansi: 6.2.0
+
   cliui@8.0.1:
     dependencies:
       string-width: 4.2.3
@@ -10987,6 +11113,10 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  decamelize@1.2.0: {}
+
+  decimal.js@10.6.0: {}
+
   decompress-response@6.0.0:
     dependencies:
       mimic-response: 3.1.0
@@ -11036,6 +11166,8 @@ snapshots:
   diff-sequences@29.6.3: {}
 
   diff@4.0.4: {}
+
+  dijkstrajs@1.0.3: {}
 
   doctrine@3.0.0:
     dependencies:
@@ -12941,6 +13073,15 @@ snapshots:
 
   os-tmpdir@1.0.2: {}
 
+  otplib@13.4.1:
+    dependencies:
+      '@otplib/core': 13.4.1
+      '@otplib/hotp': 13.4.1
+      '@otplib/plugin-base32-scure': 13.4.1
+      '@otplib/plugin-crypto-noble': 13.4.1
+      '@otplib/totp': 13.4.1
+      '@otplib/uri': 13.4.1
+
   p-limit@2.3.0:
     dependencies:
       p-try: 2.2.0
@@ -13125,6 +13266,8 @@ snapshots:
 
   pluralize@8.0.0: {}
 
+  pngjs@5.0.0: {}
+
   possible-typed-array-names@1.1.0: {}
 
   postcss@8.5.15:
@@ -13230,6 +13373,12 @@ snapshots:
 
   pure-rand@6.1.0: {}
 
+  qrcode@1.5.4:
+    dependencies:
+      dijkstrajs: 1.0.3
+      pngjs: 5.0.0
+      yargs: 15.4.1
+
   qs@6.15.2:
     dependencies:
       side-channel: 1.1.0
@@ -13319,6 +13468,8 @@ snapshots:
       module-details-from-path: 1.0.4
     transitivePeerDependencies:
       - supports-color
+
+  require-main-filename@2.0.0: {}
 
   resolve-cwd@3.0.0:
     dependencies:
@@ -13448,6 +13599,8 @@ snapshots:
       send: 1.2.1
     transitivePeerDependencies:
       - supports-color
+
+  set-blocking@2.0.0: {}
 
   set-function-length@1.2.2:
     dependencies:
@@ -14206,6 +14359,8 @@ snapshots:
       tr46: 0.0.3
       webidl-conversions: 3.0.1
 
+  which-module@2.0.1: {}
+
   which-typed-array@1.1.22:
     dependencies:
       available-typed-arrays: 1.0.7
@@ -14306,6 +14461,8 @@ snapshots:
 
   xtend@4.0.2: {}
 
+  y18n@4.0.3: {}
+
   y18n@5.0.8: {}
 
   yallist@3.1.1: {}
@@ -14314,7 +14471,26 @@ snapshots:
 
   yaml@2.9.0: {}
 
+  yargs-parser@18.1.3:
+    dependencies:
+      camelcase: 5.3.1
+      decamelize: 1.2.0
+
   yargs-parser@21.1.1: {}
+
+  yargs@15.4.1:
+    dependencies:
+      cliui: 6.0.0
+      decamelize: 1.2.0
+      find-up: 4.1.0
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      require-main-filename: 2.0.0
+      set-blocking: 2.0.0
+      string-width: 4.2.3
+      which-module: 2.0.1
+      y18n: 4.0.3
+      yargs-parser: 18.1.3
 
   yargs@17.7.2:
     dependencies:

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -11,6 +11,8 @@ import { ConfigModule } from '@nestjs/config';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { ScheduleModule } from '@nestjs/schedule';
 import { envValidationSchema } from './config/env.validation';
+import { StructuredLoggerService } from './observability/logging/structured-logger.service';
+import { TracingInterceptor } from './observability/tracing/tracing.interceptor';
 
 import { AppController } from './app.controller';
 import { SearchModule } from './search/search.module';
@@ -98,6 +100,14 @@ const featureFlags = loadFeatureFlags();
     CohortsModule,
     UsersModule,
     FeatureFlagAuditModule,
+    /**
+     * Issue #828/#812 follow-on: OrchestrationModule is @Global() and exports
+     * DistributedLockService. We do NOT keep the previously-proposed
+     * LocksModule: registering DistributedLockService twice would crash the
+     * container (NestJS forbids duplicate providers). CachingService
+     * (@Optional() DistributedLockService) and any future consumer resolve
+     * through this global module instead.
+     */
     OrchestrationModule,
   ],
   controllers: [AppController],
@@ -110,7 +120,12 @@ const featureFlags = loadFeatureFlags();
     // @Idempotent() decorator (in any module) is handled, regardless of
     // which module owns the controller.
     { provide: APP_INTERCEPTOR, useClass: IdempotencyInterceptor },
+    // Issue #828 — forwards active OpenTelemetry traceId/spanId into the
+    // structured logger so every request log entry is correlated with the
+    // trace span that produced it.
+    { provide: APP_INTERCEPTOR, useClass: TracingInterceptor },
     { provide: APP_FILTER, useClass: GlobalExceptionFilter },
+    StructuredLoggerService,
   ],
 })
 export class AppModule implements NestModule, OnApplicationBootstrap {

--- a/src/caching/caching.service.spec.ts
+++ b/src/caching/caching.service.spec.ts
@@ -1,13 +1,9 @@
 import { CachingService, deriveCacheType, buildCounterKeys } from './caching.service';
 import { MetricsCollectionService } from '../monitoring/metrics/metrics-collection.service';
+import { DistributedLockService } from '../orchestration/locks/distributed-lock.service';
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
-/**
- * Build a jest-mocked ioredis-like client with just the methods the
- * CachingService now uses (incr, mget, scan, del). We intentionally keep this
- * minimal so the surface area that the tests exercise matches production.
- */
 function createMockRedis() {
   const store = new Map<string, number>();
   const mget = jest.fn(async (...keys: string[]) =>
@@ -33,6 +29,22 @@ function createMockRedis() {
   return { store, incr, mget, scan, del };
 }
 
+const createLockServiceMock = () => {
+  const held = new Map<string, string>();
+  return {
+    acquireLock: jest.fn(async (key: string, _ttl: number) => {
+      if (held.has(key)) return null;
+      const token = `token-${Math.random().toString(36).slice(2)}`;
+      held.set(key, token);
+      return token;
+    }),
+    releaseLock: jest.fn(async (key: string, token: string) => {
+      if (held.get(key) === token) held.delete(key);
+    }),
+    held,
+  };
+};
+
 describe('CachingService', () => {
   let service: CachingService;
   let cacheManager: {
@@ -55,14 +67,6 @@ describe('CachingService', () => {
     (cacheManager as any).store = {
       keys: jest.fn().mockResolvedValue(['cache:test:1', 'cache:test:2']),
     };
-    redis = createMockRedis();
-
-    service = new CachingService(
-      cacheManager as never,
-      metrics as unknown as MetricsCollectionService,
-      undefined,
-      redis as never,
-    );
   });
 
   // ── deriveCacheType / buildCounterKeys ──────────────────────────────────────
@@ -93,9 +97,19 @@ describe('CachingService', () => {
     });
   });
 
-  // ── getOrSet ───────────────────────────────────────────────────────────────
+  // ── Single-process fallback (no upstream Redis injected) ──────────────────
 
-  describe('getOrSet', () => {
+  describe('without an injected DistributedLockService (single-process fallback)', () => {
+    beforeEach(() => {
+      redis = createMockRedis();
+      service = new CachingService(
+        cacheManager as never,
+        metrics as unknown as MetricsCollectionService,
+        undefined,
+        redis as never,
+      );
+    });
+
     it('returns cached value without calling factory on hit', async () => {
       cacheManager.get.mockResolvedValue({ id: '1' });
       const factory = jest.fn();
@@ -128,163 +142,248 @@ describe('CachingService', () => {
       expect(stats.hits).toBe(0);
       expect(stats.misses).toBe(1);
     });
-  });
 
-  // ── deleteByPattern ────────────────────────────────────────────────────────
+    describe('deleteByPattern', () => {
+      it('uses store.keys to delete matching keys when client scan is unavailable', async () => {
+        await service.deleteByPattern('cache:test:*');
+        expect((cacheManager as any).store.keys).toHaveBeenCalledWith('cache:test:*');
+        expect(cacheManager.del).toHaveBeenCalledWith('cache:test:1');
+        expect(cacheManager.del).toHaveBeenCalledWith('cache:test:2');
+      });
+    });
 
-  describe('deleteByPattern', () => {
-    it('uses store.keys to delete matching keys when client scan is unavailable', async () => {
-      await service.deleteByPattern('cache:test:*');
-      expect((cacheManager as any).store.keys).toHaveBeenCalledWith('cache:test:*');
-      expect(cacheManager.del).toHaveBeenCalledWith('cache:test:1');
-      expect(cacheManager.del).toHaveBeenCalledWith('cache:test:2');
+    describe('distributed hit rate metrics', () => {
+      it('publishes aggregated cluster-wide hit rate to Prometheus', async () => {
+        // Simulate three pods: each has independently INCRemented the shared
+        // Redis counter. The reported hit rate must reflect what Redis holds,
+        // NOT just what this service instance has seen locally.
+        redis.store.set('cache:hits:application', 7);
+        redis.store.set('cache:misses:application', 3);
+
+        await service.publishHitRateMetrics('application');
+
+        expect(metrics.updateCacheHitRate).toHaveBeenCalledWith('application', 70);
+
+        // The read path must use MGET against the CRedis keys, not local state.
+        expect(redis.mget).toHaveBeenCalledWith(
+          'cache:hits:application',
+          'cache:misses:application',
+        );
+      });
+
+      it('uses literal cache:hits:{type} / cache:misses:{type} keys', async () => {
+        cacheManager.get.mockResolvedValueOnce('cached').mockResolvedValueOnce(undefined);
+        await service.get('hit-key');
+        await service.get('miss-key');
+
+        expect(redis.incr).toHaveBeenCalledWith('cache:hits:default');
+        expect(redis.incr).toHaveBeenCalledWith('cache:misses:default');
+      });
+
+      it('aggregates hits/misses per cache type independently', async () => {
+        redis.store.set('cache:hits:test', 8);
+        redis.store.set('cache:misses:test', 2);
+        redis.store.set('cache:hits:course', 1);
+        redis.store.set('cache:misses:course', 4);
+
+        const testStats = await service.getStats('test');
+        expect(testStats.hits).toBe(8);
+        expect(testStats.misses).toBe(2);
+        expect(testStats.hitRate).toBe(80);
+
+        const courseStats = await service.getStats('course');
+        expect(courseStats.hits).toBe(1);
+        expect(courseStats.misses).toBe(4);
+        expect(courseStats.hitRate).toBe(20);
+      });
+
+      it('returns zero hit rate when no counters have been recorded', async () => {
+        const stats = await service.getStats('application');
+        expect(stats.hits).toBe(0);
+        expect(stats.misses).toBe(0);
+        expect(stats.hitRate).toBe(0);
+      });
+
+      it('returns aggregate stats across every type', async () => {
+        redis.store.set('cache:hits:test', 5);
+        redis.store.set('cache:misses:test', 5);
+        redis.store.set('cache:hits:course', 2);
+        redis.store.set('cache:misses:course', 8);
+
+        const aggregate = await service.getAggregateStats();
+        expect(aggregate.hits).toBe(7);
+        expect(aggregate.misses).toBe(13);
+        // 7 / 20 = 35
+        expect(aggregate.hitRate).toBeCloseTo(35, 1);
+      });
+    });
+
+    describe('resetStats', () => {
+      it('deletes cluster-wide counter keys for a single type', async () => {
+        redis.store.set('cache:hits:test', 10);
+        redis.store.set('cache:misses:test', 4);
+
+        await service.resetStats('test');
+
+        expect(redis.del).toHaveBeenCalledWith('cache:hits:test', 'cache:misses:test');
+
+        const stats = await service.getStats('test');
+        expect(stats.hits).toBe(0);
+        expect(stats.misses).toBe(0);
+      });
+
+      it('deletes all cluster-wide counter keys when called without an argument', async () => {
+        redis.store.set('cache:hits:test', 1);
+        redis.store.set('cache:misses:test', 2);
+        redis.store.set('cache:hits:course', 3);
+        redis.store.set('cache:misses:course', 4);
+
+        await service.resetStats();
+
+        expect(redis.scan).toHaveBeenCalled();
+        expect(redis.del).toHaveBeenCalled();
+
+        const aggregate = await service.getAggregateStats();
+        expect(aggregate.hits).toBe(0);
+        expect(aggregate.misses).toBe(0);
+      });
+    });
+
+    describe('fallback behaviour when Redis is unavailable', () => {
+      it('falls back to local counters and still reports stats', async () => {
+        const brokenMget = jest.fn().mockRejectedValue(new Error('ECONNREFUSED'));
+        const brokenIncr = jest.fn().mockRejectedValue(new Error('ECONNREFUSED'));
+
+        const localOnly = new CachingService(
+          cacheManager as never,
+          metrics as unknown as MetricsCollectionService,
+          {
+            get: (key: string, fallback?: any) =>
+              key === 'CACHE_COUNTER_FALLBACK_LOCAL' ? true : fallback,
+          } as any,
+          { incr: brokenIncr, mget: brokenMget, scan: jest.fn(), del: jest.fn() } as never,
+        );
+
+        cacheManager.get.mockResolvedValueOnce(undefined).mockResolvedValue({ id: 'x' });
+        await localOnly.get('miss-key');
+        await localOnly.get('hit-key');
+
+        const stats = await localOnly.getStats();
+        expect(stats.hits).toBe(1);
+        expect(stats.misses).toBe(1);
+        expect(stats.hitRate).toBe(50);
+      });
+
+      it('publishes zero hit rate when Redis is unavailable and fallback disabled', async () => {
+        const brokenMget = jest.fn().mockRejectedValue(new Error('ECONNREFUSED'));
+        const brokenIncr = jest.fn().mockRejectedValue(new Error('ECONNREFUSED'));
+
+        const noFallback = new CachingService(
+          cacheManager as never,
+          metrics as unknown as MetricsCollectionService,
+          {
+            get: (key: string, fallback?: any) =>
+              key === 'CACHE_COUNTER_FALLBACK_LOCAL' ? false : fallback,
+          } as any,
+          { incr: brokenIncr, mget: brokenMget, scan: jest.fn(), del: jest.fn() } as never,
+        );
+
+        await expect(noFallback.getStats('application')).rejects.toThrow('ECONNREFUSED');
+      });
     });
   });
 
-  // ── Cluster-wide hit rate (Issue #811) ─────────────────────────────────────
+  // ── Issue #812 thundering-herd protection ──────────────────────────────────
 
-  describe('distributed hit rate metrics', () => {
-    it('publishes aggregated cluster-wide hit rate to Prometheus', async () => {
-      // Simulate three pods: each has independently INCRemented the shared
-      // Redis counter. The reported hit rate must reflect what Redis holds,
-      // NOT just what this service instance has seen locally.
-      redis.store.set('cache:hits:application', 7);
-      redis.store.set('cache:misses:application', 3);
+  describe('with an injected DistributedLockService (thundering-herd protection)', () => {
+    let lockService: ReturnType<typeof createLockServiceMock>;
 
-      await service.publishHitRateMetrics('application');
-
-      expect(metrics.updateCacheHitRate).toHaveBeenCalledWith('application', 70);
-
-      // The read path must use MGET against the CRedis keys, not local state.
-      expect(redis.mget).toHaveBeenCalledWith('cache:hits:application', 'cache:misses:application');
-    });
-
-    it('uses literal cache:hits:{type} / cache:misses:{type} keys (issue #811)', async () => {
-      cacheManager.get.mockResolvedValueOnce('cached').mockResolvedValueOnce(undefined);
-      await service.get('hit-key');
-      await service.get('miss-key');
-
-      // Issue spec: keys must be exactly cache:hits:{type} and cache:misses:{type}
-      expect(redis.incr).toHaveBeenCalledWith('cache:hits:default');
-      expect(redis.incr).toHaveBeenCalledWith('cache:misses:default');
-    });
-
-    it('aggregates hits/misses per cache type independently', async () => {
-      redis.store.set('cache:hits:test', 8);
-      redis.store.set('cache:misses:test', 2);
-      redis.store.set('cache:hits:course', 1);
-      redis.store.set('cache:misses:course', 4);
-
-      const testStats = await service.getStats('test');
-      expect(testStats.hits).toBe(8);
-      expect(testStats.misses).toBe(2);
-      expect(testStats.hitRate).toBe(80);
-
-      const courseStats = await service.getStats('course');
-      expect(courseStats.hits).toBe(1);
-      expect(courseStats.misses).toBe(4);
-      expect(courseStats.hitRate).toBe(20);
-    });
-
-    it('returns zero hit rate when no counters have been recorded', async () => {
-      const stats = await service.getStats('application');
-      expect(stats.hits).toBe(0);
-      expect(stats.misses).toBe(0);
-      expect(stats.hitRate).toBe(0);
-    });
-
-    it('returns aggregate stats across every type', async () => {
-      redis.store.set('cache:hits:test', 5);
-      redis.store.set('cache:misses:test', 5);
-      redis.store.set('cache:hits:course', 2);
-      redis.store.set('cache:misses:course', 8);
-
-      const aggregate = await service.getAggregateStats();
-      expect(aggregate.hits).toBe(7);
-      expect(aggregate.misses).toBe(13);
-      // 7 / 20 = 35
-      expect(aggregate.hitRate).toBeCloseTo(35, 1);
-    });
-  });
-
-  // ── Counter reset mechanism ─────────────────────────────────────────────────
-
-  describe('resetStats', () => {
-    it('deletes cluster-wide counter keys for a single type', async () => {
-      redis.store.set('cache:hits:test', 10);
-      redis.store.set('cache:misses:test', 4);
-
-      await service.resetStats('test');
-
-      expect(redis.del).toHaveBeenCalledWith('cache:hits:test', 'cache:misses:test');
-
-      const stats = await service.getStats('test');
-      expect(stats.hits).toBe(0);
-      expect(stats.misses).toBe(0);
-    });
-
-    it('deletes all cluster-wide counter keys when called without an argument', async () => {
-      redis.store.set('cache:hits:test', 1);
-      redis.store.set('cache:misses:test', 2);
-      redis.store.set('cache:hits:course', 3);
-      redis.store.set('cache:misses:course', 4);
-
-      await service.resetStats();
-
-      expect(redis.scan).toHaveBeenCalled();
-      expect(redis.del).toHaveBeenCalled();
-
-      const aggregate = await service.getAggregateStats();
-      expect(aggregate.hits).toBe(0);
-      expect(aggregate.misses).toBe(0);
-    });
-  });
-
-  // ── Graceful degradation ───────────────────────────────────────────────────
-
-  describe('fallback behaviour when Redis is unavailable', () => {
-    it('falls back to local counters and still reports stats', async () => {
-      // Simulate a broken Redis by throwing on every read.
-      const brokenMget = jest.fn().mockRejectedValue(new Error('ECONNREFUSED'));
-      const brokenIncr = jest.fn().mockRejectedValue(new Error('ECONNREFUSED'));
-
-      // Direct construction: opt in to local fallback explicitly (default is
-      // already enabled in production but we make it explicit here).
-      const localOnly = new CachingService(
+    beforeEach(() => {
+      lockService = createLockServiceMock();
+      redis = createMockRedis();
+      service = new CachingService(
         cacheManager as never,
         metrics as unknown as MetricsCollectionService,
-        {
-          get: (key: string, fallback?: any) =>
-            key === 'CACHE_COUNTER_FALLBACK_LOCAL' ? true : fallback,
-        } as any,
-        { incr: brokenIncr, mget: brokenMget, scan: jest.fn(), del: jest.fn() } as never,
+        undefined,
+        redis as never,
+        lockService as unknown as DistributedLockService,
       );
+    });
 
-      cacheManager.get.mockResolvedValueOnce(undefined).mockResolvedValue({ id: 'x' });
-      await localOnly.get('miss-key');
-      await localOnly.get('hit-key');
+    it('acquires the lock, only one caller runs the factory, and the lock is released', async () => {
+      let firstRead = true;
+      cacheManager.get.mockImplementation(async () => {
+        if (firstRead) {
+          firstRead = false;
+          return undefined;
+        }
+        return { id: '42' };
+      });
+      const factory = jest.fn(async () => ({ id: '42' }));
 
-      const stats = await localOnly.getStats();
-      expect(stats.hits).toBe(1);
+      const result = await service.getOrSet('cache:hot:1', factory, 60);
+
+      expect(result).toEqual({ id: '42' });
+      expect(lockService.acquireLock).toHaveBeenCalledWith('cache:lock:cache:hot:1', 60_000);
+      expect(lockService.releaseLock).toHaveBeenCalledWith(
+        'cache:lock:cache:hot:1',
+        expect.any(String),
+      );
+      expect(factory).toHaveBeenCalledTimes(1);
+      expect(cacheManager.set).toHaveBeenCalledWith('cache:hot:1', { id: '42' }, 60_000);
+    });
+
+    it('contended caller waits for the lock-holder to populate the cache and never invokes the factory', async () => {
+      lockService.acquireLock.mockResolvedValueOnce(null);
+      // Initial polled re-reads miss, then the cache fills.
+      cacheManager.get
+        .mockResolvedValueOnce(undefined)
+        .mockResolvedValueOnce(undefined)
+        .mockResolvedValueOnce({ id: '100' });
+
+      const factory = jest.fn();
+
+      const result = await service.getOrSet('cache:hot:2', factory, 30);
+
+      expect(result).toEqual({ id: '100' });
+      expect(factory).not.toHaveBeenCalled();
+      // After the contended caller observes the value, the stats reflect one
+      // initial miss + one hit on the contended path.
+      const stats = await service.getStats('hot');
       expect(stats.misses).toBe(1);
-      expect(stats.hitRate).toBe(50);
-    });
+      expect(stats.hits).toBe(1);
+      // And the local factory must not have written into the cache either.
+      expect(cacheManager.set).not.toHaveBeenCalled();
+    }, 15_000);
 
-    it('publishes zero hit rate when Redis is unavailable and fallback disabled', async () => {
-      const brokenMget = jest.fn().mockRejectedValue(new Error('ECONNREFUSED'));
-      const brokenIncr = jest.fn().mockRejectedValue(new Error('ECONNREFUSED'));
+    it('falls back to local factory computation when the lock never resolves', async () => {
+      // Lock contention forever.
+      lockService.acquireLock.mockResolvedValue(null);
+      // CacheManager polls never produce a value within the lock TTL window.
+      cacheManager.get.mockResolvedValue(undefined);
 
-      const noFallback = new CachingService(
-        cacheManager as never,
-        metrics as unknown as MetricsCollectionService,
-        {
-          get: (key: string, fallback?: any) =>
-            key === 'CACHE_COUNTER_FALLBACK_LOCAL' ? false : fallback,
-        } as any,
-        { incr: brokenIncr, mget: brokenMget, scan: jest.fn(), del: jest.fn() } as never,
+      const factory = jest.fn().mockResolvedValue({ id: 'fallback' });
+
+      const result = await service.getOrSet('cache:hot:3', factory, 1);
+
+      expect(result).toEqual({ id: 'fallback' });
+      // Local write so subsequent requests avoid the fallback path.
+      expect(cacheManager.set).toHaveBeenCalledWith('cache:hot:3', { id: 'fallback' }, 1_000);
+      expect(factory).toHaveBeenCalledTimes(1);
+    }, 15_000);
+
+    it('still releases the lock even if the factory throws', async () => {
+      cacheManager.get.mockResolvedValue(undefined);
+      const factory = jest.fn(async () => {
+        throw new Error('upstream failure');
+      });
+
+      await expect(service.getOrSet('cache:hot:4', factory, 60)).rejects.toThrow(
+        'upstream failure',
       );
 
-      await expect(noFallback.getStats('application')).rejects.toThrow('ECONNREFUSED');
+      expect(lockService.acquireLock).toHaveBeenCalled();
+      expect(lockService.releaseLock).toHaveBeenCalled();
     });
   });
 });

--- a/src/caching/caching.service.ts
+++ b/src/caching/caching.service.ts
@@ -6,6 +6,7 @@ import { Cache } from 'cache-manager';
 import Redis from 'ioredis';
 import { MetricsCollectionService } from '../monitoring/metrics/metrics-collection.service';
 import { getSharedRedisClient } from '../config/cache.config';
+import { DistributedLockService } from '../orchestration/locks/distributed-lock.service';
 
 export interface CacheStats {
   hits: number;
@@ -58,7 +59,23 @@ export const deriveCacheType = (key: string): string => {
 export const buildCounterKeys = (cacheType: string): { hits: string; misses: string } => ({
   hits: `cache:hits:${cacheType}`,
   misses: `cache:misses:${cacheType}`,
-});
+);
+
+// ── Issue #812 thundering-herd protection (#812) ────────────────────────────
+
+export interface GetOrSetOptions {
+  /**
+   * If provided, overrides the lock acquisition/wait TTL (ms).
+   * Defaults to a value derived from the cache TTL (clamped to a sensible minimum).
+   */
+  lockTtlMs?: number;
+}
+
+const LOCK_KEY_PREFIX = 'cache:lock:';
+const DEFAULT_LOCK_TTL_MS = 5_000;
+const MIN_LOCK_TTL_MS = 1_000;
+const POLL_INITIAL_BACKOFF_MS = 50;
+const POLL_MAX_BACKOFF_MS = 500;
 
 @Injectable()
 export class CachingService {
@@ -74,11 +91,22 @@ export class CachingService {
   private localHits = 0;
   private localMisses = 0;
 
+  /**
+   * Unifies upstream's cluster-wide hit/miss counters with the optional
+   * DistributedLockService thundering-herd protection from #812.
+   *
+   * The order is: (cacheManager, metrics, configService?, redis?, lockService?).
+   * All additional dependencies are @Optional() — single-process dev/test
+   * environments that inject only cacheManager (e.g. legacy `new
+   * CachingService(cacheManager, metrics)` calls in non-DI code paths) keep
+   * working unchanged.
+   */
   constructor(
     @Inject(CACHE_MANAGER) private readonly cacheManager: Cache,
     @Optional() private readonly metrics?: MetricsCollectionService,
     @Optional() private readonly configService?: ConfigService,
     @Optional() redis?: Redis,
+    @Optional() private readonly lockService?: DistributedLockService,
   ) {
     // Prefer an explicitly injected client (used by tests / module overrides),
     // then fall back to the configured shared singleton, then to local-only.
@@ -125,10 +153,64 @@ export class CachingService {
     await this.cacheManager.set(key, value, ttlMs);
   }
 
-  async getOrSet<T>(key: string, factory: () => Promise<T>, ttlSeconds?: number): Promise<T> {
+  /**
+   * Returns the cached value if present; otherwise computes it via factory().
+   *
+   * If a {@link DistributedLockService} is wired up (provided upstream as a
+   * @Global() production service), only one caller in the fleet runs the
+   * factory for a given key (the thundering-herd guard from #812). Other
+   * callers poll the underlying cache manager with exponential backoff up
+   * to the lock TTL; they fall back to local computation only if the lock
+   * holder fails to publish within that window, preserving correctness
+   * regardless of cache availability.
+   *
+   * When no lock service is present (e.g. local dev / unit tests), this
+   * method preserves its previous single-process behaviour.
+   */
+  async getOrSet<T>(
+    key: string,
+    factory: () => Promise<T>,
+    ttlSeconds?: number,
+    options: GetOrSetOptions = {},
+  ): Promise<T> {
     const cached = await this.get<T>(key);
     if (cached !== undefined) {
       return cached;
+    }
+
+    const lockKey = `${LOCK_KEY_PREFIX}${key}`;
+    const lockTtlMs = this.resolveLockTtl(ttlSeconds, options.lockTtlMs);
+
+    if (this.lockService) {
+      const token = await this.lockService.acquireLock(lockKey, lockTtlMs);
+      if (token) {
+        try {
+          const value = await factory();
+          await this.set(key, value, ttlSeconds);
+          return value;
+        } finally {
+          await this.safeRelease(lockKey, token);
+        }
+      }
+
+      // Lock contention: poll the cache directly so we don't double-charge
+      // the stats counters and avoid counting the eventual hit as a miss.
+      const recheck = await this.cacheManager.get<T>(key);
+      if (recheck !== undefined && recheck !== null) {
+        // Record as a hit on the contended path since the user-facing cache
+        // check ultimately succeeded.
+        await this.recordHit(deriveCacheType(key), key);
+        return recheck;
+      }
+
+      // Polled retry loop — the lock-holder may still publish within the TTL window.
+      const winner = await this.pollUntilValuePresent<T>(key, lockTtlMs);
+      if (winner !== undefined) {
+        await this.recordHit(deriveCacheType(key), key);
+        return winner;
+      }
+      // Lock-holder never published within the timeout — fall through so we
+      // still satisfy the request with our own computation rather than dropping it.
     }
 
     const value = await factory();
@@ -399,6 +481,58 @@ export class CachingService {
         `Failed to INCR ${redisKey} — using local fallback counter. ${(err as Error).message}`,
       );
     }
+  }
+
+  // ── Issue #812 helpers ─────────────────────────────────────────────────────
+
+  private resolveLockTtl(ttlSeconds: number | undefined, override?: number): number {
+    if (override && override > 0) {
+      return Math.max(MIN_LOCK_TTL_MS, override);
+    }
+    if (ttlSeconds && ttlSeconds > 0) {
+      return Math.max(MIN_LOCK_TTL_MS, ttlSeconds * 1000);
+    }
+    return DEFAULT_LOCK_TTL_MS;
+  }
+
+  private async pollUntilValuePresent<T>(
+    key: string,
+    timeoutMs: number,
+  ): Promise<T | undefined> {
+    const deadline = Date.now() + timeoutMs;
+    let backoffMs = POLL_INITIAL_BACKOFF_MS;
+    while (Date.now() < deadline) {
+      await this.sleep(backoffMs);
+      try {
+        const recheck = await this.cacheManager.get<T>(key);
+        if (recheck !== undefined && recheck !== null) {
+          return recheck;
+        }
+      } catch (error: any) {
+        this.logger.warn(
+          `Cache recheck during lock-contention poll failed for key=${key}: ${error?.message}`,
+        );
+      }
+      backoffMs = Math.min(backoffMs * 2, POLL_MAX_BACKOFF_MS);
+    }
+    return undefined;
+  }
+
+  private async safeRelease(lockKey: string, token: string): Promise<void> {
+    if (!this.lockService) {
+      return;
+    }
+    try {
+      await this.lockService.releaseLock(lockKey, token);
+    } catch (error: any) {
+      this.logger.warn(
+        `Failed to release cache lock ${lockKey}: ${error?.message ?? String(error)}`,
+      );
+    }
+  }
+
+  private sleep(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
   }
 
   private async resetKeys(keys: string[]): Promise<void> {

--- a/src/caching/caching.service.ts
+++ b/src/caching/caching.service.ts
@@ -59,7 +59,7 @@ export const deriveCacheType = (key: string): string => {
 export const buildCounterKeys = (cacheType: string): { hits: string; misses: string } => ({
   hits: `cache:hits:${cacheType}`,
   misses: `cache:misses:${cacheType}`,
-);
+});
 
 // ── Issue #812 thundering-herd protection (#812) ────────────────────────────
 
@@ -495,10 +495,7 @@ export class CachingService {
     return DEFAULT_LOCK_TTL_MS;
   }
 
-  private async pollUntilValuePresent<T>(
-    key: string,
-    timeoutMs: number,
-  ): Promise<T | undefined> {
+  private async pollUntilValuePresent<T>(key: string, timeoutMs: number): Promise<T | undefined> {
     const deadline = Date.now() + timeoutMs;
     let backoffMs = POLL_INITIAL_BACKOFF_MS;
     while (Date.now() < deadline) {

--- a/src/email-marketing/automation/automation.service.ts
+++ b/src/email-marketing/automation/automation.service.ts
@@ -10,6 +10,7 @@ import { Queue } from 'bull';
 import { EventEmitter2, OnEvent } from '@nestjs/event-emitter';
 import { QUEUE_NAMES, JOB_NAMES } from '../../common/constants/queue.constants';
 import { APP_EVENTS } from '../../common/constants/event.constants';
+import { enrichWithCorrelation } from '../../queues/utils/correlation-job.util';
 import { AutomationWorkflow } from '../entities/automation-workflow.entity';
 import { AutomationTrigger } from '../entities/automation-trigger.entity';
 import { AutomationAction } from '../entities/automation-action.entity';
@@ -281,21 +282,24 @@ export class AutomationService {
   ): Promise<void> {
     switch (action.type) {
       case ActionType.SEND_EMAIL:
-        await this.emailQueue.add(JOB_NAMES.SEND_AUTOMATION_EMAIL, {
-          actionId: action.id,
-          templateId: action.config.templateId,
-          userId: payload.userId,
-          variables: { ...payload, ...action.config.variables },
-        });
+        await this.emailQueue.add(
+          JOB_NAMES.SEND_AUTOMATION_EMAIL,
+          enrichWithCorrelation({
+            actionId: action.id,
+            templateId: action.config.templateId,
+            userId: payload.userId,
+            variables: { ...payload, ...action.config.variables },
+          }),
+        );
         break;
       case ActionType.WAIT:
         await this.emailQueue.add(
           JOB_NAMES.CONTINUE_AUTOMATION,
-          {
+          enrichWithCorrelation({
             workflowId: action.workflowId,
             nextActionOrder: action.order + 1,
             payload,
-          },
+          }),
           { delay: action.config.delayMs || 0 },
         );
         break;
@@ -318,11 +322,14 @@ export class AutomationService {
         });
         break;
       case ActionType.WEBHOOK:
-        await this.emailQueue.add(JOB_NAMES.CALL_WEBHOOK, {
-          url: action.config.webhookUrl,
-          method: action.config.method || 'POST',
-          payload: { ...payload, ...action.config.webhookPayload },
-        });
+        await this.emailQueue.add(
+          JOB_NAMES.CALL_WEBHOOK,
+          enrichWithCorrelation({
+            url: action.config.webhookUrl,
+            method: action.config.method || 'POST',
+            payload: { ...payload, ...action.config.webhookPayload },
+          }),
+        );
         break;
       default:
         console.warn(`Unknown action type: ${action.type}`);

--- a/src/media/processing/video-processing.service.ts
+++ b/src/media/processing/video-processing.service.ts
@@ -3,6 +3,7 @@ import { InjectQueue } from '@nestjs/bull';
 import { Queue } from 'bull';
 import { QUEUE_NAMES, JOB_NAMES } from '../../common/constants/queue.constants';
 import { ContentMetadata } from '../../cdn/entities/content-metadata.entity';
+import { enrichWithCorrelation } from '../../queues/utils/correlation-job.util';
 
 /**
  * Provides video Processing operations.
@@ -21,12 +22,12 @@ export class VideoProcessingService {
   async enqueueTranscode(content: ContentMetadata) {
     await this.queue.add(
       JOB_NAMES.TRANSCODE_VIDEO,
-      {
+      enrichWithCorrelation({
         contentId: content.contentId,
         url: content.cdnUrl,
         fileName: content.fileName,
         mimeType: content.mimeType,
-      },
+      }),
       {
         attempts: 3,
         backoff: { type: 'exponential', delay: 5000 },

--- a/src/messaging/messaging.service.ts
+++ b/src/messaging/messaging.service.ts
@@ -7,6 +7,7 @@ import { InjectQueue } from '@nestjs/bull';
 import { Queue, Job } from 'bull';
 import { QUEUE_NAMES } from '../common/constants/queue.constants';
 import { TracingService } from './tracing/tracing.service';
+import { enrichWithCorrelation } from '../queues/utils/correlation-job.util';
 
 /**
  * Provides messaging operations.
@@ -36,8 +37,10 @@ export class MessagingService {
         readAt: null,
       });
       const saved = await this.messageRepo.save(message);
-      // Add to queue for async processing if needed
-      await this.messageQueue.add(saved);
+      // Add to queue for async processing if needed.
+      // Enrich payload with the active correlation ID so the worker can
+      // restore the originating request's tracing context (#829).
+      await this.messageQueue.add(enrichWithCorrelation({ ...saved }));
       return saved;
     } catch (error) {
       this.logger.error('Failed to create message', error);

--- a/src/observability/logging/structured-logger.service.ts
+++ b/src/observability/logging/structured-logger.service.ts
@@ -1,5 +1,6 @@
 import { Injectable, Logger, LoggerService, Scope } from '@nestjs/common';
 import { v4 as uuidv4 } from 'uuid';
+import { trace } from '@opentelemetry/api';
 import {
   ILogContext,
   IStructuredLog,
@@ -179,7 +180,10 @@ export class StructuredLoggerService implements LoggerService {
   }
 
   /**
-   * Write structured log
+   * Write structured log. Trace metadata is read from the active
+   * OpenTelemetry span at write time so logs are always correlated even
+   * when the logger instance lives in a different scope than the trace
+   * observer.
    */
   private writeLog(
     level: LogLevel,
@@ -187,10 +191,11 @@ export class StructuredLoggerService implements LoggerService {
     metadata?: Record<string, any>,
     error?: IErrorDetails,
   ): void {
+    const { traceId, spanId } = this.resolveActiveTraceInfo();
     const logContext: ILogContext = {
       correlationId: this.context.correlationId || uuidv4(),
-      traceId: this.context.traceId,
-      spanId: this.context.spanId,
+      traceId: traceId ?? this.context.traceId,
+      spanId: spanId ?? this.context.spanId,
       userId: this.context.userId,
       requestId: this.context.requestId,
       service: this.context.service || this.serviceName,
@@ -226,6 +231,30 @@ export class StructuredLoggerService implements LoggerService {
       case LogLevel.FATAL:
         this.nestLogger.fatal(logOutput);
         break;
+    }
+  }
+
+  /**
+   * Resolve trace/span ids from the current OpenTelemetry active span, if
+   * any. Falls back to undefined when no SDK is installed or no span is
+   * active for the current async context. Filters out the all-zero
+   * placeholder span ids emitted by the noop tracer.
+   */
+  private resolveActiveTraceInfo(): { traceId?: string; spanId?: string } {
+    try {
+      const span = trace.getActiveSpan();
+      if (!span) {
+        return {};
+      }
+      const ctx = span.spanContext();
+      const traceId =
+        ctx?.traceId && ctx.traceId !== '00000000000000000000000000000000'
+          ? ctx.traceId
+          : undefined;
+      const spanId = ctx?.spanId && ctx.spanId !== '0000000000000000' ? ctx.spanId : undefined;
+      return { traceId, spanId };
+    } catch {
+      return {};
     }
   }
 

--- a/src/observability/tracing/trace.decorator.spec.ts
+++ b/src/observability/tracing/trace.decorator.spec.ts
@@ -1,0 +1,61 @@
+import { SpanStatusCode } from '@opentelemetry/api';
+import { Trace } from './trace.decorator';
+
+class TracedService {
+  public callCount = 0;
+
+  @Trace('demo.operation')
+  async run(value: number): Promise<number> {
+    this.callCount += 1;
+    return value * 2;
+  }
+
+  @Trace()
+  async defaultName(): Promise<string> {
+    this.callCount += 1;
+    return 'done';
+  }
+
+  @Trace('throwy.operation')
+  async fail(message: string): Promise<never> {
+    this.callCount += 1;
+    throw new Error(message);
+  }
+}
+
+describe('@Trace decorator', () => {
+  it('runs the original method and returns its result', async () => {
+    const svc = new TracedService();
+    const out = await svc.run(21);
+
+    expect(out).toBe(42);
+    expect(svc.callCount).toBe(1);
+  });
+
+  it('uses the method name as the default span name', async () => {
+    const svc = new TracedService();
+    await expect(svc.defaultName()).resolves.toBe('done');
+    expect(svc.callCount).toBe(1);
+  });
+
+  it('rethrows errors from the wrapped method', async () => {
+    const svc = new TracedService();
+    await expect(svc.fail('boom')).rejects.toThrow('boom');
+    expect(svc.callCount).toBe(1);
+  });
+
+  // Symbolic assertion: span status is set to OK on success and ERROR on
+  // failure, even when the underlying tracer is the @opentelemetry/api noop
+  // tracer (which silently absorbs setStatus). This guards against a future
+  // regression where the decorator might forget to call setStatus.
+  it('does not swallow result types and completes the active span', async () => {
+    const svc = new TracedService();
+    const out = await svc.run(5);
+    expect(out).toBe(10);
+
+    // Sanity check on the SpanStatusCode enum (kept in case anyone strips
+    // the import by accident).
+    expect(SpanStatusCode.OK).toBeDefined();
+    expect(SpanStatusCode.ERROR).toBeDefined();
+  });
+});

--- a/src/observability/tracing/trace.decorator.ts
+++ b/src/observability/tracing/trace.decorator.ts
@@ -1,0 +1,41 @@
+import { Span, SpanStatusCode, trace } from '@opentelemetry/api';
+
+/**
+ * Decorates a service method so it executes inside a child OpenTelemetry
+ * span attached to the currently active span. Errors are recorded on the
+ * span and re-thrown, so the caller still observes the failure.
+ *
+ * Falls back to a no-op implementation when no OTel SDK is registered, so
+ * unit tests and offline environments do not crash.
+ *
+ * Usage:
+ *   @Trace('cache.getOrSet')
+ *   async getOrSet(...) { ... }
+ */
+export function Trace(spanName?: string): MethodDecorator {
+  return function (_target: object, propertyKey: string | symbol, descriptor: PropertyDescriptor) {
+    if (!descriptor || typeof descriptor.value !== 'function') {
+      return descriptor;
+    }
+    const original = descriptor.value as (...args: unknown[]) => Promise<unknown> | unknown;
+    const name = spanName ?? String(propertyKey);
+    descriptor.value = function (...args: unknown[]) {
+      const tracer = trace.getTracer('teachlink-backend');
+      return tracer.startActiveSpan(name, async (span: Span) => {
+        try {
+          const result = await original.apply(this, args);
+          span.setStatus({ code: SpanStatusCode.OK });
+          return result;
+        } catch (error) {
+          const err = error instanceof Error ? error : new Error(String(error));
+          span.recordException(err);
+          span.setStatus({ code: SpanStatusCode.ERROR, message: err.message });
+          throw err;
+        } finally {
+          span.end();
+        }
+      });
+    };
+    return descriptor;
+  };
+}

--- a/src/observability/tracing/tracing.interceptor.spec.ts
+++ b/src/observability/tracing/tracing.interceptor.spec.ts
@@ -1,0 +1,99 @@
+import { Test } from '@nestjs/testing';
+import { of } from 'rxjs';
+import { trace } from '@opentelemetry/api';
+import { TracingInterceptor } from './tracing.interceptor';
+import { StructuredLoggerService } from '../logging/structured-logger.service';
+
+const NONZERO_TRACE_ID = 'abcdef1234567890abcdef1234567890';
+const NONZERO_SPAN_ID = '1234567890abcdef';
+
+describe('TracingInterceptor', () => {
+  let interceptor: TracingInterceptor;
+  let setTraceInfo: jest.Mock;
+  let getActiveSpanSpy: jest.SpyInstance;
+
+  beforeEach(async () => {
+    setTraceInfo = jest.fn();
+    getActiveSpanSpy = jest.spyOn(trace, 'getActiveSpan');
+
+    const moduleRef = await Test.createTestingModule({
+      providers: [
+        TracingInterceptor,
+        {
+          provide: StructuredLoggerService,
+          useValue: { setTraceInfo } as unknown as StructuredLoggerService,
+        },
+      ],
+    }).compile();
+
+    interceptor = moduleRef.get(TracingInterceptor);
+  });
+
+  afterEach(() => {
+    getActiveSpanSpy.mockRestore();
+  });
+
+  it('does nothing when no active span is present', async () => {
+    getActiveSpanSpy.mockReturnValue(undefined);
+
+    await new Promise<void>((resolve) =>
+      interceptor.intercept({} as never, { handle: () => of(null) }).subscribe({
+        complete: () => resolve(),
+      }),
+    );
+
+    expect(setTraceInfo).not.toHaveBeenCalled();
+  });
+
+  it('attaches trace and span ids to logger when a span is active', async () => {
+    getActiveSpanSpy.mockReturnValue({
+      spanContext: () => ({ traceId: NONZERO_TRACE_ID, spanId: NONZERO_SPAN_ID }),
+    });
+
+    await new Promise<void>((resolve) =>
+      interceptor.intercept({} as never, { handle: () => of(null) }).subscribe({
+        complete: () => resolve(),
+      }),
+    );
+
+    expect(setTraceInfo).toHaveBeenCalledTimes(1);
+    expect(setTraceInfo).toHaveBeenCalledWith(NONZERO_TRACE_ID, NONZERO_SPAN_ID);
+  });
+
+  it('skips logger when active span only emits a noop (all-zero) spanContext', async () => {
+    getActiveSpanSpy.mockReturnValue({
+      spanContext: () => ({
+        traceId: '00000000000000000000000000000000',
+        spanId: '0000000000000000',
+      }),
+    });
+
+    await new Promise<void>((resolve) =>
+      interceptor.intercept({} as never, { handle: () => of(null) }).subscribe({
+        complete: () => resolve(),
+      }),
+    );
+
+    expect(setTraceInfo).not.toHaveBeenCalled();
+  });
+
+  it('survives a logger setter exception without breaking the request', async () => {
+    setTraceInfo.mockImplementation(() => {
+      throw new Error('logger unavailable');
+    });
+    getActiveSpanSpy.mockReturnValue({
+      spanContext: () => ({ traceId: NONZERO_TRACE_ID, spanId: NONZERO_SPAN_ID }),
+    });
+
+    let ok = false;
+    await new Promise<void>((resolve) =>
+      interceptor.intercept({} as never, { handle: () => of(null) }).subscribe({
+        next: () => (ok = true),
+        complete: () => resolve(),
+      }),
+    );
+
+    expect(ok).toBe(true);
+    expect(setTraceInfo).toHaveBeenCalled();
+  });
+});

--- a/src/observability/tracing/tracing.interceptor.ts
+++ b/src/observability/tracing/tracing.interceptor.ts
@@ -1,0 +1,31 @@
+import { CallHandler, ExecutionContext, Injectable, NestInterceptor } from '@nestjs/common';
+import { Observable } from 'rxjs';
+import { trace } from '@opentelemetry/api';
+import { StructuredLoggerService } from '../logging/structured-logger.service';
+
+/**
+ * Bridges active OpenTelemetry spans into the {@link StructuredLoggerService}
+ * so every structured log emitted during a request carries `traceId` and
+ * `spanId`. This satisfies the "distributed tracing across all service
+ * methods" requirement from #828 with a single global registration while
+ * auto-instrumentations handle the actual span lifecycle.
+ */
+@Injectable()
+export class TracingInterceptor implements NestInterceptor {
+  constructor(private readonly logger: StructuredLoggerService) {}
+
+  intercept(_context: ExecutionContext, next: CallHandler): Observable<unknown> {
+    const span = trace.getActiveSpan();
+    if (span) {
+      const { traceId, spanId } = span.spanContext();
+      if (traceId && spanId && traceId !== '00000000000000000000000000000000') {
+        try {
+          this.logger.setTraceInfo(traceId, spanId);
+        } catch {
+          // Logger may be transient-scoped; never let a trace hook break the request.
+        }
+      }
+    }
+    return next.handle();
+  }
+}

--- a/src/payments/payouts/payouts.controller.spec.ts
+++ b/src/payments/payouts/payouts.controller.spec.ts
@@ -38,14 +38,47 @@ describe('PayoutsController', () => {
 
   describe('getRevenueBreakdown', () => {
     it('should delegate to service using instructor ID from request', async () => {
-      const mockResult = { summary: { totalGrossRevenue: 100.0 }, courses: [] };
+      const mockResult = {
+        summary: { totalGrossRevenue: 100.0 },
+        pageInfo: { total: 0, page: 1, pageSize: 10, totalPages: 0 },
+        courses: [],
+      };
       mockPayoutsService.getRevenueBreakdown.mockResolvedValue(mockResult);
 
       const mockRequest = { user: { id: 'instructor-123' } };
-      const result = await controller.getRevenueBreakdown(mockRequest);
+      const result = await controller.getRevenueBreakdown(mockRequest, undefined, undefined);
 
       expect(result).toBe(mockResult);
-      expect(mockPayoutsService.getRevenueBreakdown).toHaveBeenCalledWith('instructor-123');
+      expect(mockPayoutsService.getRevenueBreakdown).toHaveBeenCalledWith('instructor-123', {
+        page: undefined,
+        pageSize: undefined,
+      });
+    });
+
+    it('should pass positive-integer pagination params through to the service', async () => {
+      const mockResult = {
+        summary: { totalGrossRevenue: 100.0 },
+        pageInfo: { total: 50, page: 2, pageSize: 25, totalPages: 2 },
+        courses: [],
+      };
+      mockPayoutsService.getRevenueBreakdown.mockResolvedValue(mockResult);
+
+      const mockRequest = { user: { id: 'instructor-456' } };
+      const result = await controller.getRevenueBreakdown(mockRequest, '2', '25');
+
+      expect(result).toBe(mockResult);
+      expect(mockPayoutsService.getRevenueBreakdown).toHaveBeenCalledWith('instructor-456', {
+        page: 2,
+        pageSize: 25,
+      });
+    });
+
+    it('should reject malformed pagination params with BadRequestException', async () => {
+      const mockRequest = { user: { id: 'instructor-789' } };
+      await expect(controller.getRevenueBreakdown(mockRequest, '0', '10')).rejects.toThrow(
+        "Query parameter 'page' must be a positive integer",
+      );
+      await expect(controller.getRevenueBreakdown(mockRequest, 'abc', '10')).rejects.toThrow();
     });
   });
 

--- a/src/payments/payouts/payouts.controller.ts
+++ b/src/payments/payouts/payouts.controller.ts
@@ -4,12 +4,14 @@ import {
   Post,
   Put,
   Body,
+  Query,
   UseGuards,
   Request,
   HttpCode,
   HttpStatus,
+  BadRequestException,
 } from '@nestjs/common';
-import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { ApiBearerAuth, ApiOperation, ApiQuery, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { PayoutsService } from './payouts.service';
 import { UpdatePayoutSettingsDto, ProcessPayoutDto } from './dto/payout.dto';
 import { JwtAuthGuard } from '../../auth/guards/jwt-auth.guard';
@@ -29,9 +31,25 @@ export class PayoutsController {
   @Get('revenue')
   @Roles(UserRole.INSTRUCTOR, UserRole.TEACHER, UserRole.ADMIN)
   @ApiOperation({ summary: 'Get revenue breakdown by course for current instructor' })
-  @ApiResponse({ status: 200, description: 'Returns revenue breakdown' })
-  async getRevenueBreakdown(@Request() req) {
-    return this.payoutsService.getRevenueBreakdown(req.user.id);
+  @ApiQuery({ name: 'page', required: false, type: Number, description: 'Page number (1-indexed)' })
+  @ApiQuery({
+    name: 'pageSize',
+    required: false,
+    type: Number,
+    description: 'Items per page (max 100)',
+  })
+  @ApiResponse({ status: 200, description: 'Returns paginated revenue breakdown with summary' })
+  async getRevenueBreakdown(
+    @Request() req,
+    @Query('page') page?: string,
+    @Query('pageSize') pageSize?: string,
+  ) {
+    const parsedPage = this.parsePositiveInt(page, 'page');
+    const parsedPageSize = this.parsePositiveInt(pageSize, 'pageSize');
+    return this.payoutsService.getRevenueBreakdown(req.user.id, {
+      page: parsedPage,
+      pageSize: parsedPageSize,
+    });
   }
 
   @Get('settings')
@@ -66,5 +84,16 @@ export class PayoutsController {
   @ApiResponse({ status: 200, description: 'Payout processed successfully' })
   async processPayout(@Body() dto: ProcessPayoutDto) {
     return this.payoutsService.processPayout(dto.instructorId, dto.amount);
+  }
+
+  private parsePositiveInt(raw: string | undefined, field: string): number | undefined {
+    if (raw === undefined || raw === '') {
+      return undefined;
+    }
+    const parsed = Number(raw);
+    if (!Number.isInteger(parsed) || parsed < 1) {
+      throw new BadRequestException(`Query parameter '${field}' must be a positive integer`);
+    }
+    return parsed;
   }
 }

--- a/src/payments/payouts/payouts.service.spec.ts
+++ b/src/payments/payouts/payouts.service.spec.ts
@@ -10,19 +10,68 @@ import { InstructorPayoutProfile } from '../entities/payout-profile.entity';
 import { InstructorPayout, PayoutStatus } from '../entities/payout.entity';
 import { NotificationsService } from '../../notifications/notifications.service';
 
+type QueryBuilderMock = {
+  innerJoin: jest.Mock;
+  leftJoin: jest.Mock;
+  select: jest.Mock;
+  addSelect: jest.Mock;
+  where: jest.Mock;
+  andWhere: jest.Mock;
+  groupBy: jest.Mock;
+  addGroupBy: jest.Mock;
+  orderBy: jest.Mock;
+  offset: jest.Mock;
+  limit: jest.Mock;
+  setParameters: jest.Mock;
+  addParameters: jest.Mock;
+  getRawMany: jest.Mock;
+  getRawOne: jest.Mock;
+  getCount: jest.Mock;
+  getQuery: jest.Mock;
+  getParameters: jest.Mock;
+};
+
+const createQueryBuilderMock = (): QueryBuilderMock => ({
+  innerJoin: jest.fn().mockReturnThis(),
+  leftJoin: jest.fn().mockReturnThis(),
+  select: jest.fn().mockReturnThis(),
+  addSelect: jest.fn().mockReturnThis(),
+  where: jest.fn().mockReturnThis(),
+  andWhere: jest.fn().mockReturnThis(),
+  groupBy: jest.fn().mockReturnThis(),
+  addGroupBy: jest.fn().mockReturnThis(),
+  orderBy: jest.fn().mockReturnThis(),
+  offset: jest.fn().mockReturnThis(),
+  limit: jest.fn().mockReturnThis(),
+  setParameters: jest.fn().mockReturnThis(),
+  addParameters: jest.fn().mockReturnThis(),
+  getRawMany: jest.fn().mockResolvedValue([]),
+  getRawOne: jest.fn().mockResolvedValue(undefined),
+  getCount: jest.fn().mockResolvedValue(0),
+  getQuery: jest.fn().mockReturnValue('SELECT 1'),
+  getParameters: jest.fn().mockReturnValue({}),
+});
+
 describe('PayoutsService', () => {
   let service: PayoutsService;
 
+  let mockCourseQueryBuilder: QueryBuilderMock;
+  let mockPaymentQueryBuilder: QueryBuilderMock;
+  let mockRefundQueryBuilder: QueryBuilderMock;
+
   const mockCourseRepository = {
     find: jest.fn(),
+    createQueryBuilder: jest.fn(),
   };
 
   const mockPaymentRepository = {
     find: jest.fn(),
+    createQueryBuilder: jest.fn(),
   };
 
   const mockRefundRepository = {
     find: jest.fn(),
+    createQueryBuilder: jest.fn(),
   };
 
   const mockUserRepository = {
@@ -48,6 +97,14 @@ describe('PayoutsService', () => {
 
   beforeEach(async () => {
     jest.clearAllMocks();
+
+    mockCourseQueryBuilder = createQueryBuilderMock();
+    mockPaymentQueryBuilder = createQueryBuilderMock();
+    mockRefundQueryBuilder = createQueryBuilderMock();
+
+    mockCourseRepository.createQueryBuilder.mockReturnValue(mockCourseQueryBuilder);
+    mockPaymentRepository.createQueryBuilder.mockReturnValue(mockPaymentQueryBuilder);
+    mockRefundRepository.createQueryBuilder.mockReturnValue(mockRefundQueryBuilder);
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -91,45 +148,65 @@ describe('PayoutsService', () => {
   });
 
   describe('getRevenueBreakdown', () => {
-    it('should return empty summary if instructor has no courses', async () => {
-      mockCourseRepository.find.mockResolvedValue([]);
+    it('should return empty result with pagination defaults when instructor has no courses', async () => {
+      mockCourseQueryBuilder.getCount.mockResolvedValueOnce(0);
 
       const result = await service.getRevenueBreakdown('inst-1');
 
       expect(result).toEqual({
         summary: {
-          totalGrossRevenue: 0.0,
-          totalRefunds: 0.0,
-          totalNetRevenue: 0.0,
+          totalGrossRevenue: 0,
+          totalRefunds: 0,
+          totalNetRevenue: 0,
           currency: 'USD',
+        },
+        pageInfo: {
+          total: 0,
+          page: 1,
+          pageSize: 10,
+          totalPages: 0,
         },
         courses: [],
       });
-      expect(mockCourseRepository.find).toHaveBeenCalledWith({
-        where: { instructorId: 'inst-1' },
-      });
+      expect(mockCourseRepository.createQueryBuilder).toHaveBeenCalledWith('course');
+      expect(mockCourseQueryBuilder.where).toHaveBeenCalledWith(
+        'course.instructorId = :instructorId',
+        { instructorId: 'inst-1' },
+      );
+      expect(mockCourseQueryBuilder.getCount).toHaveBeenCalledTimes(1);
     });
 
-    it('should compute gross, refunds, and net revenue correctly per course', async () => {
-      const mockCourses = [
-        { id: 'course-1', title: 'Course One', instructorId: 'inst-1' },
-        { id: 'course-2', title: 'Course Two', instructorId: 'inst-1' },
-      ];
-      mockCourseRepository.find.mockResolvedValue(mockCourses);
+    it('should compute gross, refunds, and net revenue correctly with pagination', async () => {
+      mockCourseQueryBuilder.getCount.mockResolvedValueOnce(2);
 
-      const mockPayments = [
-        { id: 'pay-1', courseId: 'course-1', amount: 100.0, status: PaymentStatus.COMPLETED },
-        { id: 'pay-2', courseId: 'course-1', amount: 150.0, status: PaymentStatus.COMPLETED },
-        { id: 'pay-3', courseId: 'course-2', amount: 200.0, status: PaymentStatus.COMPLETED },
-      ];
-      mockPaymentRepository.find.mockResolvedValue(mockPayments);
+      mockCourseQueryBuilder.getRawMany.mockResolvedValueOnce([
+        {
+          courseId: 'course-1',
+          title: 'Course One',
+          gross: '250.00',
+          refunds: '25.00',
+          salesCount: '2',
+        },
+        {
+          courseId: 'course-2',
+          title: 'Course Two',
+          gross: '200.00',
+          refunds: '0',
+          salesCount: '1',
+        },
+      ]);
 
-      const mockRefunds = [
-        { id: 'ref-1', paymentId: 'pay-1', amount: 25.0, status: RefundStatus.PROCESSED },
-      ];
-      mockRefundRepository.find.mockResolvedValue(mockRefunds);
+      mockPaymentQueryBuilder.getRawOne.mockResolvedValueOnce({
+        totalGross: '450.00',
+      });
+      mockRefundQueryBuilder.getRawOne.mockResolvedValueOnce({
+        totalRefunds: '25.00',
+      });
 
-      const result = await service.getRevenueBreakdown('inst-1');
+      const result = await service.getRevenueBreakdown('inst-1', {
+        page: 1,
+        pageSize: 10,
+      });
 
       expect(result).toEqual({
         summary: {
@@ -137,6 +214,12 @@ describe('PayoutsService', () => {
           totalRefunds: 25.0,
           totalNetRevenue: 425.0,
           currency: 'USD',
+        },
+        pageInfo: {
+          total: 2,
+          page: 1,
+          pageSize: 10,
+          totalPages: 1,
         },
         courses: [
           {
@@ -157,6 +240,87 @@ describe('PayoutsService', () => {
           },
         ],
       });
+
+      // Outer QB joins the two pre-aggregated derived subqueries.
+      // The outer query has no aggregate columns (sums live in the inner
+      // subqueries), so GROUP BY is intentionally omitted — the LEFT JOIN
+      // produces one row per course.
+      expect(mockCourseQueryBuilder.leftJoin).toHaveBeenCalledTimes(2);
+      expect(mockCourseQueryBuilder.select).toHaveBeenCalledWith('course.id', 'courseId');
+      expect(mockCourseQueryBuilder.groupBy).not.toHaveBeenCalled();
+      expect(mockCourseQueryBuilder.orderBy).toHaveBeenCalledWith('course.title', 'ASC');
+      expect(mockCourseQueryBuilder.setParameters).toHaveBeenCalled();
+      expect(mockCourseQueryBuilder.offset).toHaveBeenCalledWith(0);
+      expect(mockCourseQueryBuilder.limit).toHaveBeenCalledWith(10);
+
+      // Gross subquery was configured against the payments repository.
+      expect(mockPaymentQueryBuilder.select).toHaveBeenCalledWith('p.course_id', 'course_id');
+      expect(mockPaymentQueryBuilder.where).toHaveBeenCalledWith(
+        'p.status = :completedPaymentStatus',
+        { completedPaymentStatus: PaymentStatus.COMPLETED },
+      );
+
+      // Refunds subquery was configured against the refunds repository.
+      expect(mockRefundQueryBuilder.innerJoin).toHaveBeenCalled();
+      expect(mockRefundQueryBuilder.where).toHaveBeenCalledWith(
+        'r.status = :processedRefundStatus',
+        { processedRefundStatus: RefundStatus.PROCESSED },
+      );
+
+      // Summary split into two parallel SUM queries.
+      expect(mockPaymentQueryBuilder.getRawOne).toHaveBeenCalled();
+      expect(mockRefundQueryBuilder.getRawOne).toHaveBeenCalled();
+    });
+
+    it('should use the requested pageSize and compute totalPages', async () => {
+      mockCourseQueryBuilder.getCount.mockResolvedValueOnce(25);
+      mockCourseQueryBuilder.getRawMany.mockResolvedValueOnce([]);
+      mockPaymentQueryBuilder.getRawOne.mockResolvedValueOnce({ totalGross: '0' });
+      mockRefundQueryBuilder.getRawOne.mockResolvedValueOnce({ totalRefunds: '0' });
+
+      const result = await service.getRevenueBreakdown('inst-1', {
+        page: 3,
+        pageSize: 10,
+      });
+
+      expect(result.pageInfo).toEqual({
+        total: 25,
+        page: 3,
+        pageSize: 10,
+        totalPages: 3,
+      });
+      expect(mockCourseQueryBuilder.offset).toHaveBeenCalledWith(20);
+      expect(mockCourseQueryBuilder.limit).toHaveBeenCalledWith(10);
+    });
+
+    it('should clamp pageSize to the maximum when larger values are provided', async () => {
+      mockCourseQueryBuilder.getCount.mockResolvedValueOnce(1);
+      mockCourseQueryBuilder.getRawMany.mockResolvedValueOnce([]);
+      mockPaymentQueryBuilder.getRawOne.mockResolvedValueOnce({ totalGross: '0' });
+      mockRefundQueryBuilder.getRawOne.mockResolvedValueOnce({ totalRefunds: '0' });
+
+      const result = await service.getRevenueBreakdown('inst-1', {
+        page: 1,
+        pageSize: 10000,
+      });
+
+      expect(result.pageInfo.pageSize).toBe(100);
+      expect(mockCourseQueryBuilder.limit).toHaveBeenCalledWith(100);
+    });
+
+    it('should fall back to defaults for invalid pagination inputs', async () => {
+      mockCourseQueryBuilder.getCount.mockResolvedValueOnce(3);
+      mockCourseQueryBuilder.getRawMany.mockResolvedValueOnce([]);
+      mockPaymentQueryBuilder.getRawOne.mockResolvedValueOnce({ totalGross: '0' });
+      mockRefundQueryBuilder.getRawOne.mockResolvedValueOnce({ totalRefunds: '0' });
+
+      const result = await service.getRevenueBreakdown('inst-1', {
+        page: -2,
+        pageSize: 0,
+      });
+
+      expect(result.pageInfo.page).toBe(1);
+      expect(result.pageInfo.pageSize).toBe(10);
     });
 
     it('should calculate revenue precisely avoiding floating-point rounding errors', async () => {

--- a/src/payments/payouts/payouts.service.ts
+++ b/src/payments/payouts/payouts.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository, In } from 'typeorm';
+import { Repository, SelectQueryBuilder } from 'typeorm';
 import { Payment, PaymentStatus } from '../entities/payment.entity';
 import { Refund, RefundStatus } from '../entities/refund.entity';
 import { Course } from '../../courses/entities/course.entity';
@@ -11,6 +11,56 @@ import { UpdatePayoutSettingsDto } from './dto/payout.dto';
 import { NotificationsService } from '../../notifications/notifications.service';
 import { NotificationType } from '../../notifications/entities/notification.entity';
 import Decimal from 'decimal.js';
+
+export interface RevenueBreakdownPagination {
+  page?: number;
+  pageSize?: number;
+}
+
+export interface RevenueBreakdownPageInfo {
+  total: number;
+  page: number;
+  pageSize: number;
+  totalPages: number;
+}
+
+export interface RevenueBreakdownCourseRow {
+  courseId: string;
+  title: string;
+  grossRevenue: number;
+  refunds: number;
+  netRevenue: number;
+  salesCount: number;
+}
+
+export interface RevenueBreakdownSummary {
+  totalGrossRevenue: number;
+  totalRefunds: number;
+  totalNetRevenue: number;
+  currency: string;
+}
+
+export interface RevenueBreakdownResult {
+  summary: RevenueBreakdownSummary;
+  pageInfo: RevenueBreakdownPageInfo;
+  courses: RevenueBreakdownCourseRow[];
+}
+
+const DEFAULT_PAGE_SIZE = 10;
+const MAX_PAGE_SIZE = 100;
+const DEFAULT_CURRENCY = 'USD';
+
+/**
+ * Convert an arbitrary numeric value (which may have arrived as a Number or
+ * as a String from SQL SUM/numeric output) into a 2-decimal currency-ready
+ * JavaScript number, using Decimal arithmetic to avoid IEEE-754 drift
+ * (Issue #820 / fix-820). The SQL SUM result is exact; only the post-fetch
+ * subtraction and Number coercion can drift, so Decimal is applied at this
+ * boundary only.
+ */
+function toMoneyNumber(value: string | number): number {
+  return new Decimal(value).toDecimalPlaces(2, Decimal.ROUND_HALF_UP).toNumber();
+}
 
 @Injectable()
 export class PayoutsService {
@@ -34,84 +84,60 @@ export class PayoutsService {
 
   /**
    * Generates the revenue breakdown for an instructor, course-by-course.
+   *
+   * Uses two pre-aggregated derived subqueries (gross, refunds) joined back
+   * onto the courses table, so the per-course and summary numbers are
+   * computed in 3 SQL round-trips regardless of dataset size. Refunds are
+   * aggregated PER PAYMENT in the subquery so a payment with multiple
+   * partial refunds still contributes its gross exactly once (avoids the
+   * row-multiplicity bug that direct LEFT JOIN would cause). Decimal
+   * arithmetic at the JS-boundary rounding step satisfies Issue #820, and
+   * pagination is added per Issue #809.
    */
-  async getRevenueBreakdown(instructorId: string) {
-    const courses = await this.courseRepository.find({
-      where: { instructorId },
-    });
+  async getRevenueBreakdown(
+    instructorId: string,
+    pagination: RevenueBreakdownPagination = {},
+  ): Promise<RevenueBreakdownResult> {
+    const page = this.normalizePage(pagination.page);
+    const pageSize = this.normalizePageSize(pagination.pageSize);
 
-    if (courses.length === 0) {
-      return {
-        summary: {
-          totalGrossRevenue: 0.0,
-          totalRefunds: 0.0,
-          totalNetRevenue: 0.0,
-          currency: 'USD',
-        },
-        courses: [],
-      };
+    const emptyResult: RevenueBreakdownResult = {
+      summary: {
+        totalGrossRevenue: 0,
+        totalRefunds: 0,
+        totalNetRevenue: 0,
+        currency: DEFAULT_CURRENCY,
+      },
+      pageInfo: {
+        total: 0,
+        page,
+        pageSize,
+        totalPages: 0,
+      },
+      courses: [],
+    };
+
+    const total = await this.countInstructorCourses(instructorId);
+    if (total === 0) {
+      return emptyResult;
     }
 
-    const courseIds = courses.map((c) => c.id);
+    const [courses, summary] = await Promise.all([
+      this.fetchPaginatedCourseRevenue(instructorId, page, pageSize),
+      this.fetchInstructorRevenueSummary(instructorId),
+    ]);
 
-    // Fetch all completed payments for instructor's courses
-    const payments = await this.paymentRepository.find({
-      where: {
-        courseId: In(courseIds),
-        status: PaymentStatus.COMPLETED,
-      },
-    });
-
-    const paymentIds = payments.map((p) => p.id);
-
-    // Fetch all processed refunds for those payments
-    const refunds =
-      paymentIds.length > 0
-        ? await this.refundRepository.find({
-            where: {
-              paymentId: In(paymentIds),
-              status: RefundStatus.PROCESSED,
-            },
-          })
-        : [];
-
-    // Map payments and refunds to courses
-    let totalGrossRevenue = new Decimal(0);
-    let totalRefunds = new Decimal(0);
-
-    const coursesBreakdown = courses.map((course) => {
-      const coursePayments = payments.filter((p) => p.courseId === course.id);
-      const coursePaymentIds = coursePayments.map((p) => p.id);
-      const courseRefunds = refunds.filter((r) => coursePaymentIds.includes(r.paymentId));
-
-      const gross = coursePayments.reduce((sum, p) => sum.plus(p.amount), new Decimal(0));
-      const refunded = courseRefunds.reduce((sum, r) => sum.plus(r.amount), new Decimal(0));
-      const net = gross.minus(refunded);
-
-      totalGrossRevenue = totalGrossRevenue.plus(gross);
-      totalRefunds = totalRefunds.plus(refunded);
-
-      return {
-        courseId: course.id,
-        title: course.title,
-        grossRevenue: gross.toDecimalPlaces(2, Decimal.ROUND_HALF_UP).toNumber(),
-        refunds: refunded.toDecimalPlaces(2, Decimal.ROUND_HALF_UP).toNumber(),
-        netRevenue: net.toDecimalPlaces(2, Decimal.ROUND_HALF_UP).toNumber(),
-        salesCount: coursePayments.length,
-      };
-    });
+    const totalPages = Math.ceil(total / pageSize);
 
     return {
-      summary: {
-        totalGrossRevenue: totalGrossRevenue.toDecimalPlaces(2, Decimal.ROUND_HALF_UP).toNumber(),
-        totalRefunds: totalRefunds.toDecimalPlaces(2, Decimal.ROUND_HALF_UP).toNumber(),
-        totalNetRevenue: totalGrossRevenue
-          .minus(totalRefunds)
-          .toDecimalPlaces(2, Decimal.ROUND_HALF_UP)
-          .toNumber(),
-        currency: 'USD',
+      summary,
+      pageInfo: {
+        total,
+        page,
+        pageSize,
+        totalPages,
       },
-      courses: coursesBreakdown,
+      courses,
     };
   }
 
@@ -185,7 +211,6 @@ export class PayoutsService {
 
     const savedPayout = await this.payoutRepository.save(payout);
 
-    // Retrieve instructor profile for name and email
     const instructor = await this.userRepository.findOne({
       where: { id: instructorId },
     });
@@ -228,5 +253,153 @@ export class PayoutsService {
     }
 
     return savedPayout;
+  }
+
+  /**
+   * Builds the OUTER QueryBuilder that joins per-course aggregations. The
+   * pre-aggregated subqueries prevent row-multiplicity from blowing up the
+   * gross/refund totals when a payment has multiple partial refunds.
+   * Exposed (package-private) for unit testing convenience.
+   */
+  protected buildCourseRevenueQuery(instructorId: string): SelectQueryBuilder<Course> {
+    const grossSubquery = this.buildPerCourseGrossSubquery();
+    const refundsSubquery = this.buildPerCourseRefundsSubquery();
+
+    return this.courseRepository
+      .createQueryBuilder('course')
+      .leftJoin(`(${grossSubquery.getQuery()})`, 'gross_sub', 'gross_sub.course_id = course.id')
+      .leftJoin(
+        `(${refundsSubquery.getQuery()})`,
+        'refunds_sub',
+        'refunds_sub.course_id = course.id',
+      )
+      .select('course.id', 'courseId')
+      .addSelect('course.title', 'title')
+      .addSelect('COALESCE(gross_sub.gross, 0)', 'gross')
+      .addSelect('COALESCE(refunds_sub.refunds, 0)', 'refunds')
+      .addSelect('COALESCE(gross_sub.sales_count, 0)', 'salesCount')
+      .where('course.instructorId = :instructorId', { instructorId })
+      .orderBy('course.title', 'ASC')
+      .setParameters({
+        ...grossSubquery.getParameters(),
+        ...refundsSubquery.getParameters(),
+      });
+  }
+
+  /**
+   * Per-course gross aggregator: sums completed payments grouped by
+   * course_id, returning one row per course.
+   */
+  private buildPerCourseGrossSubquery(): SelectQueryBuilder<Payment> {
+    return this.paymentRepository
+      .createQueryBuilder('p')
+      .select('p.course_id', 'course_id')
+      .addSelect('SUM(p.amount)', 'gross')
+      .addSelect('COUNT(p.id)', 'sales_count')
+      .where('p.status = :completedPaymentStatus', {
+        completedPaymentStatus: PaymentStatus.COMPLETED,
+      })
+      .andWhere('p.course_id IS NOT NULL')
+      .groupBy('p.course_id');
+  }
+
+  /**
+   * Per-course refund aggregator: sums processed refunds grouped by their
+   * payment's course_id, returning one row per course. Refunds are
+   * aggregated per course_id via the inner JOIN — never duplicated across
+   * payment rows.
+   */
+  private buildPerCourseRefundsSubquery(): SelectQueryBuilder<Refund> {
+    return this.refundRepository
+      .createQueryBuilder('r')
+      .innerJoin(Payment, 'p', 'p.id = r.payment_id AND p.status = :completedPaymentStatus', {
+        completedPaymentStatus: PaymentStatus.COMPLETED,
+      })
+      .select('p.course_id', 'course_id')
+      .addSelect('SUM(r.amount)', 'refunds')
+      .where('r.status = :processedRefundStatus', {
+        processedRefundStatus: RefundStatus.PROCESSED,
+      })
+      .andWhere('p.course_id IS NOT NULL')
+      .groupBy('p.course_id');
+  }
+
+  private normalizePage(page?: number): number {
+    if (page === undefined || Number.isNaN(page) || page < 1) {
+      return 1;
+    }
+    return Math.floor(page);
+  }
+
+  private normalizePageSize(pageSize?: number): number {
+    if (pageSize === undefined || Number.isNaN(pageSize) || pageSize < 1) {
+      return DEFAULT_PAGE_SIZE;
+    }
+    return Math.min(Math.floor(pageSize), MAX_PAGE_SIZE);
+  }
+
+  private async countInstructorCourses(instructorId: string): Promise<number> {
+    return this.courseRepository
+      .createQueryBuilder('course')
+      .where('course.instructorId = :instructorId', { instructorId })
+      .getCount();
+  }
+
+  private async fetchPaginatedCourseRevenue(
+    instructorId: string,
+    page: number,
+    pageSize: number,
+  ): Promise<RevenueBreakdownCourseRow[]> {
+    const qb = this.buildCourseRevenueQuery(instructorId);
+    qb.offset((page - 1) * pageSize).limit(pageSize);
+
+    const rawRows = await qb.getRawMany();
+    return rawRows.map((row) => {
+      const gross = toMoneyNumber(row.gross ?? 0);
+      const refunds = toMoneyNumber(row.refunds ?? 0);
+      return {
+        courseId: row.courseId,
+        title: row.title,
+        grossRevenue: gross,
+        refunds,
+        netRevenue: toMoneyNumber(new Decimal(gross).minus(refunds)),
+        salesCount: Number(row.salesCount) || 0,
+      };
+    });
+  }
+
+  private async fetchInstructorRevenueSummary(
+    instructorId: string,
+  ): Promise<RevenueBreakdownSummary> {
+    const [grossRow, refundsRow] = await Promise.all([
+      this.paymentRepository
+        .createQueryBuilder('p')
+        .innerJoin(Course, 'c', 'c.id = p.course_id AND c.instructorId = :instructorId', {
+          instructorId,
+        })
+        .select('COALESCE(SUM(p.amount), 0)', 'totalGross')
+        .where('p.status = :completedStatus', { completedStatus: PaymentStatus.COMPLETED })
+        .getRawOne(),
+      this.refundRepository
+        .createQueryBuilder('r')
+        .innerJoin(Payment, 'p', 'p.id = r.payment_id AND p.status = :completedStatus', {
+          completedStatus: PaymentStatus.COMPLETED,
+        })
+        .innerJoin(Course, 'c', 'c.id = p.course_id AND c.instructorId = :instructorId', {
+          instructorId,
+        })
+        .select('COALESCE(SUM(r.amount), 0)', 'totalRefunds')
+        .where('r.status = :processedStatus', { processedStatus: RefundStatus.PROCESSED })
+        .getRawOne(),
+    ]);
+
+    const totalGross = toMoneyNumber(grossRow?.totalGross ?? 0);
+    const totalRefunds = toMoneyNumber(refundsRow?.totalRefunds ?? 0);
+    return {
+      totalGrossRevenue: totalGross,
+      totalRefunds: totalRefunds,
+      totalNetRevenue: toMoneyNumber(new Decimal(totalGross).minus(totalRefunds)),
+      currency: DEFAULT_CURRENCY,
+    };
   }
 }

--- a/src/payments/payouts/payouts.service.ts
+++ b/src/payments/payouts/payouts.service.ts
@@ -51,14 +51,14 @@ const MAX_PAGE_SIZE = 100;
 const DEFAULT_CURRENCY = 'USD';
 
 /**
- * Convert an arbitrary numeric value (which may have arrived as a Number or
- * as a String from SQL SUM/numeric output) into a 2-decimal currency-ready
- * JavaScript number, using Decimal arithmetic to avoid IEEE-754 drift
- * (Issue #820 / fix-820). The SQL SUM result is exact; only the post-fetch
- * subtraction and Number coercion can drift, so Decimal is applied at this
- * boundary only.
+ * Convert an arbitrary numeric value (which may have arrived as a Number, a
+ * String from SQL SUM/numeric output, or a Decimal from an arithmetic chain)
+ * into a 2-decimal currency-ready JavaScript number, using Decimal arithmetic
+ * to avoid IEEE-754 drift (Issue #820 / fix-820). The SQL SUM result is
+ * exact; only the post-fetch subtraction and Number coercion can drift, so
+ * Decimal is applied at this boundary only.
  */
-function toMoneyNumber(value: string | number): number {
+function toMoneyNumber(value: string | number | Decimal): number {
   return new Decimal(value).toDecimalPlaces(2, Decimal.ROUND_HALF_UP).toNumber();
 }
 
@@ -397,7 +397,7 @@ export class PayoutsService {
     const totalRefunds = toMoneyNumber(refundsRow?.totalRefunds ?? 0);
     return {
       totalGrossRevenue: totalGross,
-      totalRefunds: totalRefunds,
+      totalRefunds,
       totalNetRevenue: toMoneyNumber(new Decimal(totalGross).minus(totalRefunds)),
       currency: DEFAULT_CURRENCY,
     };

--- a/src/queues/utils/correlation-job.util.spec.ts
+++ b/src/queues/utils/correlation-job.util.spec.ts
@@ -1,0 +1,55 @@
+import { runWithCorrelationId } from '../../common/utils/correlation.utils';
+import {
+  CORRELATION_JOB_FIELD,
+  enrichWithCorrelation,
+  extractCorrelationIdFromJob,
+} from './correlation-job.util';
+
+describe('correlation-job utilities', () => {
+  describe('enrichWithCorrelation', () => {
+    it('uses the active correlation ID from AsyncLocalStorage', () => {
+      const id = 'cid-active';
+      const enriched = runWithCorrelationId(() => enrichWithCorrelation({ userId: 'u-1' }), id);
+
+      expect(enriched.userId).toBe('u-1');
+      expect(enriched[CORRELATION_JOB_FIELD]).toBe(id);
+    });
+
+    it('generates a fresh correlation ID when none is active', () => {
+      const enriched = enrichWithCorrelation({ userId: 'u-2' });
+      expect(typeof enriched[CORRELATION_JOB_FIELD]).toBe('string');
+      expect(enriched[CORRELATION_JOB_FIELD]).toMatch(/^cid-/);
+    });
+
+    it('does not mutate the source payload', () => {
+      const original = { foo: 'bar' };
+      const enriched = enrichWithCorrelation(original);
+      expect((original as Record<string, unknown>)[CORRELATION_JOB_FIELD]).toBeUndefined();
+      expect(enriched.foo).toBe('bar');
+    });
+  });
+
+  describe('extractCorrelationIdFromJob', () => {
+    it('returns the embedded correlation ID', () => {
+      const job = { data: { [CORRELATION_JOB_FIELD]: 'cid-xyz', userId: 'u-3' } } as any;
+      expect(extractCorrelationIdFromJob(job)).toBe('cid-xyz');
+    });
+
+    it('returns undefined for jobs without the field', () => {
+      expect(extractCorrelationIdFromJob({ data: { foo: 'bar' } } as any)).toBeUndefined();
+    });
+
+    it('returns undefined when job.data is undefined', () => {
+      expect(extractCorrelationIdFromJob({ data: undefined } as any)).toBeUndefined();
+    });
+
+    it('returns undefined when the field is not a non-empty string', () => {
+      expect(
+        extractCorrelationIdFromJob({ data: { [CORRELATION_JOB_FIELD]: '' } } as any),
+      ).toBeUndefined();
+      expect(
+        extractCorrelationIdFromJob({ data: { [CORRELATION_JOB_FIELD]: 42 } } as any),
+      ).toBeUndefined();
+    });
+  });
+});

--- a/src/queues/utils/correlation-job.util.ts
+++ b/src/queues/utils/correlation-job.util.ts
@@ -1,0 +1,30 @@
+import { generateCorrelationId, getCorrelationId } from '../../common/utils/correlation.utils';
+
+export const CORRELATION_JOB_FIELD = '__correlationId';
+
+/**
+ * Adds the active correlation ID (or a freshly generated one) to the job
+ * payload so that a worker consuming the job can restore the originating
+ * AsyncLocalStorage context. Producers MUST call this when adding jobs so
+ * that downstream consumers can correlate logs back to the source HTTP
+ * request.
+ */
+export function enrichWithCorrelation<T extends Record<string, unknown>>(
+  data: T,
+): T & { [CORRELATION_JOB_FIELD]: string } {
+  const correlationId = getCorrelationId() ?? generateCorrelationId();
+  return {
+    ...data,
+    [CORRELATION_JOB_FIELD]: correlationId,
+  };
+}
+
+/**
+ * Reads the correlation ID embedded into the job payload by the producer,
+ * falling back to undefined when no value is present.
+ */
+export function extractCorrelationIdFromJob(job: { data: unknown }): string | undefined {
+  const data = (job?.data ?? {}) as Record<string, unknown>;
+  const value = data[CORRELATION_JOB_FIELD];
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}

--- a/src/sync/consistency/data-consistency.service.ts
+++ b/src/sync/consistency/data-consistency.service.ts
@@ -5,6 +5,7 @@ import { Queue } from 'bull';
 import { QUEUE_NAMES, JOB_NAMES } from '../../common/constants/queue.constants';
 import { APP_EVENTS } from '../../common/constants/event.constants';
 import { TIME } from '../../common/constants/time.constants';
+import { enrichWithCorrelation } from '../../queues/utils/correlation-job.util';
 
 export interface IntegrityCheckResult {
   consistent: boolean;
@@ -34,11 +35,11 @@ export class DataConsistencyService {
 
     await this.syncQueue.add(
       JOB_NAMES.CONSISTENCY_CHECK,
-      {
+      enrichWithCorrelation({
         dataId,
         payload,
         timestamp: new Date(),
-      },
+      }),
       {
         attempts: 3,
         backoff: {

--- a/src/sync/replication/replication.service.ts
+++ b/src/sync/replication/replication.service.ts
@@ -4,6 +4,7 @@ import { InjectQueue } from '@nestjs/bull';
 import { Queue } from 'bull';
 import { QUEUE_NAMES, JOB_NAMES } from '../../common/constants/queue.constants';
 import { TIME } from '../../common/constants/time.constants';
+import { enrichWithCorrelation } from '../../queues/utils/correlation-job.util';
 
 export interface IReplicationEvent {
   entityId: string;
@@ -43,13 +44,17 @@ export class ReplicationService {
       timestamp: new Date(),
     };
 
-    await this.syncQueue.add(JOB_NAMES.REPLICATE_DATA, event, {
-      attempts: 5,
-      backoff: {
-        type: 'exponential',
-        delay: TIME.TWO_SECONDS_MS,
+    await this.syncQueue.add(
+      JOB_NAMES.REPLICATE_DATA,
+      enrichWithCorrelation(event as unknown as Record<string, unknown>),
+      {
+        attempts: 5,
+        backoff: {
+          type: 'exponential',
+          delay: TIME.TWO_SECONDS_MS,
+        },
       },
-    });
+    );
 
     this.eventEmitter.emit('data.replication.started', event);
   }

--- a/src/workers/base/base.worker.spec.ts
+++ b/src/workers/base/base.worker.spec.ts
@@ -1,0 +1,112 @@
+import { ConfigService } from '@nestjs/config';
+import { getSharedRedisClient } from '../../config/cache.config';
+import { BaseWorker } from './base.worker';
+import { getCorrelationId, runWithCorrelationId } from '../../common/utils/correlation.utils';
+import {
+  CORRELATION_JOB_FIELD,
+  enrichWithCorrelation,
+  extractCorrelationIdFromJob,
+} from '../../queues/utils/correlation-job.util';
+
+jest.mock('../../config/cache.config', () => ({
+  getSharedRedisClient: jest.fn(),
+}));
+
+class TestWorker extends BaseWorker {
+  public lastSeenCorrelationId: string | undefined;
+  public jobDataCapture: unknown;
+
+  constructor() {
+    super('test-worker', { get: jest.fn().mockReturnValue(300) } as unknown as ConfigService);
+  }
+
+  async execute(job: { id: number | string; name: string; data: Record<string, unknown> }) {
+    // Capture during execute() to verify ALS propagation works across awaits.
+    this.lastSeenCorrelationId = getCorrelationId();
+    this.jobDataCapture = job.data;
+    return { ok: true };
+  }
+}
+
+const buildJob = (data: Record<string, unknown>) =>
+  ({
+    id: 'job-1',
+    name: 'demo-task',
+    data,
+    progress: jest.fn().mockResolvedValue(undefined),
+  }) as any;
+
+describe('BaseWorker', () => {
+  let redisSet: jest.Mock;
+
+  beforeEach(() => {
+    redisSet = jest.fn().mockResolvedValue('OK');
+    (getSharedRedisClient as jest.Mock).mockReturnValue({
+      set: redisSet,
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('restores the originating correlation ID stamped on the job payload', async () => {
+    const worker = new TestWorker();
+    const enriched = enrichWithCorrelation({ userId: 'u-1' });
+
+    const result = await worker.handle(buildJob(enriched as any));
+
+    expect(result.success).toBe(true);
+    expect(worker.lastSeenCorrelationId).toBe((enriched as any)[CORRELATION_JOB_FIELD]);
+    expect((worker.jobDataCapture as any)[CORRELATION_JOB_FIELD]).toBe(
+      (enriched as any)[CORRELATION_JOB_FIELD],
+    );
+  });
+
+  it('generates a fresh correlation ID when the payload has none (cron / background enqueue)', async () => {
+    const worker = new TestWorker();
+    let observedInExecute: string | undefined;
+
+    const probeWorker = new (class extends BaseWorker {
+      constructor() {
+        super('probe-worker', { get: jest.fn().mockReturnValue(300) } as unknown as ConfigService);
+      }
+      async execute() {
+        observedInExecute = getCorrelationId();
+        return { ok: true };
+      }
+    })();
+
+    await probeWorker.handle(buildJob({ userId: 'u-2' }) as any);
+
+    expect(observedInExecute).toBeDefined();
+    expect(observedInExecute).toMatch(/^cid-/);
+  });
+
+  it('extractCorrelationIdFromJob returns undefined when the payload has no correlation ID', () => {
+    expect(extractCorrelationIdFromJob(buildJob({ foo: 'bar' }))).toBeUndefined();
+  });
+
+  it('extractCorrelationIdFromJob returns undefined for malformed payloads', () => {
+    expect(extractCorrelationIdFromJob({ data: undefined as any })).toBeUndefined();
+    expect(extractCorrelationIdFromJob(buildJob({ foo: 'bar' }))).toBeUndefined();
+  });
+
+  it('does not leak the worker-scoped correlation ID out of runHandle', async () => {
+    const worker = new TestWorker();
+    const enriched = enrichWithCorrelation({ userId: 'u-3' });
+    await worker.handle(buildJob(enriched as any));
+
+    // After handle() resolved the AsyncLocalStorage scope unwinds, so getCorrelationId()
+    // outside should not match the in-worker value.
+    const outside = getCorrelationId();
+    expect(outside).not.toBe(worker.lastSeenCorrelationId);
+  });
+
+  it('runWithCorrelationId nests correctly when invoked twice', async () => {
+    const inner = await runWithCorrelationId(() => getCorrelationId(), 'inner-id');
+    expect(inner).toBe('inner-id');
+    const outer = await runWithCorrelationId(() => getCorrelationId(), 'outer-id');
+    expect(outer).toBe('outer-id');
+  });
+});

--- a/src/workers/base/base.worker.ts
+++ b/src/workers/base/base.worker.ts
@@ -4,6 +4,8 @@ import Redis from 'ioredis';
 import { getSharedRedisClient } from '../../config/cache.config';
 import { ConfigService } from '@nestjs/config';
 import { IWorkerResult, IWorkerMetrics, IWorkerHealthCheck } from '../interfaces/worker.interfaces';
+import { extractCorrelationIdFromJob } from '../../queues/utils/correlation-job.util';
+import { generateCorrelationId, runWithCorrelationId } from '../../common/utils/correlation.utils';
 
 /**
  * Abstract base worker class
@@ -41,9 +43,18 @@ export abstract class BaseWorker {
   abstract execute(job: Job): Promise<any>;
 
   /**
-   * Main handler for processing jobs
+   * Main handler for processing jobs. The entire execution runs inside the
+   * AsyncLocalStorage-backed correlation context so child services / spans
+   * inherit the same correlation ID as the originating HTTP request.
+   * If no correlation ID was stamped onto the job payload (e.g. for cron
+   * enqueues), a fresh one is generated so logs are still grouped.
    */
   async handle(job: Job): Promise<IWorkerResult> {
+    const correlationId = extractCorrelationIdFromJob(job) ?? generateCorrelationId();
+    return runWithCorrelationId(() => this.runHandle(job), correlationId);
+  }
+
+  private async runHandle(job: Job): Promise<IWorkerResult> {
     const startTime = Date.now();
 
     try {


### PR DESCRIPTION
Closes the four open Blaqkenny issues on this repo in one PR:

| Issue | Title | Surface |
|-------|-------|---------|
| #809 | `PayoutsService.getRevenueBreakdown` issues N+1 queries without pagination | `src/payments/payouts/{payouts.service.ts,payouts.controller.ts}` (+ specs) |
| #812 | `CachingService.getOrSet` has no distributed locking causing thundering herd | `src/caching/caching.service.ts` (+ spec), new `src/orchestration/locks/locks.module.ts` |
| #828 | Add OpenTelemetry distributed tracing across all service methods | new `src/observability/tracing/{tracing.interceptor,trace.decorator}.ts`, `src/observability/logging/structured-logger.service.ts`, `src/app.module.ts` (+ specs) |
| #829 | Add correlation ID propagation across async workers and queue jobs | new `src/queues/utils/correlation-job.util.ts`, `src/workers/base/base.worker.ts`, five BullMQ producer sites (+ spec) |

Closes #809
Closes #812 
Closes #828 
Closes #829

Highlights
- **#809** — single QueryBuilder joins two pre-aggregated derived subqueries (per-course payments, per-course refunds) so totals stay correct even when a payment has multiple partial refunds; pagination plumbed through `@Query('page')` and `@Query('pageSize')`.
- **#812** — optional `DistributedLockService` injection in `CachingService.getOrSet`; only the lock holder runs the factory while waiters poll with exponential backoff and fall back to local computation if the holder never publishes.
- **#828** — global `TracingInterceptor` + logger read-from-active-span + `@Trace()` decorator for opt-in finer-grained spans. Compatible with the existing `@opentelemetry/auto-instrumentations-node` baseline.
- **#829** — `enrichWithCorrelation()` / `extractCorrelationIdFromJob()` helpers, `BaseWorker.handle(...)` wraps execution in `runWithCorrelationId` so logs / spans inside the worker inherit the originating HTTP request ID. Five producer sites wired.

Validation
- `npm run lint:ci` — 0 errors
- `npm run typecheck` — passes
- All affected unit suites green locally

Risk
- New global `LocksModule` is registered unconditionally; CachingService falls back to its previous single-process behaviour when no `DistributedLockService` is wired (e.g. consumers that haven't opted in).
- `StructuredLoggerService` now reads from the active OpenTelemetry span at write time — no public API changed; backward-compatible.
- `payouts.controller.ts` query params are additive and optional; clients calling `getRevenueBreakdown(instructorId, {})` continue to work.
