### PR TITLE
feat(i18n): derive supported locales from loaded bundles

### DIFF
--- a/src/i18n/i18n.service.spec.ts
+++ b/src/i18n/i18n.service.spec.ts
@@ -1,0 +1,210 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { I18nWrapperService } from './i18n.service';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Creates a temporary locales root and returns helpers to populate it. */
+function makeTmpLocalesDir() {
+  const root = mkdtempSync(join(tmpdir(), 'i18n-test-'));
+
+  function addLocale(
+    code: string,
+    bundles: Record<string, Record<string, unknown>>,
+    meta?: { name?: string; direction?: 'ltr' | 'rtl' },
+  ) {
+    const dir = join(root, code);
+    mkdirSync(dir, { recursive: true });
+
+    for (const [ns, content] of Object.entries(bundles)) {
+      writeFileSync(join(dir, `${ns}.json`), JSON.stringify(content));
+    }
+
+    if (meta !== undefined) {
+      writeFileSync(join(dir, '_meta.json'), JSON.stringify(meta));
+    }
+  }
+
+  function addBrokenLocale(code: string) {
+    const dir = join(root, code);
+    mkdirSync(dir, { recursive: true });
+    // Write invalid JSON so bundle parsing throws.
+    writeFileSync(join(dir, 'common.json'), '{ INVALID JSON }');
+  }
+
+  return { root, addLocale, addBrokenLocale };
+}
+
+/** Builds an I18nWrapperService pointed at a custom locales path. */
+function makeService(localesPath: string): I18nWrapperService {
+  const svc = new I18nWrapperService();
+  // Override the private localesPath and reload bundles.
+  (svc as any).localesPath = localesPath;
+  (svc as any).supported.length = 0;
+  Object.keys((svc as any).bundles).forEach((k) => delete (svc as any).bundles[k]);
+  (svc as any).loadBundles();
+  return svc;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('I18nWrapperService', () => {
+  let root: string;
+  let addLocale: ReturnType<typeof makeTmpLocalesDir>['addLocale'];
+  let addBrokenLocale: ReturnType<typeof makeTmpLocalesDir>['addBrokenLocale'];
+
+  beforeEach(() => {
+    ({ root, addLocale, addBrokenLocale } = makeTmpLocalesDir());
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  // ── getSupportedLocales matches loaded bundles ──────────────────────────
+
+  describe('getSupportedLocales()', () => {
+    it('returns only the locales whose bundles loaded successfully', () => {
+      addLocale('en', { common: { greeting: 'Hello' } }, { name: 'English', direction: 'ltr' });
+      addLocale('ar', { common: { greeting: 'مرحبا' } }, { name: 'Arabic', direction: 'rtl' });
+
+      const svc = makeService(root);
+      const codes = svc.getSupportedLocales().map((l) => l.code);
+
+      expect(codes).toHaveLength(2);
+      expect(codes).toContain('en');
+      expect(codes).toContain('ar');
+    });
+
+    it('excludes a locale whose bundle file contains invalid JSON', () => {
+      addLocale('en', { common: { greeting: 'Hello' } }, { name: 'English', direction: 'ltr' });
+      addBrokenLocale('fr');
+
+      const svc = makeService(root);
+      const codes = svc.getSupportedLocales().map((l) => l.code);
+
+      expect(codes).toHaveLength(1);
+      expect(codes).toContain('en');
+      expect(codes).not.toContain('fr');
+    });
+
+    it('returns an empty array when no locale directories exist', () => {
+      const svc = makeService(root);
+      expect(svc.getSupportedLocales()).toHaveLength(0);
+    });
+  });
+
+  // ── Adding a new bundle makes the locale appear automatically ────────────
+
+  describe('new locale discovery', () => {
+    it('advertises a newly added locale without any service code change', () => {
+      addLocale('en', { common: { greeting: 'Hello' } }, { name: 'English', direction: 'ltr' });
+      addLocale('es', { common: { greeting: 'Hola' } }, { name: 'Spanish', direction: 'ltr' });
+
+      const svc = makeService(root);
+      const codes = svc.getSupportedLocales().map((l) => l.code);
+
+      expect(codes).toContain('es');
+    });
+
+    it('reports the correct direction for the newly added locale', () => {
+      addLocale('es', { common: { greeting: 'Hola' } }, { name: 'Spanish', direction: 'ltr' });
+
+      const svc = makeService(root);
+      const es = svc.getSupportedLocales().find((l) => l.code === 'es');
+
+      expect(es).toBeDefined();
+      expect(es!.direction).toBe('ltr');
+    });
+
+    it('reports the correct name for the newly added locale', () => {
+      addLocale('es', { common: { greeting: 'Hola' } }, { name: 'Spanish', direction: 'ltr' });
+
+      const svc = makeService(root);
+      const es = svc.getSupportedLocales().find((l) => l.code === 'es');
+
+      expect(es!.name).toBe('Spanish');
+    });
+  });
+
+  // ── Direction is correct for every advertised locale ────────────────────
+
+  describe('direction metadata', () => {
+    it('reads direction from _meta.json when present', () => {
+      addLocale('ar', { common: { greeting: 'مرحبا' } }, { name: 'Arabic', direction: 'rtl' });
+
+      const svc = makeService(root);
+      const ar = svc.getSupportedLocales().find((l) => l.code === 'ar');
+
+      expect(ar!.direction).toBe('rtl');
+    });
+
+    it('falls back to RTL_LANGS inference when _meta.json is absent', () => {
+      // ar is in RTL_LANGS — no _meta.json provided.
+      addLocale('ar', { common: { greeting: 'مرحبا' } });
+
+      const svc = makeService(root);
+      const ar = svc.getSupportedLocales().find((l) => l.code === 'ar');
+
+      expect(ar!.direction).toBe('rtl');
+    });
+
+    it('falls back to ltr when locale is not in RTL_LANGS and _meta.json is absent', () => {
+      addLocale('fr', { common: { greeting: 'Bonjour' } });
+
+      const svc = makeService(root);
+      const fr = svc.getSupportedLocales().find((l) => l.code === 'fr');
+
+      expect(fr!.direction).toBe('ltr');
+    });
+
+    it('uses uppercased code as name when _meta.json is absent', () => {
+      addLocale('fr', { common: { greeting: 'Bonjour' } });
+
+      const svc = makeService(root);
+      const fr = svc.getSupportedLocales().find((l) => l.code === 'fr');
+
+      expect(fr!.name).toBe('FR');
+    });
+
+    it('does not include _meta as a translation namespace', () => {
+      addLocale('en', { common: { greeting: 'Hello' } }, { name: 'English', direction: 'ltr' });
+
+      const svc = makeService(root);
+      // _meta should not appear as a translation key.
+      const result = svc.translate('_meta.name', 'en');
+      // Falls back to the key itself when the namespace doesn't exist.
+      expect(result).toBe('_meta.name');
+    });
+  });
+
+  // ── translate() still works after refactor ───────────────────────────────
+
+  describe('translate()', () => {
+    it('returns the translated string for a loaded bundle', () => {
+      addLocale('en', { common: { greeting: 'Hello' } }, { name: 'English', direction: 'ltr' });
+
+      const svc = makeService(root);
+      expect(svc.translate('common.greeting', 'en')).toBe('Hello');
+    });
+
+    it('falls back to the fallback locale when requested locale is not loaded', () => {
+      addLocale('en', { common: { greeting: 'Hello' } }, { name: 'English', direction: 'ltr' });
+
+      const svc = makeService(root);
+      expect(svc.translate('common.greeting', 'de')).toBe('Hello');
+    });
+
+    it('returns the key when neither the locale nor the fallback has it', () => {
+      addLocale('en', { common: { greeting: 'Hello' } }, { name: 'English', direction: 'ltr' });
+
+      const svc = makeService(root);
+      expect(svc.translate('common.missing_key', 'en')).toBe('common.missing_key');
+    });
+  });
+});

--- a/src/i18n/i18n.service.ts
+++ b/src/i18n/i18n.service.ts
@@ -1,11 +1,31 @@
 import { Injectable, Logger } from '@nestjs/common';
-import { readdirSync, readFileSync } from 'fs';
+import { existsSync, readdirSync, readFileSync } from 'fs';
 import { extname, join } from 'path';
 
+/**
+ * Languages written right-to-left, used as a fallback when a locale directory
+ * does not ship a `_meta.json` file.  The authoritative source of direction for
+ * any locale that *does* provide `_meta.json` is that file.
+ */
 const RTL_LANGS = ['ar', 'he', 'fa', 'ur'];
+
 const DEFAULT_LOCALE = 'en';
 
-interface LocaleDefinition {
+/**
+ * Shape of the optional `_meta.json` file that can be placed inside each
+ * locale directory to supply display metadata.
+ *
+ * Example — `locales/ar/_meta.json`:
+ * ```json
+ * { "name": "Arabic", "direction": "rtl" }
+ * ```
+ */
+interface LocaleMeta {
+  name?: string;
+  direction?: 'ltr' | 'rtl';
+}
+
+export interface LocaleDefinition {
   code: string;
   name: string;
   direction: 'ltr' | 'rtl';
@@ -16,63 +36,121 @@ export class I18nWrapperService {
   private readonly logger = new Logger(I18nWrapperService.name);
   private readonly localesPath = join(__dirname, 'locales');
   private readonly fallbackLocale = DEFAULT_LOCALE;
-  private readonly supported: LocaleDefinition[] = [
-    { code: 'en', name: 'English', direction: 'ltr' },
-    { code: 'ar', name: 'Arabic', direction: 'rtl' },
-  ];
+
+  /**
+   * Populated during construction by {@link loadBundles}.
+   * Contains exactly one entry per locale whose directory was discovered and
+   * whose bundle loaded without error — no more, no less.
+   */
+  private readonly supported: LocaleDefinition[] = [];
+
+  /** Translation bundles keyed by locale code. */
   private readonly bundles: Record<string, Record<string, unknown>> = {};
 
   constructor() {
     this.loadBundles();
   }
 
-  getSupportedLocales() {
+  /**
+   * Returns the set of locales whose bundles actually loaded at startup.
+   * This is the authoritative list for language-picker endpoints.
+   */
+  getSupportedLocales(): LocaleDefinition[] {
     return this.supported;
   }
 
-  getDirection(locale: string) {
+  getDirection(locale: string): 'ltr' | 'rtl' {
     return this.isRtl(locale) ? 'rtl' : 'ltr';
   }
 
-  translate(key: string, locale: string) {
+  translate(key: string, locale: string): string {
     const normalized = this.normalizeLocale(locale);
-    const bundle = this.bundles[normalized] || this.bundles[this.fallbackLocale] || {};
+    const bundle = this.bundles[normalized] ?? this.bundles[this.fallbackLocale] ?? {};
     return this.lookup(bundle, key) ?? key;
   }
 
-  isRtl(locale: string) {
+  isRtl(locale: string): boolean {
     if (!locale) return false;
     return RTL_LANGS.includes(this.normalizeLocale(locale));
   }
 
-  private loadBundles() {
+  // ── Private ───────────────────────────────────────────────────────────────
+
+  /**
+   * Scans `localesPath` for subdirectories, loads every `*.json` file inside
+   * each one as a named namespace (excluding `_meta.json`), and builds the
+   * `supported` list from the directories that loaded successfully.
+   *
+   * `_meta.json` — if present — provides the display name and direction for
+   * the locale.  If it is absent, direction falls back to {@link RTL_LANGS}
+   * and the display name falls back to the uppercased locale code.
+   */
+  private loadBundles(): void {
+    let localeDirs: string[];
+
     try {
-      const localeDirs = readdirSync(this.localesPath, { withFileTypes: true }).filter((entry) =>
-        entry.isDirectory(),
-      );
-      for (const localeDir of localeDirs) {
-        const locale = localeDir.name;
-        const bundle: Record<string, unknown> = {};
+      localeDirs = readdirSync(this.localesPath, { withFileTypes: true })
+        .filter((entry) => entry.isDirectory())
+        .map((entry) => entry.name);
+    } catch (err) {
+      this.logger.error('Failed to read locales directory', err as Error);
+      return;
+    }
+
+    for (const locale of localeDirs) {
+      try {
         const localeFolder = join(this.localesPath, locale);
-        const files = readdirSync(localeFolder, { withFileTypes: true }).filter((entry) =>
-          entry.isFile(),
-        );
+        const bundle: Record<string, unknown> = {};
+
+        const files = readdirSync(localeFolder, { withFileTypes: true }).filter((e) => e.isFile());
 
         for (const file of files) {
+          // _meta.json is metadata, not a translation namespace — skip it here.
+          if (file.name === '_meta.json') continue;
           if (extname(file.name).toLowerCase() !== '.json') continue;
+
           const namespace = file.name.replace(/\.json$/i, '');
           const raw = readFileSync(join(localeFolder, file.name), 'utf8');
-          bundle[namespace] = JSON.parse(raw);
+          bundle[namespace] = JSON.parse(raw) as Record<string, unknown>;
         }
 
         this.bundles[locale] = bundle;
+
+        // Read optional metadata; fall back gracefully if absent or malformed.
+        const meta = this.readMeta(localeFolder, locale);
+
+        this.supported.push({
+          code: locale,
+          name: meta.name ?? locale.toUpperCase(),
+          direction: meta.direction ?? (RTL_LANGS.includes(locale) ? 'rtl' : 'ltr'),
+        });
+
+        this.logger.debug(`Loaded locale bundle: ${locale}`);
+      } catch (err) {
+        // A broken bundle must not advertise the locale as supported.
+        this.logger.error(`Failed to load locale bundle: ${locale}`, err as Error);
       }
-    } catch (error) {
-      this.logger.error('Failed to load locale bundles', error as Error);
     }
   }
 
-  private normalizeLocale(locale: string) {
+  /**
+   * Attempts to read and parse `_meta.json` from `localeFolder`.
+   * Returns an empty object (causing fallbacks to apply) on any error.
+   */
+  private readMeta(localeFolder: string, locale: string): LocaleMeta {
+    const metaPath = join(localeFolder, '_meta.json');
+    if (!existsSync(metaPath)) return {};
+
+    try {
+      const raw = readFileSync(metaPath, 'utf8');
+      return JSON.parse(raw) as LocaleMeta;
+    } catch (err) {
+      this.logger.warn(`Could not parse _meta.json for locale "${locale}"`, err as Error);
+      return {};
+    }
+  }
+
+  private normalizeLocale(locale: string): string {
     return String(locale).split(',')[0].split('-')[0].toLowerCase();
   }
 
@@ -81,9 +159,7 @@ export class I18nWrapperService {
     let result: unknown = bundle;
 
     for (const segment of segments) {
-      if (typeof result !== 'object' || result === null) {
-        return undefined;
-      }
+      if (typeof result !== 'object' || result === null) return undefined;
       result = (result as Record<string, unknown>)[segment];
     }
 

--- a/src/i18n/locales/ar/_meta.json
+++ b/src/i18n/locales/ar/_meta.json
@@ -1,0 +1,4 @@
+{
+  "name": "Arabic",
+  "direction": "rtl"
+}

--- a/src/i18n/locales/en/_meta.json
+++ b/src/i18n/locales/en/_meta.json
@@ -1,0 +1,4 @@
+{
+  "name": "English",
+  "direction": "ltr"
+}


### PR DESCRIPTION
Derive supported locales from loaded bundles
  
  getSupportedLocales() previously returned a hardcoded list of two locales (en, ar) that had no
  connection to the bundle files actually on disk. A translator adding es.json would get a
  working translate() call but the locale would never appear in the language picker. If ar.json
  was missing, Arabic would still be advertised and silently fall back to English. The RTL_LANGS
   constant listed four languages while supported listed two, making the inconsistency visible
  in the file itself.
  
  ───────────────────────────────────────────────────────────────────────────────────────────────
  
  Changes
  
  src/i18n/locales/en/_meta.json and src/i18n/locales/ar/_meta.json (new)
  Each locale directory now carries its own display metadata:
  
  { "name": "Arabic", "direction": "rtl" }
  
  Metadata lives alongside the translations it describes. Adding a new locale means dropping a
  directory with bundle files and a _meta.json — no service edits required.
  
  src/i18n/i18n.service.ts
  
  - Removed the hardcoded supported literal entirely.
  - loadBundles() builds supported[] dynamically from whatever locale directories are present at
  startup.
  - For each directory that loads without error, _meta.json is read for name and direction. If
  absent or malformed, direction falls back to the RTL_LANGS check and name falls back to the
  uppercased locale code — existing bundles without a _meta.json continue to work.
  - _meta.json is explicitly skipped as a translation namespace so it never surfaces through
  translate().
  - A locale whose bundle throws (malformed JSON, unreadable file) is caught per-locale, logged,
  and excluded from supported. It cannot be advertised if it cannot serve translations.
  
  src/i18n/i18n.service.spec.ts (new, 14 tests)
  Tests use a fresh temporary directory per test run — fully isolated from the real locale files.
  Covers:
  
  - getSupportedLocales() returns exactly the set of loaded bundles
  - A locale with a broken bundle is excluded
  - An empty locales directory returns an empty list
  - Dropping a new locale directory (es) makes it appear with no service code change
  - Direction and name are read from _meta.json when present
  - RTL fallback (from RTL_LANGS) when _meta.json is absent
  - LTR fallback when locale is not in RTL_LANGS and _meta.json is absent
  - Name fallback to uppercased code when _meta.json is absent
  - _meta is not exposed as a translation namespace
  - translate() happy path, fallback locale, and missing-key passthrough
  
  ───────────────────────────────────────────────────────────────────────────────────────────────
  
  Testing
  
  pnpm test --testPathPattern="i18n.service"   # 14/14 pass
  pnpm typecheck                                # clean
  
  ───────────────────────────────────────────────────────────────────────────────────────────────
  
  Acceptance checklist
  
  - [x] getSupportedLocales() matches the set of loaded bundles exactly
  - [x] Direction is correct for every advertised locale
  - [x] Adding a bundle requires no change to the service source
  closes #1036 