### PR TITLE
chore: remove build artifacts from git tracking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,30 @@ on:
   pull_request:
 
 jobs:
+  # ── Guard: build artifacts must never be committed ────────────────────────
+  # Scans the git index for dist/ files and *.tsbuildinfo files.
+  # These are machine-generated outputs; committing them causes large diffs,
+  # guaranteed merge conflicts, and the risk of deploying a stale build.
+  no-build-artifacts:
+    name: No build artifacts in git
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Fail if build artifacts are tracked
+        run: |
+          ARTIFACTS=$(git ls-files 'dist/' '*.tsbuildinfo')
+          if [ -n "$ARTIFACTS" ]; then
+            echo "::error::Build artifacts found in git index. Remove them with 'git rm --cached' and add to .gitignore."
+            echo ""
+            echo "Offending paths:"
+            echo "$ARTIFACTS"
+            exit 1
+          fi
+          echo "✓ No build artifacts tracked."
+
+  # ── Main validation pipeline ──────────────────────────────────────────────
   validate:
     runs-on: ubuntu-latest
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
-# compiled output
+# Build outputs — generated files, never committed.
+# dist/ is produced by `npm run build`; *.tsbuildinfo are TypeScript
+# incremental build caches that are machine-specific and must not be
+# shared via version control.
 /dist
 /node_modules
 /build
@@ -77,7 +80,6 @@ terraform.rc
 
 # Terraform crash log
 crash.log
-tsconfig.build.tsbuildinfo
 
 # Backups
 /backups


### PR DESCRIPTION
emove build artifacts from git tracking
  
  tsconfig.build.tsbuildinfo was committed to the repository despite a .gitignore rule intended
  to exclude it. A committed incremental build cache causes TypeScript to skip recompilation
  based on another machine's timestamps, producing builds that differ between CI and a
  developer's checkout. A committed dist/ carries the same risk: any deployment process running
  node dist/main.js can serve a stale build without a fresh compile. Both artifacts also generate
  large, semantically meaningless diffs and guaranteed merge conflicts on every build.
  
  ───────────────────────────────────────────────────────────────────────────────────────────────
  
  Changes
  
  .gitignore
  
  - Replaced the scattered duplicate entries (*.tsbuildinfo on line 5 and a redundant
  tsconfig.build.tsbuildinfo on line 80) with a single consolidated block at the top of the file.
  - Added an explanatory comment so the intent is clear to future contributors.
  
  # Build outputs — generated files, never committed.
  # dist/ is produced by `npm run build`; *.tsbuildinfo are TypeScript
  # incremental build caches that are machine-specific and must not be
  # shared via version control.
  /dist
  /build
  *.tsbuildinfo
  
  git rm --cached (verified, no action needed)
  
  - tsconfig.build.tsbuildinfo was already removed from the index in a prior commit (021d2e5).
  dist/ does not exist on disk. git ls-files confirms neither path is tracked.
  
  Dockerfile (verified, no change needed)
  
  - The multi-stage build already runs RUN npm run build in the builder stage and copies only
  dist/ into the production image. It never relies on a committed artifact.
  
  .github/workflows/ci.yml
  
  - Added a no-build-artifacts job that runs on every push and pull request, independent of the
  main validate job.
  - Immediately after checkout it runs git ls-files 'dist/' '*.tsbuildinfo'. If any match is
  found it emits a GitHub Actions ::error:: annotation listing the offending paths and exits 1.
  - Uses only git — no Node, no pnpm install — so it fails fast before dependency installation.
  
  ───────────────────────────────────────────────────────────────────────────────────────────────
  
  Acceptance checklist
  
  - [x] git ls-files returns no path under dist/ and no .tsbuildinfo
  - [x] Dockerfile builds from source, not from a committed artifact
  - [x] CI rejects any PR that reintroduces build outputs

closes #1044 