### PR TITLE
fix: consolidate privileged role checks into shared hasRole helper

### DIFF
--- a/src/courses/courses.service.ts
+++ b/src/courses/courses.service.ts
@@ -12,7 +12,7 @@ import {
   BulkOperationStatus,
   BulkOperationType,
 } from './entities/bulk-operation.entity';
-import { User } from '../users/entities/user.entity';
+import { User, PRIVILEGED_ROLES } from '../users/entities/user.entity';
 import { CreateCourseDto } from './dto/create-course.dto';
 import { UpdateCourseDto } from './dto/update-course.dto';
 import { SubmitForReviewDto } from './dto/submit-for-review.dto';
@@ -107,11 +107,7 @@ export class CoursesService {
   ): Promise<OffsetPaginatedResponse<Course>> {
     const page = query?.page ?? 1;
     const limit = query?.limit ?? 20;
-    const isPrivileged =
-      requestingUser &&
-      requestingUser.roles?.some((role) =>
-        ['admin', 'moderator'].includes(typeof role === 'string' ? role : role.name),
-      );
+    const isPrivileged = requestingUser?.hasRole(...PRIVILEGED_ROLES) ?? false;
 
     const where = isPrivileged ? {} : { status: CourseStatus.PUBLISHED };
     const [data, total] = await this.courseRepo.findAndCount({
@@ -390,20 +386,13 @@ export class CoursesService {
   }
 
   private assertPrivileged(user: User): void {
-    const isPrivileged = user.roles?.some((role) =>
-      ['admin', 'moderator'].includes(typeof role === 'string' ? role : role.name),
-    );
-    if (!isPrivileged) {
+    if (!user.hasRole(...PRIVILEGED_ROLES)) {
       throw new ForbiddenOperationException('Only admins or moderators may perform this action.');
     }
   }
 
   private assertOwnerOrPrivileged(course: Course, user: User): void {
-    const isOwner = course.instructorId === user.id;
-    const isPrivileged = user.roles?.some((role) =>
-      ['admin', 'moderator'].includes(typeof role === 'string' ? role : role.name),
-    );
-    if (!isOwner && !isPrivileged) {
+    if (course.instructorId !== user.id && !user.hasRole(...PRIVILEGED_ROLES)) {
       throw new ForbiddenOperationException('Insufficient permissions.');
     }
   }
@@ -500,9 +489,7 @@ export class CoursesService {
       throw new ResourceNotFoundException('Bulk operation', operationId);
     }
 
-    const isInitiator = op.initiatedById === user.id;
-    const isPrivileged = user.roles.some((role) => ['admin', 'moderator'].includes(role.name));
-    if (!isInitiator && !isPrivileged) {
+    if (op.initiatedById !== user.id && !user.hasRole(...PRIVILEGED_ROLES)) {
       throw new ForbiddenOperationException(
         'Only the initiator or an admin/moderator may undo this operation.',
       );
@@ -563,7 +550,7 @@ export class CoursesService {
     apply: (course: Course) => BulkCourseSnapshot['previous'];
   }): Promise<BulkOperation> {
     const { type, payload, courseIds, user, apply } = args;
-    const isPrivileged = user.roles.some((role) => ['admin', 'moderator'].includes(role.name));
+    const isPrivileged = user.hasRole(...PRIVILEGED_ROLES);
 
     const courses = await this.courseRepo.find({ where: { id: In(courseIds) } });
     const found = new Map(courses.map((c) => [c.id, c]));

--- a/src/courses/enrollments.service.ts
+++ b/src/courses/enrollments.service.ts
@@ -11,7 +11,7 @@ import { EventEmitter2 } from '@nestjs/event-emitter';
 
 import { Course, CourseStatus } from './entities/course.entity';
 import { Enrollment } from './entities/enrollment.entity';
-import { User } from '../users/entities/user.entity';
+import { User, PRIVILEGED_ROLES } from '../users/entities/user.entity';
 
 import { CACHE_EVENTS } from '../caching/caching.constants';
 import { APP_EVENTS } from '../common/constants/event.constants';
@@ -376,11 +376,7 @@ export class EnrollmentsService {
    * Check admin/moderator role.
    */
   private isPrivileged(user: User): boolean {
-    return (
-      user.roles?.some((role) =>
-        ['admin', 'moderator'].includes(typeof role === 'string' ? role : role.name),
-      ) ?? false
-    );
+    return user.hasRole(...PRIVILEGED_ROLES);
   }
 
   /**

--- a/src/moderation/reports/content-reporting.service.spec.ts
+++ b/src/moderation/reports/content-reporting.service.spec.ts
@@ -8,6 +8,7 @@ import { ContentReport } from './content-report.entity';
 import { ContentReportingService } from './content-reporting.service';
 import { ContentReportDisposition } from './dto/review-content-report.dto';
 import { ReportAssignmentService } from '../assignment/report-assignment.service';
+import { User } from '../../users/entities/user.entity';
 
 const mockRepo = {
   create: jest.fn(),
@@ -28,15 +29,15 @@ const mockReportAssignmentService = {
 describe('ContentReportingService', () => {
   let service: ContentReportingService;
 
-  const reporter = {
+  const reporter = Object.assign(new User(), {
     id: 'reporter-1',
     roles: [{ name: 'student' }],
-  } as any;
+  }) as User;
 
-  const moderator = {
+  const moderator = Object.assign(new User(), {
     id: 'moderator-1',
     roles: [{ name: 'moderator' }],
-  } as any;
+  }) as User;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({

--- a/src/moderation/reports/content-reporting.service.ts
+++ b/src/moderation/reports/content-reporting.service.ts
@@ -7,7 +7,7 @@ import {
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { FindOptionsWhere, Repository } from 'typeorm';
-import { User } from '../../users/entities/user.entity';
+import { User, PRIVILEGED_ROLES } from '../../users/entities/user.entity';
 import { ManualReviewService } from '../manual/manual-review.service';
 import { ReportAssignmentService } from '../assignment/report-assignment.service';
 import { ContentReportReason } from './content-report-reason.enum';
@@ -151,17 +151,13 @@ export class ContentReportingService {
   }
 
   private assertModerator(user: User): void {
-    const isPrivileged =
-      user.roles?.some((role) => ['admin', 'moderator'].includes(role.name)) ?? false;
-    if (!isPrivileged) {
+    if (!user.hasRole(...PRIVILEGED_ROLES)) {
       throw new ForbiddenException('Only admins or moderators may access the reporting queue.');
     }
   }
 
   private canViewReport(report: ContentReport, user: User): boolean {
-    const isPrivileged =
-      user.roles?.some((role) => ['admin', 'moderator'].includes(role.name)) ?? false;
-    return isPrivileged || report.reporterId === user.id;
+    return user.hasRole(...PRIVILEGED_ROLES) || report.reporterId === user.id;
   }
 
   private buildQueueSummary(report: ContentReport): string {

--- a/src/users/entities/user.entity.spec.ts
+++ b/src/users/entities/user.entity.spec.ts
@@ -34,3 +34,51 @@ describe('User entity - role getter', () => {
     expect(user.role).toBe(UserRole.STUDENT);
   });
 });
+
+describe('User entity - hasRole', () => {
+  it('should throw when roles relation is not loaded', () => {
+    const user = new User();
+    expect(() => user.hasRole(UserRole.ADMIN)).toThrow(
+      'User.roles relation not loaded. Include relations: ["roles"] in the query.',
+    );
+  });
+
+  it('should return true when a hydrated entity role matches', () => {
+    const user = new User();
+    (user as any).roles = [{ name: 'admin' }, { name: 'moderator' }];
+    expect(user.hasRole(UserRole.ADMIN)).toBe(true);
+    expect(user.hasRole(UserRole.MODERATOR)).toBe(true);
+  });
+
+  it('should return true when a plain string role matches', () => {
+    const user = new User();
+    (user as any).roles = ['admin', 'moderator'];
+    expect(user.hasRole(UserRole.ADMIN)).toBe(true);
+    expect(user.hasRole(UserRole.MODERATOR)).toBe(true);
+  });
+
+  it('should return false when no role matches', () => {
+    const user = new User();
+    (user as any).roles = [{ name: 'student' }];
+    expect(user.hasRole(UserRole.ADMIN)).toBe(false);
+    expect(user.hasRole(UserRole.MODERATOR)).toBe(false);
+  });
+
+  it('should return false for an empty roles array', () => {
+    const user = new User();
+    (user as any).roles = [];
+    expect(user.hasRole(UserRole.ADMIN)).toBe(false);
+  });
+
+  it('should match any of multiple target roles', () => {
+    const user = new User();
+    (user as any).roles = [{ name: 'moderator' }];
+    expect(user.hasRole(UserRole.ADMIN, UserRole.MODERATOR)).toBe(true);
+  });
+
+  it('should handle mixed string and entity roles in the same array', () => {
+    const user = new User();
+    (user as any).roles = ['student', { name: 'admin' }];
+    expect(user.hasRole(UserRole.ADMIN)).toBe(true);
+  });
+});

--- a/src/users/entities/user.entity.ts
+++ b/src/users/entities/user.entity.ts
@@ -30,6 +30,8 @@ export enum UserStatus {
   SUSPENDED = 'suspended',
 }
 
+export const PRIVILEGED_ROLES: UserRole[] = [UserRole.ADMIN, UserRole.MODERATOR];
+
 /**
  * Represents the user entity.
  */
@@ -136,6 +138,16 @@ export class User {
       return this.roles[0].name as UserRole;
     }
     return UserRole.STUDENT;
+  }
+
+  hasRole(...roleNames: UserRole[]): boolean {
+    if (this.roles === undefined) {
+      throw new Error('User.roles relation not loaded. Include relations: ["roles"] in the query.');
+    }
+    return this.roles.some((role) => {
+      const name = typeof role === 'string' ? role : role.name;
+      return roleNames.includes(name as UserRole);
+    });
   }
 
   @OneToMany(() => Course, (course) => course.instructor)


### PR DESCRIPTION
 Closes #1052

# Summary

Centralizes privileged-role checks behind a shared helper on the `User` entity, eliminating duplicated authorization logic and string literals across the codebase.

This refactor also resolves the inconsistency where user roles could be represented as either hydrated `Role` entities or plain strings by normalizing that behavior in a single location.

## What Changed

### Added a shared role helper

- Added `User.hasRole(...roleNames)` to encapsulate role lookup logic.
- Added a shared `PRIVILEGED_ROLES` constant using the existing typed `UserRole` enum.
- The helper transparently supports both:
  - Hydrated `Role` entities
  - Plain string role names

### Replaced duplicated privilege checks

Removed inline privileged-role checks from service classes and replaced them with:

```ts
user.hasRole(...PRIVILEGED_ROLES)
```

Updated call sites in:

- `src/courses/courses.service.ts`
- `src/courses/enrollments.service.ts`
- `src/moderation/reports/content-reporting.service.ts`

### Added unit tests

Extended `user.entity.spec.ts` to cover:

- Hydrated role entities
- String role representations
- Mixed role representations
- Empty role collections
- Multiple target roles
- Non-matching roles
- Unhydrated `roles` relation

### Test updates

Updated moderation reporting tests to instantiate real `User` entities so the new helper is exercised during testing.

## Benefits

- Removes duplicated authorization logic
- Eliminates hard-coded role name string literals
- Centralizes role normalization in one place
- Fixes call sites that previously assumed roles were always hydrated entities
- Makes future privilege changes require updates in only one location

## Verification

The following verification was completed successfully:

```bash
pnpm test
pnpm run lint:ci
pnpm run typecheck
pnpm run build
```

All checks pass successfully.

## Acceptance Criteria

- [x] No privileged-role checks remain inline in service classes
- [x] Role names use typed constants instead of string literals
- [x] Role normalization is centralized in a shared helper
- [x] Unit tests cover hydrated roles, string roles, and the unhydrated relation case