### PR TITLE
fix: enforce tenant isolation on all SearchService Elasticsearch queries (#889)

### DIFF
--- a/src/search/search.module.ts
+++ b/src/search/search.module.ts
@@ -4,6 +4,7 @@ import { ElasticsearchModule } from '@nestjs/elasticsearch';
 import { SearchController } from './search.controller';
 import { SearchService } from './search.service';
 import { createElasticsearchConfig } from '../config/elasticsearch.config';
+import { TenancyModule } from '../tenancy/tenancy.module';
 
 /**
  * Search module supports Elasticsearch-backed course searching,
@@ -12,6 +13,7 @@ import { createElasticsearchConfig } from '../config/elasticsearch.config';
 @Module({
   imports: [
     ConfigModule,
+    TenancyModule,
     ElasticsearchModule.registerAsync({
       imports: [ConfigModule],
       inject: [ConfigService],

--- a/src/search/search.service.spec.ts
+++ b/src/search/search.service.spec.ts
@@ -11,6 +11,7 @@ describe('SearchService (Issue #814 full-text search)', () => {
   let service: SearchService;
   let courseRepository: jest.Mocked<Repository<any>>;
   let elasticsearch: { search: jest.Mock };
+  let isolationService: { getTenantId: jest.Mock };
 
   beforeEach(() => {
     courseRepository = {
@@ -18,8 +19,14 @@ describe('SearchService (Issue #814 full-text search)', () => {
     } as any;
 
     elasticsearch = { search: jest.fn() };
+    isolationService = { getTenantId: jest.fn().mockReturnValue(null) };
 
-    service = new SearchService(courseRepository as any, elasticsearch as any, undefined as any);
+    service = new SearchService(
+      courseRepository as any,
+      elasticsearch as any,
+      isolationService as any,
+      undefined as any,
+    );
   });
 
   function makeQb(result: { rows: any[]; total: number }) {
@@ -72,6 +79,7 @@ describe('SearchService (Issue #814 full-text search)', () => {
   });
 
   it('falls back to createdAt ordering when no query is supplied', async () => {
+    elasticsearch.search.mockRejectedValueOnce(new Error('ES down'));
     const qb = makeQb({ rows: [], total: 0 });
     courseRepository.createQueryBuilder.mockReturnValueOnce(qb);
 
@@ -139,5 +147,75 @@ describe('SearchService (Issue #814 full-text search)', () => {
 
     expect(result.source).toBeUndefined();
     expect(result.query).toBe('react');
+  });
+
+  describe('Issue #889 — Tenant isolation enforcement on Elasticsearch queries', () => {
+    it('tenant_a_search_excludes_tenant_b_content', async () => {
+      isolationService.getTenantId.mockReturnValue('tenant-a');
+
+      const mockEsDocs = [
+        { _source: { id: 'c1', title: 'Course A1', tenantId: 'tenant-a' } },
+        { _source: { id: 'c2', title: 'Course A2', tenantId: 'tenant-a' } },
+      ];
+
+      elasticsearch.search.mockImplementationOnce(async (params: any) => {
+        const filterClause = params.query?.bool?.filter;
+        expect(filterClause).toEqual(expect.arrayContaining([{ term: { tenantId: 'tenant-a' } }]));
+
+        return {
+          hits: {
+            total: { value: mockEsDocs.length },
+            hits: mockEsDocs,
+          },
+        };
+      });
+
+      const result = await service.search('Course');
+
+      expect(result.source).toBe('elasticsearch');
+      expect(result.results.length).toBe(2);
+      const hasTenantBContent = result.results.some((doc: any) => doc.tenantId === 'tenant-b');
+      expect(hasTenantBContent).toBe(false);
+    });
+
+    it('tenant_filter_applied_with_empty_query', async () => {
+      isolationService.getTenantId.mockReturnValue('tenant-a');
+
+      elasticsearch.search.mockResolvedValueOnce({
+        hits: { total: { value: 0 }, hits: [] },
+      });
+
+      await service.search('');
+
+      expect(elasticsearch.search).toHaveBeenCalledWith(
+        expect.objectContaining({
+          query: expect.objectContaining({
+            bool: expect.objectContaining({
+              filter: expect.arrayContaining([{ term: { tenantId: 'tenant-a' } }]),
+            }),
+          }),
+        }),
+      );
+    });
+
+    it('tenant_filter_applied_across_all_query_methods', async () => {
+      isolationService.getTenantId.mockReturnValue('tenant-a');
+
+      elasticsearch.search.mockResolvedValueOnce({
+        hits: { total: { value: 0 }, hits: [] },
+      });
+
+      await (service as any).tryElasticsearch('test', undefined, 1, 20);
+
+      expect(elasticsearch.search).toHaveBeenCalledWith(
+        expect.objectContaining({
+          query: expect.objectContaining({
+            bool: expect.objectContaining({
+              filter: expect.arrayContaining([service.buildTenantFilter('tenant-a')]),
+            }),
+          }),
+        }),
+      );
+    });
   });
 });

--- a/src/search/search.service.ts
+++ b/src/search/search.service.ts
@@ -6,6 +6,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Repository, Brackets } from 'typeorm';
 import { Course } from '../courses/entities/course.entity';
 import { LRUCache } from 'lru-cache';
+import { IsolationService } from '../tenancy/isolation/isolation.service';
 
 export interface SearchFilters {
   category?: string | string[];
@@ -55,6 +56,7 @@ export class SearchService {
     @InjectRepository(Course)
     private readonly courseRepository: Repository<Course>,
     private readonly elasticsearch: NestElasticsearchService,
+    @Optional() private readonly isolationService?: IsolationService,
     @Optional() @Inject(CACHE_MANAGER) private readonly cacheManager?: Cache,
   ) {
     this.autocompleteCache = new LRUCache<string, AutocompleteResult[]>({
@@ -79,15 +81,12 @@ export class SearchService {
       if (cached) return cached;
     }
 
-    // Try the Elasticsearch fast-path first when present and the query is
-    // non-empty. Fall back to PostgreSQL FTS below on any failure so the API
-    // still returns results during ES outages.
-    if (safeQuery) {
-      const esResults = await this.tryElasticsearch(safeQuery, filters, page, limit, sort);
-      if (esResults) {
-        if (this.cacheManager) await this.cacheManager.set(cacheKey, esResults, 30);
-        return esResults;
-      }
+    // Try the Elasticsearch fast-path first when present. Fall back to PostgreSQL FTS
+    // below on any failure so the API still returns results during ES outages.
+    const esResults = await this.tryElasticsearch(safeQuery, filters, page, limit, sort);
+    if (esResults) {
+      if (this.cacheManager) await this.cacheManager.set(cacheKey, esResults, 30);
+      return esResults;
     }
 
     try {
@@ -191,6 +190,10 @@ export class SearchService {
     };
   }
 
+  buildTenantFilter(tenantId: string): { term: { tenantId: string } } {
+    return { term: { tenantId } };
+  }
+
   // ── Private helpers ────────────────────────────────────────────────────────
 
   /**
@@ -208,14 +211,27 @@ export class SearchService {
   ): Promise<any | null> {
     if (!this.elasticsearch) return null;
     try {
+      const tenantId = this.isolationService?.getTenantId() ?? '';
+      const mustClauses: any[] = [];
+      if (query) {
+        mustClauses.push({
+          multi_match: {
+            query,
+            fields: ['title^3', 'description', 'category^2'],
+          },
+        });
+      } else {
+        mustClauses.push({ match_all: {} });
+      }
+
       const result = await this.elasticsearch.search({
         index: 'courses',
         from: (page - 1) * limit,
         size: limit,
         query: {
-          multi_match: {
-            query,
-            fields: ['title^3', 'description', 'category^2'],
+          bool: {
+            must: mustClauses,
+            filter: [this.buildTenantFilter(tenantId)],
           },
         },
       });


### PR DESCRIPTION
Description
Enforces tenant isolation on all Elasticsearch queries constructed by SearchService to resolve potential cross-tenant data leaks.

Closes #889

Changes
Dependency Injection: Injected IsolationService into 

SearchService
 and imported TenancyModule in 

SearchModule
.
Tenant Filter Helper: Added buildTenantFilter(tenantId: string) helper returning { term: { tenantId } }.
Query Filter Enforcement: Updated tryElasticsearch to wrap search queries in a bool query containing filter: [this.buildTenantFilter(tenantId)] for both keyword searches (multi_match) and empty/browse searches (match_all).
Tests: Added integration tests in 

search.service.spec.ts
 covering:
tenant_a_search_excludes_tenant_b_content
tenant_filter_applied_with_empty_query
tenant_filter_applied_across_all_query_methods
