### PR TITLE
perf(auth): replace bcrypt with HMAC-SHA-256 for refresh token verifi…

### DIFF
--- a/scripts/benchmark-refresh-token.ts
+++ b/scripts/benchmark-refresh-token.ts
@@ -1,0 +1,268 @@
+/**
+ * Benchmark: Refresh Token Verification Throughput
+ *
+ * Compares the performance of three approaches for refresh token hashing/verification:
+ *   1. bcrypt (cost factor 12) — the original approach
+ *   2. SHA-256 + timingSafeEqual — intermediate approach
+ *   3. HMAC-SHA-256 + timingSafeEqual — the current approach
+ *
+ * Run with:
+ *   npx ts-node scripts/benchmark-refresh-token.ts
+ */
+
+import * as bcrypt from 'bcrypt';
+import * as crypto from 'crypto';
+
+// ---------------------------------------------------------------------------
+// Configuration
+// ---------------------------------------------------------------------------
+const BCRYPT_ROUNDS = 12;
+const WARMUP_OPS = 50;
+const BENCHMARK_DURATION_MS = 5_000; // run each benchmark for up to 5 s
+const HMAC_SECRET = 'benchmark-test-secret-key-for-hmac-sha-256';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function generateTestToken(): string {
+  return crypto.randomBytes(48).toString('hex');
+}
+
+function sha256Hex(value: string): string {
+  return crypto.createHash('sha256').update(value).digest('hex');
+}
+
+function hmacSha256Hex(secret: string, value: string): string {
+  return crypto.createHmac('sha256', secret).update(value).digest('hex');
+}
+
+/**
+ * Run a single benchmark: execute `op` as many times as possible within
+ * `durationMs` milliseconds (after a warm-up phase). Returns ops/sec and ms/op.
+ */
+async function runBenchmark(
+  label: string,
+  durationMs: number,
+  warmupOps: number,
+  op: () => Promise<void> | void,
+): Promise<{ opsPerSec: number; msPerOp: number }> {
+  // Warm-up
+  for (let i = 0; i < warmupOps; i++) {
+    await op();
+  }
+
+  // Timed run
+  const start = process.hrtime.bigint();
+  const endNs = BigInt(durationMs) * 1_000_000n; // ms → ns
+  let count = 0;
+
+  while (true) {
+    await op();
+    count++;
+    const elapsed = process.hrtime.bigint() - start;
+    if (elapsed >= endNs) break;
+  }
+
+  const elapsedNs = Number(process.hrtime.bigint() - start);
+  const elapsedMs = elapsedNs / 1_000_000;
+  const opsPerSec = Math.round((count / elapsedMs) * 1000);
+  const msPerOp = parseFloat((elapsedMs / count).toFixed(4));
+
+  return { opsPerSec, msPerOp };
+}
+
+// ---------------------------------------------------------------------------
+// Table formatting
+// ---------------------------------------------------------------------------
+
+function padRight(str: string, width: number): string {
+  return str.length >= width ? str : str + ' '.repeat(width - str.length);
+}
+
+function padCenter(str: string, width: number): string {
+  if (str.length >= width) return str;
+  const totalPad = width - str.length;
+  const leftPad = Math.floor(totalPad / 2);
+  const rightPad = totalPad - leftPad;
+  return ' '.repeat(leftPad) + str + ' '.repeat(rightPad);
+}
+
+function padLeft(str: string, width: number): string {
+  return str.length >= width ? str : ' '.repeat(width - str.length) + str;
+}
+
+function printTable(
+  results: Array<{ label: string; opsPerSec: number; msPerOp: number }>,
+): void {
+  const colMethod = 32;
+  const colOps = 14;
+  const colMsOp = 16;
+  const colVs = 12;
+
+  const topBorder =
+    '╔' +
+    '═'.repeat(colMethod + 2) +
+    '╦' +
+    '═'.repeat(colOps + 2) +
+    '╦' +
+    '═'.repeat(colMsOp + 2) +
+    '╦' +
+    '═'.repeat(colVs + 2) +
+    '╗';
+
+  const headerSep =
+    '╠' +
+    '═'.repeat(colMethod + 2) +
+    '╬' +
+    '═'.repeat(colOps + 2) +
+    '╬' +
+    '═'.repeat(colMsOp + 2) +
+    '╬' +
+    '═'.repeat(colVs + 2) +
+    '╣';
+
+  const bottomBorder =
+    '╚' +
+    '═'.repeat(colMethod + 2) +
+    '╩' +
+    '═'.repeat(colOps + 2) +
+    '╩' +
+    '═'.repeat(colMsOp + 2) +
+    '╩' +
+    '═'.repeat(colVs + 2) +
+    '╝';
+
+  const headerRow =
+    '║ ' +
+    padRight('Method', colMethod) +
+    ' ║ ' +
+    padCenter('Ops/sec', colOps) +
+    ' ║ ' +
+    padCenter('ms/op', colMsOp) +
+    ' ║ ' +
+    padCenter('vs bcrypt', colVs) +
+    ' ║';
+
+  const bcryptOps = results[0].opsPerSec;
+
+  console.log('');
+  console.log(topBorder);
+  console.log(headerRow);
+  console.log(headerSep);
+
+  for (const r of results) {
+    const multiplier = (bcryptOps / r.opsPerSec).toFixed(1);
+    const vsBcrypt =
+      r === results[0] ? '1.0x' : `${(r.opsPerSec / bcryptOps).toFixed(1)}x`;
+
+    const row =
+      '║ ' +
+      padRight(r.label, colMethod) +
+      ' ║ ' +
+      padLeft(r.opsPerSec.toLocaleString(), colOps) +
+      ' ║ ' +
+      padLeft(r.msPerOp.toFixed(4), colMsOp) +
+      ' ║ ' +
+      padCenter(vsBcrypt, colVs) +
+      ' ║';
+
+    console.log(row);
+  }
+
+  console.log(bottomBorder);
+  console.log('');
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main(): Promise<void> {
+  console.log('═══════════════════════════════════════════════════════════════');
+  console.log('  Refresh Token Verification Benchmark');
+  console.log('  bcrypt vs SHA-256 vs HMAC-SHA-256');
+  console.log('═══════════════════════════════════════════════════════════════');
+  console.log('');
+  console.log(`  Bcrypt rounds : ${BCRYPT_ROUNDS}`);
+  console.log(`  Warm-up ops   : ${WARMUP_OPS}`);
+  console.log(`  Benchmark time: ${BENCHMARK_DURATION_MS / 1000}s per method`);
+  console.log('');
+
+  const token = generateTestToken();
+  console.log(`  Test token (hex): ${token.substring(0, 32)}...`);
+  console.log('');
+
+  // -----------------------------------------------------------------------
+  // 1. bcrypt (cost 12)
+  // -----------------------------------------------------------------------
+  console.log('  [1/3] Benchmarking bcrypt (cost 12) ...');
+  const bcryptHash = await bcrypt.hash(token, BCRYPT_ROUNDS);
+
+  const bcryptResult = await runBenchmark(
+    'bcrypt (cost 12)',
+    BENCHMARK_DURATION_MS,
+    WARMUP_OPS,
+    async () => {
+      await bcrypt.compare(token, bcryptHash);
+    },
+  );
+  console.log(`         → ${bcryptResult.opsPerSec.toLocaleString()} ops/sec, ${bcryptResult.msPerOp.toFixed(2)} ms/op`);
+
+  // -----------------------------------------------------------------------
+  // 2. SHA-256 + timingSafeEqual
+  // -----------------------------------------------------------------------
+  console.log('  [2/3] Benchmarking SHA-256 + timingSafeEqual ...');
+  const sha256Hash = sha256Hex(token);
+  const sha256Buf = Buffer.from(sha256Hash, 'hex');
+
+  const sha256Result = await runBenchmark(
+    'SHA-256 + timingSafeEqual',
+    BENCHMARK_DURATION_MS,
+    WARMUP_OPS,
+    () => {
+      const candidate = Buffer.from(sha256Hex(token), 'hex');
+      crypto.timingSafeEqual(candidate, sha256Buf);
+    },
+  );
+  console.log(`         → ${sha256Result.opsPerSec.toLocaleString()} ops/sec, ${sha256Result.msPerOp.toFixed(4)} ms/op`);
+
+  // -----------------------------------------------------------------------
+  // 3. HMAC-SHA-256 + timingSafeEqual
+  // -----------------------------------------------------------------------
+  console.log('  [3/3] Benchmarking HMAC-SHA-256 + timingSafeEqual ...');
+  const hmacHash = hmacSha256Hex(HMAC_SECRET, token);
+  const hmacBuf = Buffer.from(hmacHash, 'hex');
+
+  const hmacResult = await runBenchmark(
+    'HMAC-SHA-256 + timingSafeEqual',
+    BENCHMARK_DURATION_MS,
+    WARMUP_OPS,
+    () => {
+      const candidate = Buffer.from(hmacSha256Hex(HMAC_SECRET, token), 'hex');
+      crypto.timingSafeEqual(candidate, hmacBuf);
+    },
+  );
+  console.log(`         → ${hmacResult.opsPerSec.toLocaleString()} ops/sec, ${hmacResult.msPerOp.toFixed(4)} ms/op`);
+
+  // -----------------------------------------------------------------------
+  // Comparison table
+  // -----------------------------------------------------------------------
+  const results = [
+    { label: 'bcrypt (cost 12)', ...bcryptResult },
+    { label: 'SHA-256 + timingSafeEqual', ...sha256Result },
+    { label: 'HMAC-SHA-256 + timingSafeEqual', ...hmacResult },
+  ];
+
+  printTable(results);
+
+  // Summary
+  const speedup = (hmacResult.opsPerSec / bcryptResult.opsPerSec).toFixed(0);
+  console.log(`  Summary: HMAC-SHA-256 is ~${speedup}x faster than bcrypt for refresh token verification.`);
+  console.log('');
+}
+
+main().catch((err) => {
+  console.error('Benchmark failed:', err);
+  process.exit(1);
+});

--- a/src/auth/auth.service.spec.ts
+++ b/src/auth/auth.service.spec.ts
@@ -219,7 +219,8 @@ describe('AuthService', () => {
     });
 
     function hmacToken(token: string): string {
-      const secret = process.env.HMAC_SECRET || process.env.JWT_REFRESH_SECRET || 'default-hmac-secret';
+      const secret =
+        process.env.HMAC_SECRET || process.env.JWT_REFRESH_SECRET || 'default-hmac-secret';
       return createHmac('sha256', secret).update(token).digest('hex');
     }
 
@@ -241,7 +242,9 @@ describe('AuthService', () => {
 
     it('throws UnauthorizedException when the refresh token hash does not match', async () => {
       mockJwtService.verify.mockReturnValue(validDecoded);
-      mockUserRepo.findOne.mockResolvedValue(makeUser({ refreshToken: hmacToken('some-other-token') }));
+      mockUserRepo.findOne.mockResolvedValue(
+        makeUser({ refreshToken: hmacToken('some-other-token') }),
+      );
 
       await expect(service.refreshTokens('wrong-token')).rejects.toThrow(UnauthorizedException);
       expect(mockSecurityEventLogger.emit).toHaveBeenCalledWith(

--- a/src/auth/auth.service.spec.ts
+++ b/src/auth/auth.service.spec.ts
@@ -1,10 +1,5 @@
 import 'reflect-metadata';
-
-jest.mock('bcrypt', () => ({
-  genSalt: jest.fn().mockResolvedValue('salt'),
-  hash: jest.fn().mockResolvedValue('hashed-password'),
-  compare: jest.fn().mockResolvedValue(true),
-}));
+import { createHmac } from 'crypto';
 
 jest.mock('../users/entities/user.entity', () => ({
   User: class User {},
@@ -27,7 +22,6 @@ import { JwtService } from '@nestjs/jwt';
 import { ConfigService } from '@nestjs/config';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { UnauthorizedException } from '@nestjs/common';
-import * as bcrypt from 'bcrypt';
 import { AuthService } from './auth.service';
 import { TokenBlacklistService } from './services/token-blacklist.service';
 import { User, UserStatus } from '../users/entities/user.entity';
@@ -110,7 +104,6 @@ describe('AuthService', () => {
       const result = await service.login(makeUser());
 
       expect(mockJwtService.signAsync).toHaveBeenCalledTimes(2);
-      expect(bcrypt.genSalt).toHaveBeenCalledWith(10);
       expect(mockUserRepo.update).toHaveBeenCalledWith(
         'user-1',
         expect.objectContaining({ refreshToken: expect.any(String) }),
@@ -193,12 +186,13 @@ describe('AuthService', () => {
     });
 
     it('revokes all tokens and throws when a blacklisted token is reused', async () => {
+      const rawToken = 'revoked-token';
       mockJwtService.verify.mockReturnValue(validDecoded);
-      mockUserRepo.findOne.mockResolvedValue(makeUser());
+      mockUserRepo.findOne.mockResolvedValue(makeUser({ refreshToken: hmacToken(rawToken) }));
       mockBlacklistService.isBlacklisted.mockResolvedValue(true);
       mockUserRepo.update.mockResolvedValue(undefined);
 
-      await expect(service.refreshTokens('revoked-token')).rejects.toThrow(UnauthorizedException);
+      await expect(service.refreshTokens(rawToken)).rejects.toThrow(UnauthorizedException);
       expect(mockUserRepo.update).toHaveBeenCalledWith('user-1', { refreshToken: null });
       expect(mockSecurityEventLogger.emit).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -224,9 +218,15 @@ describe('AuthService', () => {
       await expect(service.refreshTokens('token')).rejects.toThrow(UnauthorizedException);
     });
 
+    function hmacToken(token: string): string {
+      const secret = process.env.HMAC_SECRET || process.env.JWT_REFRESH_SECRET || 'default-hmac-secret';
+      return createHmac('sha256', secret).update(token).digest('hex');
+    }
+
     it('issues new tokens when the refresh token is valid and not blacklisted', async () => {
+      const rawToken = 'valid-token';
       mockJwtService.verify.mockReturnValue(validDecoded);
-      mockUserRepo.findOne.mockResolvedValue(makeUser());
+      mockUserRepo.findOne.mockResolvedValue(makeUser({ refreshToken: hmacToken(rawToken) }));
       mockBlacklistService.isBlacklisted.mockResolvedValue(false);
       mockBlacklistService.addToBlacklist.mockResolvedValue(undefined);
       mockJwtService.signAsync
@@ -234,9 +234,23 @@ describe('AuthService', () => {
         .mockResolvedValueOnce('new-refresh');
       mockUserRepo.update.mockResolvedValue(undefined);
 
-      const result = await service.refreshTokens('valid-token');
+      const result = await service.refreshTokens(rawToken);
 
       expect(result).toEqual({ accessToken: 'new-access', refreshToken: 'new-refresh' });
+    });
+
+    it('throws UnauthorizedException when the refresh token hash does not match', async () => {
+      mockJwtService.verify.mockReturnValue(validDecoded);
+      mockUserRepo.findOne.mockResolvedValue(makeUser({ refreshToken: hmacToken('some-other-token') }));
+
+      await expect(service.refreshTokens('wrong-token')).rejects.toThrow(UnauthorizedException);
+      expect(mockSecurityEventLogger.emit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          eventType: SecurityEventType.AUTH_FAILURE,
+          severity: 'high',
+          details: expect.objectContaining({ reason: 'refresh_token_hash_mismatch' }),
+        }),
+      );
     });
   });
 });

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -194,7 +194,8 @@ export class AuthService {
   }
 
   private hashRefreshToken(token: string): string {
-    const secret = process.env.HMAC_SECRET || process.env.JWT_REFRESH_SECRET || 'default-hmac-secret';
+    const secret =
+      process.env.HMAC_SECRET || process.env.JWT_REFRESH_SECRET || 'default-hmac-secret';
     return createHmac('sha256', secret).update(token).digest('hex');
   }
 

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -3,8 +3,7 @@ import { JwtService } from '@nestjs/jwt';
 import { ConfigService } from '@nestjs/config';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
-import { randomUUID } from 'crypto';
-import * as bcrypt from 'bcrypt';
+import { randomUUID, createHmac, timingSafeEqual } from 'crypto';
 import { User, UserStatus } from '../users/entities/user.entity';
 import { TokenBlacklistService } from './services/token-blacklist.service';
 import { SecurityEventLogger, SecurityEventType } from '../security/audit/security-event-logger';
@@ -101,7 +100,11 @@ export class AuthService {
       throw new UnauthorizedException('User is not active');
     }
 
-    const refreshTokenMatches = await bcrypt.compare(refreshToken, user.refreshToken);
+    const refreshTokenMatches = timingSafeEqual(
+      Buffer.from(this.hashRefreshToken(refreshToken)),
+      Buffer.from(user.refreshToken),
+    );
+
     if (!refreshTokenMatches) {
       this.securityEventLogger.emit({
         eventType: SecurityEventType.AUTH_FAILURE,
@@ -190,10 +193,13 @@ export class AuthService {
     await this.userRepository.update(userId, { refreshToken: null });
   }
 
+  private hashRefreshToken(token: string): string {
+    const secret = process.env.HMAC_SECRET || process.env.JWT_REFRESH_SECRET || 'default-hmac-secret';
+    return createHmac('sha256', secret).update(token).digest('hex');
+  }
+
   private async updateRefreshTokenHash(userId: string, refreshToken: string) {
-    const rounds = Number(this.configService.get('BCRYPT_ROUNDS', 12));
-    const salt = await bcrypt.genSalt(rounds);
-    const hash = await bcrypt.hash(refreshToken, salt);
+    const hash = this.hashRefreshToken(refreshToken);
     await this.userRepository.update(userId, { refreshToken: hash });
   }
 

--- a/src/migrations/1783000000003-clear-legacy-bcrypt-refresh-tokens.ts
+++ b/src/migrations/1783000000003-clear-legacy-bcrypt-refresh-tokens.ts
@@ -1,0 +1,35 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Issue #850 — Clear legacy bcrypt-hashed refresh tokens.
+ *
+ * ## Context
+ *
+ * Refresh tokens were previously stored as bcrypt hashes (identifiable by the
+ * `$2b$` prefix). As part of the migration to HMAC-SHA-256 for refresh token
+ * storage, all existing bcrypt hashes must be cleared because they cannot be
+ * converted to the new hashing scheme (bcrypt is one-way).
+ *
+ * Setting `refreshToken` to NULL forces affected users to re-login on their
+ * next API call. During re-login, a new refresh token is issued and stored
+ * using HMAC-SHA-256.
+ *
+ * ## Irreversibility
+ *
+ * This migration is **not reversible**. Bcrypt hashes cannot be converted back
+ * to plaintext or re-hashed with HMAC-SHA-256. The `down()` method is a no-op.
+ */
+export class ClearLegacyBcryptRefreshTokens1783000000003 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      UPDATE users
+         SET "refreshToken" = NULL
+       WHERE "refreshToken" LIKE '$2b$%'
+    `);
+  }
+
+  public async down(): Promise<void> {
+    // Cannot reverse this migration - bcrypt hashes cannot be recovered from HMAC-SHA-256 hashes.
+    // Affected users will need to re-login to obtain new refresh tokens.
+  }
+}


### PR DESCRIPTION
…cation
Closes #1024
- Remove dual-path bcrypt/SHA-256 verification in auth.service.ts

- Add hashRefreshToken() using HMAC-SHA-256 keyed by HMAC_SECRET
Closes #1025
- Use crypto.timingSafeEqual for constant-time comparison

- Keep bcrypt for password hashing (unchanged)

- Add migration to clear legacy bcrypt-hashed refresh tokens
Closes #1026
- Add benchmark script comparing bcrypt vs SHA-256 vs HMAC-SHA-256

- Update auth.service.spec.ts tests for HMAC-SHA-256 path
Closes #1023