### PR TITLE
feat(database): add slow query logging and automatic EXPLAIN ANALYZE

### DIFF
--- a/src/config/database.config.ts
+++ b/src/config/database.config.ts
@@ -1,5 +1,9 @@
 import { TypeOrmModuleOptions } from '@nestjs/typeorm';
 import { resolvePoolConfig } from '../database/pool';
+import {
+  SlowQueryLogger,
+  resolveSlowQueryLoggerOptions,
+} from '../database/logging/slow-query.logger';
 
 interface DatabaseConnectionSettings {
   host: string;
@@ -71,9 +75,13 @@ export function getDatabaseConfig(): TypeOrmModuleOptions {
   const primary = readPrimarySettings();
   const replicas = getReadReplicaConnections(primary);
   const pool = resolvePoolConfig();
+  const slowQuery = resolveSlowQueryLoggerOptions();
   const commonOptions = {
     autoLoadEntities: true,
     synchronize: process.env.NODE_ENV !== 'production',
+    // Drives TypeORM's logQuerySlow hook, consumed by SlowQueryLogger.
+    maxQueryExecutionTime: slowQuery.slowQueryThresholdMs,
+    ...(slowQuery.enabled ? { logger: new SlowQueryLogger(slowQuery) } : {}),
     extra: {
       max: pool.max,
       min: pool.min,

--- a/src/database/logging/slow-query.logger.spec.ts
+++ b/src/database/logging/slow-query.logger.spec.ts
@@ -1,0 +1,142 @@
+import {
+  DEFAULT_EXPLAIN_THRESHOLD_MS,
+  DEFAULT_SLOW_QUERY_THRESHOLD_MS,
+  SlowQueryLogger,
+  SlowQueryLoggerOptions,
+  resolveSlowQueryLoggerOptions,
+} from './slow-query.logger';
+
+/** Lets the un-awaited EXPLAIN ANALYZE promise settle before assertions. */
+const flushAsync = () => new Promise((resolve) => setImmediate(resolve));
+
+describe('resolveSlowQueryLoggerOptions', () => {
+  it('falls back to documented defaults when nothing is configured', () => {
+    const options = resolveSlowQueryLoggerOptions({} as NodeJS.ProcessEnv);
+
+    expect(options.slowQueryThresholdMs).toBe(DEFAULT_SLOW_QUERY_THRESHOLD_MS);
+    expect(options.explainThresholdMs).toBe(DEFAULT_EXPLAIN_THRESHOLD_MS);
+    expect(options.enabled).toBe(true);
+  });
+
+  it('reads overrides from the environment', () => {
+    const options = resolveSlowQueryLoggerOptions({
+      DB_SLOW_QUERY_THRESHOLD_MS: '250',
+      DB_EXPLAIN_THRESHOLD_MS: '1000',
+    } as NodeJS.ProcessEnv);
+
+    expect(options.slowQueryThresholdMs).toBe(250);
+    expect(options.explainThresholdMs).toBe(1000);
+  });
+
+  it('ignores values that are not positive integers', () => {
+    const options = resolveSlowQueryLoggerOptions({
+      DB_SLOW_QUERY_THRESHOLD_MS: 'not-a-number',
+      DB_EXPLAIN_THRESHOLD_MS: '-5',
+    } as NodeJS.ProcessEnv);
+
+    expect(options.slowQueryThresholdMs).toBe(DEFAULT_SLOW_QUERY_THRESHOLD_MS);
+    expect(options.explainThresholdMs).toBe(DEFAULT_EXPLAIN_THRESHOLD_MS);
+  });
+
+  it('disables itself in test environments', () => {
+    const options = resolveSlowQueryLoggerOptions({ NODE_ENV: 'test' } as NodeJS.ProcessEnv);
+
+    expect(options.enabled).toBe(false);
+  });
+});
+
+describe('SlowQueryLogger', () => {
+  const options: SlowQueryLoggerOptions = {
+    slowQueryThresholdMs: 500,
+    explainThresholdMs: 2000,
+    enabled: true,
+  };
+
+  const createQueryRunner = () => ({ query: jest.fn().mockResolvedValue([]) });
+
+  it('runs EXPLAIN ANALYZE for slow reads past the explain threshold', async () => {
+    const queryRunner = createQueryRunner();
+
+    new SlowQueryLogger(options).logQuerySlow(
+      2500,
+      'SELECT * FROM users',
+      [],
+      queryRunner as never,
+    );
+    await flushAsync();
+
+    expect(queryRunner.query).toHaveBeenCalledWith('EXPLAIN ANALYZE SELECT * FROM users', []);
+  });
+
+  it('leaves queries between the two thresholds unexplained', async () => {
+    const queryRunner = createQueryRunner();
+
+    new SlowQueryLogger(options).logQuerySlow(
+      900,
+      'SELECT * FROM users',
+      [],
+      queryRunner as never,
+    );
+    await flushAsync();
+
+    expect(queryRunner.query).not.toHaveBeenCalled();
+  });
+
+  it('never re-executes a write statement under EXPLAIN ANALYZE', async () => {
+    const queryRunner = createQueryRunner();
+
+    new SlowQueryLogger(options).logQuerySlow(
+      5000,
+      'UPDATE users SET name = $1',
+      ['teachlink'],
+      queryRunner as never,
+    );
+    await flushAsync();
+
+    expect(queryRunner.query).not.toHaveBeenCalled();
+  });
+
+  it('does not recurse when the statement is already an EXPLAIN', async () => {
+    const queryRunner = createQueryRunner();
+
+    new SlowQueryLogger(options).logQuerySlow(
+      5000,
+      'EXPLAIN ANALYZE SELECT * FROM users',
+      [],
+      queryRunner as never,
+    );
+    await flushAsync();
+
+    expect(queryRunner.query).not.toHaveBeenCalled();
+  });
+
+  it('swallows EXPLAIN ANALYZE failures', async () => {
+    const queryRunner = { query: jest.fn().mockRejectedValue(new Error('boom')) };
+
+    expect(() =>
+      new SlowQueryLogger(options).logQuerySlow(
+        5000,
+        'SELECT * FROM users',
+        [],
+        queryRunner as never,
+      ),
+    ).not.toThrow();
+    await flushAsync();
+
+    expect(queryRunner.query).toHaveBeenCalled();
+  });
+
+  it('emits nothing at all when disabled', async () => {
+    const queryRunner = createQueryRunner();
+
+    new SlowQueryLogger({ ...options, enabled: false }).logQuerySlow(
+      5000,
+      'SELECT * FROM users',
+      [],
+      queryRunner as never,
+    );
+    await flushAsync();
+
+    expect(queryRunner.query).not.toHaveBeenCalled();
+  });
+});

--- a/src/database/logging/slow-query.logger.ts
+++ b/src/database/logging/slow-query.logger.ts
@@ -1,0 +1,242 @@
+import { Logger as NestLogger } from '@nestjs/common';
+import { Logger as TypeOrmLogger, QueryRunner } from 'typeorm';
+
+export const DEFAULT_SLOW_QUERY_THRESHOLD_MS = 500;
+export const DEFAULT_EXPLAIN_THRESHOLD_MS = 2000;
+
+/** Maximum number of characters of SQL retained in a single log line. */
+const MAX_LOGGED_QUERY_LENGTH = 2000;
+
+export interface SlowQueryLoggerOptions {
+  /** Queries at or above this duration are logged. */
+  slowQueryThresholdMs: number;
+  /** Queries at or above this duration additionally get EXPLAIN ANALYZE. */
+  explainThresholdMs: number;
+  /** When false the logger becomes a no-op (used to silence test runs). */
+  enabled: boolean;
+}
+
+function parsePositiveInt(raw: string | undefined, fallback: number): number {
+  const parsed = Number.parseInt(raw ?? '', 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+/**
+ * Reads slow-query logging configuration from the environment, falling back to
+ * documented defaults when a variable is missing or not a positive integer.
+ *
+ * The logger is disabled under `NODE_ENV=test` so unit and e2e runs are not
+ * polluted with timing noise.
+ */
+export function resolveSlowQueryLoggerOptions(
+  env: NodeJS.ProcessEnv = process.env,
+): SlowQueryLoggerOptions {
+  return {
+    slowQueryThresholdMs: parsePositiveInt(
+      env.DB_SLOW_QUERY_THRESHOLD_MS,
+      DEFAULT_SLOW_QUERY_THRESHOLD_MS,
+    ),
+    explainThresholdMs: parsePositiveInt(
+      env.DB_EXPLAIN_THRESHOLD_MS,
+      DEFAULT_EXPLAIN_THRESHOLD_MS,
+    ),
+    enabled: env.NODE_ENV !== 'test',
+  };
+}
+
+/**
+ * TypeORM logger that surfaces slow queries in the application's own
+ * structured logs, so a slow query can be correlated with the request trace
+ * that produced it without reaching for an external APM.
+ *
+ * TypeORM invokes `logQuerySlow` only for queries slower than the connection's
+ * `maxQueryExecutionTime`, which `database.config.ts` wires to
+ * `slowQueryThresholdMs`.
+ */
+export class SlowQueryLogger implements TypeOrmLogger {
+  private readonly logger = new NestLogger(SlowQueryLogger.name);
+
+  constructor(
+    private readonly options: SlowQueryLoggerOptions = resolveSlowQueryLoggerOptions(),
+  ) {}
+
+  /**
+   * Emits one structured line per slow query and, past the explain threshold,
+   * schedules an EXPLAIN ANALYZE for the same statement.
+   */
+  logQuerySlow(
+    time: number,
+    query: string,
+    parameters?: unknown[],
+    queryRunner?: QueryRunner,
+  ): void {
+    if (!this.options.enabled) {
+      return;
+    }
+
+    this.logger.warn(
+      JSON.stringify({
+        event: 'db.slow_query',
+        durationMs: time,
+        thresholdMs: this.options.slowQueryThresholdMs,
+        query: this.truncate(query),
+        parameters: this.describeParameters(parameters),
+      }),
+    );
+
+    if (time >= this.options.explainThresholdMs) {
+      // Deliberately not awaited: the query has already returned to the
+      // caller and diagnostics must not extend the request lifetime.
+      void this.explainAnalyze(time, query, parameters, queryRunner);
+    }
+  }
+
+  /**
+   * Runs EXPLAIN ANALYZE for a statement that breached the explain threshold
+   * and appends the plan to the structured log.
+   *
+   * EXPLAIN ANALYZE genuinely executes the statement it wraps, so this is
+   * restricted to read-only statements -- profiling a write would duplicate
+   * it. Failures are swallowed: diagnostics must never surface as an error.
+   */
+  private async explainAnalyze(
+    time: number,
+    query: string,
+    parameters?: unknown[],
+    queryRunner?: QueryRunner,
+  ): Promise<void> {
+    if (!queryRunner || !this.isSafeToExplain(query)) {
+      return;
+    }
+
+    try {
+      const plan = await queryRunner.query(`EXPLAIN ANALYZE ${query}`, parameters as unknown[]);
+
+      this.logger.warn(
+        JSON.stringify({
+          event: 'db.slow_query_plan',
+          durationMs: time,
+          explainThresholdMs: this.options.explainThresholdMs,
+          query: this.truncate(query),
+          plan: this.formatPlan(plan),
+        }),
+      );
+    } catch (error) {
+      this.logger.debug(
+        JSON.stringify({
+          event: 'db.slow_query_plan_failed',
+          query: this.truncate(query),
+          reason: error instanceof Error ? error.message : String(error),
+        }),
+      );
+    }
+  }
+
+  /**
+   * Only read-only statements may be re-executed under EXPLAIN ANALYZE. Any
+   * already-wrapped EXPLAIN is rejected too, which prevents recursion when the
+   * diagnostic query is itself slow.
+   */
+  private isSafeToExplain(query: string): boolean {
+    const normalised = query.trim().toLowerCase();
+    if (normalised.startsWith('explain')) {
+      return false;
+    }
+    return normalised.startsWith('select') || normalised.startsWith('with');
+  }
+
+  /** Normalises the driver's plan output into a list of text rows. */
+  private formatPlan(plan: unknown): string[] {
+    if (!Array.isArray(plan)) {
+      return [];
+    }
+    return plan.map((row) => {
+      if (row && typeof row === 'object') {
+        const values = Object.values(row as Record<string, unknown>);
+        return values.length === 1 ? String(values[0]) : JSON.stringify(row);
+      }
+      return String(row);
+    });
+  }
+
+  /**
+   * Records parameter count and stringified values, guarding against oversized
+   * payloads leaking into the log stream.
+   */
+  private describeParameters(parameters?: unknown[]): { count: number; values: string } {
+    if (!parameters || parameters.length === 0) {
+      return { count: 0, values: '[]' };
+    }
+
+    try {
+      return { count: parameters.length, values: this.truncate(JSON.stringify(parameters)) };
+    } catch {
+      return { count: parameters.length, values: '[unserialisable]' };
+    }
+  }
+
+  private truncate(value: string): string {
+    return value.length > MAX_LOGGED_QUERY_LENGTH
+      ? `${value.slice(0, MAX_LOGGED_QUERY_LENGTH)}...[truncated]`
+      : value;
+  }
+
+  /* The remaining hooks keep the default TypeORM behaviour. */
+
+  logQuery(query: string, parameters?: unknown[], _queryRunner?: QueryRunner): void {
+    if (!this.options.enabled) {
+      return;
+    }
+    this.logger.debug(
+      JSON.stringify({
+        event: 'db.query',
+        query: this.truncate(query),
+        parameters: this.describeParameters(parameters),
+      }),
+    );
+  }
+
+  logQueryError(
+    error: string | Error,
+    query: string,
+    parameters?: unknown[],
+    _queryRunner?: QueryRunner,
+  ): void {
+    if (!this.options.enabled) {
+      return;
+    }
+    this.logger.error(
+      JSON.stringify({
+        event: 'db.query_error',
+        reason: error instanceof Error ? error.message : error,
+        query: this.truncate(query),
+        parameters: this.describeParameters(parameters),
+      }),
+    );
+  }
+
+  logSchemaBuild(message: string, _queryRunner?: QueryRunner): void {
+    if (!this.options.enabled) {
+      return;
+    }
+    this.logger.debug(message);
+  }
+
+  logMigration(message: string, _queryRunner?: QueryRunner): void {
+    if (!this.options.enabled) {
+      return;
+    }
+    this.logger.log(message);
+  }
+
+  log(level: 'log' | 'info' | 'warn', message: unknown, _queryRunner?: QueryRunner): void {
+    if (!this.options.enabled) {
+      return;
+    }
+    if (level === 'warn') {
+      this.logger.warn(message);
+      return;
+    }
+    this.logger.log(message);
+  }
+}


### PR DESCRIPTION
## What

Slow queries were only visible through external monitoring, so they could not be correlated with a request trace in our own structured logs. This adds a TypeORM custom logger that reports them directly.

- **New** `src/database/logging/slow-query.logger.ts` — `SlowQueryLogger` implementing the TypeORM `Logger` interface.
- Queries at or above `DB_SLOW_QUERY_THRESHOLD_MS` (default `500`) emit a structured `db.slow_query` line with query text, parameter summary, and duration.
- Queries at or above `DB_EXPLAIN_THRESHOLD_MS` (default `2000`) additionally emit `db.slow_query_plan` containing the `EXPLAIN ANALYZE` output.
- `src/config/database.config.ts` registers the logger and wires `maxQueryExecutionTime` to the slow-query threshold.
- The logger is a no-op when `NODE_ENV=test`, so test runs stay quiet.

## Implementation notes for the reviewer

Two deliberate deviations from the issue text, both worth a look:

1. **Method name.** The issue specifies `logSlowQuery(query, params, time)`. TypeORM's actual `Logger` interface declares `logQuerySlow(time, query, parameters, queryRunner)`, so the implementation follows the real interface — the described signature would never have been invoked.

2. **`EXPLAIN ANALYZE` is restricted to read-only statements.** `EXPLAIN ANALYZE` genuinely executes the statement it wraps. Profiling a slow `INSERT`/`UPDATE`/`DELETE` would therefore perform the write a second time. Only `SELECT` and `WITH` statements are explained; already-wrapped `EXPLAIN` statements are skipped too, which prevents recursion if the diagnostic query is itself slow.

The `EXPLAIN ANALYZE` call is intentionally not awaited — the original query has already returned to the caller, so diagnostics never extend request latency. Any failure inside it is swallowed and logged at debug level.

## New coverage

`src/database/logging/slow-query.logger.spec.ts` covers:

- default thresholds, environment overrides, and rejection of non-positive-integer values
- `enabled: false` under `NODE_ENV=test`
- `EXPLAIN ANALYZE` runs for slow reads past the explain threshold
- no explain for queries between the two thresholds
- write statements are never re-executed
- no recursion on an already-`EXPLAIN` statement
- explain failures are swallowed rather than thrown
- fully disabled logger performs no work

## Scope

Only three files are touched, all within the issue's stated target area:

- `src/database/logging/slow-query.logger.ts` (new)
- `src/database/logging/slow-query.logger.spec.ts` (new)
- `src/config/database.config.ts` (additive: one import, one `resolveSlowQueryLoggerOptions()` call, two keys in `commonOptions`)

No existing behaviour is modified or removed. No files outside the target folders are touched.

Closes #884