### PR TITLE
feat(search): make Elasticsearch routing and fallbacks explicit with …

### DIFF
--- a/src/search/search.module.ts
+++ b/src/search/search.module.ts
@@ -6,6 +6,8 @@ import { SearchService } from './search.service';
 import { createElasticsearchConfig } from '../config/elasticsearch.config';
 import { TenancyModule } from '../tenancy/tenancy.module';
 
+import { MetricsModule } from '../utils/masking/metrics.module';
+
 /**
  * Search module supports Elasticsearch-backed course searching,
  * facets, autocomplete, and result caching when available.
@@ -14,6 +16,7 @@ import { TenancyModule } from '../tenancy/tenancy.module';
   imports: [
     ConfigModule,
     TenancyModule,
+    MetricsModule,
     ElasticsearchModule.registerAsync({
       imports: [ConfigModule],
       inject: [ConfigService],

--- a/src/search/search.service.spec.ts
+++ b/src/search/search.service.spec.ts
@@ -10,20 +10,23 @@ import { ElasticsearchService } from '@nestjs/elasticsearch';
 describe('SearchService (Issue #814 full-text search)', () => {
   let service: SearchService;
   let courseRepository: jest.Mocked<Repository<any>>;
-  let elasticsearch: { search: jest.Mock };
+  let elasticsearch: { search: jest.Mock; ping: jest.Mock };
   let isolationService: { getTenantId: jest.Mock };
+  let metricsService: { searchFallbackCounter: { inc: jest.Mock } };
 
   beforeEach(() => {
     courseRepository = {
       createQueryBuilder: jest.fn(),
     } as any;
 
-    elasticsearch = { search: jest.fn() };
+    elasticsearch = { search: jest.fn(), ping: jest.fn().mockResolvedValue(true) };
     isolationService = { getTenantId: jest.fn().mockReturnValue(null) };
+    metricsService = { searchFallbackCounter: { inc: jest.fn() } };
 
     service = new SearchService(
       courseRepository as any,
       elasticsearch as any,
+      metricsService as any,
       isolationService as any,
       undefined as any,
     );
@@ -126,6 +129,8 @@ describe('SearchService (Issue #814 full-text search)', () => {
   });
 
   it('uses Elasticsearch fast-path when present and successful', async () => {
+    await service.onModuleInit(); // Set to available
+
     elasticsearch.search.mockResolvedValueOnce({
       hits: { total: { value: 1 }, hits: [{ _source: { id: 'c1', title: 'X' } }] },
     } as any);
@@ -136,9 +141,12 @@ describe('SearchService (Issue #814 full-text search)', () => {
     expect(result.total).toBe(1);
     expect(elasticsearch.search).toHaveBeenCalled();
     expect(courseRepository.createQueryBuilder).not.toHaveBeenCalled();
+    expect(metricsService.searchFallbackCounter.inc).not.toHaveBeenCalled();
   });
 
   it('falls back to DB when Elasticsearch throws', async () => {
+    await service.onModuleInit(); // Set to available
+
     elasticsearch.search.mockRejectedValueOnce(new Error('ES down'));
     const qb = makeQb({ rows: [], total: 0 });
     courseRepository.createQueryBuilder.mockReturnValueOnce(qb);
@@ -147,6 +155,24 @@ describe('SearchService (Issue #814 full-text search)', () => {
 
     expect(result.source).toBeUndefined();
     expect(result.query).toBe('react');
+    expect(metricsService.searchFallbackCounter.inc).toHaveBeenCalledWith({ reason: 'error' });
+  });
+
+  it('falls back to DB when ping fails at startup', async () => {
+    elasticsearch.ping.mockRejectedValueOnce(new Error('Down'));
+    await service.onModuleInit(); // Sets to unavailable
+
+    const qb = makeQb({ rows: [], total: 0 });
+    courseRepository.createQueryBuilder.mockReturnValueOnce(qb);
+
+    const result = await service.search('react');
+
+    // Should skip trying ES
+    expect(elasticsearch.search).not.toHaveBeenCalled();
+    expect(result.source).toBeUndefined();
+    expect(metricsService.searchFallbackCounter.inc).toHaveBeenCalledWith({
+      reason: 'unavailable',
+    });
   });
 
   describe('Issue #889 — Tenant isolation enforcement on Elasticsearch queries', () => {

--- a/src/search/search.service.ts
+++ b/src/search/search.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Logger, Inject, Optional } from '@nestjs/common';
+import { Injectable, Logger, Inject, Optional, OnModuleInit } from '@nestjs/common';
 import { CACHE_MANAGER } from '@nestjs/cache-manager';
 import { ElasticsearchService as NestElasticsearchService } from '@nestjs/elasticsearch';
 import type { Cache } from 'cache-manager';
@@ -7,6 +7,7 @@ import { Repository, Brackets } from 'typeorm';
 import { Course } from '../courses/entities/course.entity';
 import { LRUCache } from 'lru-cache';
 import { IsolationService } from '../tenancy/isolation/isolation.service';
+import { MetricsService } from '../utils/masking/metrics.service';
 
 export interface SearchFilters {
   category?: string | string[];
@@ -45,17 +46,19 @@ interface AutocompleteResult {
  * an index scan + ranking — no seq scan, even at 100k+ rows.
  */
 @Injectable()
-export class SearchService {
+export class SearchService implements OnModuleInit {
   private readonly logger = new Logger(SearchService.name);
   private readonly AUTOCOMPLETE_LIMIT = 10;
   private readonly CACHE_TTL_MS = 300000; // 5 minutes
   private readonly AUTOCOMPLETE_CACHE_MAX_SIZE = 1000;
   private autocompleteCache: LRUCache<string, AutocompleteResult[]>;
+  private isElasticsearchAvailable = false;
 
   constructor(
     @InjectRepository(Course)
     private readonly courseRepository: Repository<Course>,
     private readonly elasticsearch: NestElasticsearchService,
+    private readonly metricsService: MetricsService,
     @Optional() private readonly isolationService?: IsolationService,
     @Optional() @Inject(CACHE_MANAGER) private readonly cacheManager?: Cache,
   ) {
@@ -63,6 +66,27 @@ export class SearchService {
       max: this.AUTOCOMPLETE_CACHE_MAX_SIZE,
       ttl: this.CACHE_TTL_MS,
     });
+  }
+
+  async onModuleInit() {
+    if (!this.elasticsearch) {
+      this.logger.warn('Elasticsearch client not injected.');
+      return;
+    }
+    try {
+      const pingResult = await this.elasticsearch.ping();
+      this.isElasticsearchAvailable = !!pingResult;
+      if (this.isElasticsearchAvailable) {
+        this.logger.log('Elasticsearch is available and will serve search queries.');
+      } else {
+        this.logger.warn('Elasticsearch ping failed. Falling back to DB search.');
+      }
+    } catch (error) {
+      this.logger.warn(
+        `Elasticsearch ping failed: ${(error as Error).message}. Falling back to DB search.`,
+      );
+      this.isElasticsearchAvailable = false;
+    }
   }
 
   async search(
@@ -81,12 +105,16 @@ export class SearchService {
       if (cached) return cached;
     }
 
-    // Try the Elasticsearch fast-path first when present. Fall back to PostgreSQL FTS
-    // below on any failure so the API still returns results during ES outages.
-    const esResults = await this.tryElasticsearch(safeQuery, filters, page, limit, sort);
-    if (esResults) {
-      if (this.cacheManager) await this.cacheManager.set(cacheKey, esResults, 30);
-      return esResults;
+    if (this.isElasticsearchAvailable) {
+      const esResults = await this.tryElasticsearch(safeQuery, filters, page, limit, sort);
+      if (esResults) {
+        if (this.cacheManager) await this.cacheManager.set(cacheKey, esResults, 30);
+        return esResults;
+      }
+      // If tryElasticsearch returned null due to an intermittent error, we fall through and record the fallback metric.
+      this.metricsService.searchFallbackCounter.inc({ reason: 'error' });
+    } else {
+      this.metricsService.searchFallbackCounter.inc({ reason: 'unavailable' });
     }
 
     try {

--- a/src/utils/masking/metrics.service.ts
+++ b/src/utils/masking/metrics.service.ts
@@ -14,6 +14,7 @@ export class MetricsService {
 
   // Counters
   public readonly paymentsTotalCounter: Counter<string>;
+  public readonly searchFallbackCounter: Counter<string>;
 
   // Histograms
   public readonly apiLatencyHistogram: Histogram<string>;
@@ -67,6 +68,13 @@ export class MetricsService {
       name: 'teachlink_payments_total',
       help: 'Total number of payment attempts',
       labelNames: ['status'], // 'succeeded', 'failed'
+      registers: [this.registry],
+    });
+
+    this.searchFallbackCounter = new Counter({
+      name: 'teachlink_search_db_fallback_total',
+      help: 'Total number of search requests that fell back to the database',
+      labelNames: ['reason'], // 'unavailable', 'error'
       registers: [this.registry],
     });
 


### PR DESCRIPTION
Fixes #998

**: Makes the Elasticsearch query path explicitly detectable and tracks occurrences where the application is forced to fall back to the PostgreSQL database for search queries. Previously, the `SearchService` injected the Elasticsearch client but obscured its usage behind a silent fallback mechanism, making the actual utilization and failure rates unobservable.
#### Features & Architectural Changes
1. **Explicit Startup Detection:**
   - `SearchService` now implements `OnModuleInit`. At startup, it aggressively pings the Elasticsearch cluster and records its availability state into a local memory flag (`isElasticsearchAvailable`).
2. **Observable Routing Circuit Breaker:**
   - The `search()` method now explicitly evaluates the availability flag.
   - If ES is down (detected at startup), it routes directly to PostgreSQL and skips the timeout penalties entirely.
3. **Metrics Tracking:**
   - Injected `MetricsService` and established a new Prometheus counter: `teachlink_search_db_fallback_total`.
   - The system increments this counter with the label `{ reason: 'unavailable' }` if the ES startup ping failed, and `{ reason: 'error' }` if an ES query throws dynamically.
4. **Integration Testing:**
   - Augmented `search.service.spec.ts` with mocks for `MetricsService` and the `OnModuleInit` lifecycle, guaranteeing both execution paths (ES vs DB) securely return results and track metrics appropriately.