### PR TITLE
fix: resolve 4 Stellar Wave issues (#1131, #1132, #1133, #1134)

### DIFF
--- a/src/caching/adaptive-ttl.service.ts
+++ b/src/caching/adaptive-ttl.service.ts
@@ -177,7 +177,27 @@ export class AdaptiveTTLService {
       return null;
     }
 
-    const rules: AdaptiveTTLRule[] = JSON.parse(rulesData);
+    let rules: AdaptiveTTLRule[];
+    try {
+      rules = JSON.parse(rulesData) as AdaptiveTTLRule[];
+    } catch {
+      this.logger.warn(
+        'Corrupt adaptive TTL rules data in cache – treating as miss and falling back to defaults',
+      );
+      // Emit a counter for cache-deserialization failures so poisoning is observable
+      try {
+        await this.redis.incr('cache:metrics:deserialization_failures_total');
+      } catch {
+        // Silently ignore counter increment failures
+      }
+      return null;
+    }
+
+    // Validate the parsed shape is an array before using
+    if (!Array.isArray(rules)) {
+      this.logger.warn('Adaptive TTL rules data is not an array – treating as miss');
+      return null;
+    }
 
     return rules.find((rule) => this.matchesPattern(key, rule.keyPattern)) || null;
   }
@@ -236,7 +256,20 @@ export class AdaptiveTTLService {
   async getRecentAdjustments(limit: number = 50): Promise<TTLAdjustmentEvent[]> {
     const adjustments = await this.redis.zrevrange(this.adjustmentsKey, 0, limit - 1);
 
-    return adjustments.map((data) => JSON.parse(data));
+    const results: TTLAdjustmentEvent[] = [];
+    for (const data of adjustments) {
+      try {
+        results.push(JSON.parse(data) as TTLAdjustmentEvent);
+      } catch {
+        this.logger.warn('Corrupt TTL adjustment record found – skipping');
+        try {
+          await this.redis.incr('cache:metrics:deserialization_failures_total');
+        } catch {
+          // Silently ignore counter increment failures
+        }
+      }
+    }
+    return results;
   }
 
   /**
@@ -252,7 +285,19 @@ export class AdaptiveTTLService {
     const since = Date.now() - hours * 60 * 60 * 1000;
     const adjustments = await this.redis.zrangebyscore(this.adjustmentsKey, since, '+inf');
 
-    const parsed = adjustments.map((data) => JSON.parse(data) as TTLAdjustmentEvent);
+    const parsed: TTLAdjustmentEvent[] = [];
+    for (const data of adjustments) {
+      try {
+        parsed.push(JSON.parse(data) as TTLAdjustmentEvent);
+      } catch {
+        this.logger.warn('Corrupt TTL adjustment record in stats query – skipping');
+        try {
+          await this.redis.incr('cache:metrics:deserialization_failures_total');
+        } catch {
+          // Silently ignore counter increment failures
+        }
+      }
+    }
 
     const increased = parsed.filter((adj) => adj.newTtl > adj.oldTtl).length;
     const decreased = parsed.filter((adj) => adj.newTtl < adj.oldTtl).length;
@@ -288,7 +333,19 @@ export class AdaptiveTTLService {
    */
   async getRules(): Promise<AdaptiveTTLRule[]> {
     const rulesData = await this.redis.get(this.rulesKey);
-    return rulesData ? JSON.parse(rulesData) : this.defaultRules;
+    if (!rulesData) {
+      return this.defaultRules;
+    }
+    try {
+      const parsed = JSON.parse(rulesData) as AdaptiveTTLRule[];
+      if (Array.isArray(parsed)) {
+        return parsed;
+      }
+      this.logger.warn('Adaptive TTL rules data is not an array – falling back to defaults');
+    } catch {
+      this.logger.warn('Corrupt adaptive TTL rules data – falling back to defaults');
+    }
+    return this.defaultRules;
   }
 
   /**

--- a/src/caching/cache-analytics.service.ts
+++ b/src/caching/cache-analytics.service.ts
@@ -109,7 +109,30 @@ export class CacheAnalyticsService {
     const metricsData = await this.redis.hget(this.metricsKey, key);
 
     if (metricsData) {
-      return JSON.parse(metricsData);
+      try {
+        const parsed = JSON.parse(metricsData) as CacheMetrics;
+        // Validate the parsed shape has required fields before using it
+        if (typeof parsed?.hits === 'number' && typeof parsed?.misses === 'number') {
+          return parsed;
+        }
+        this.logger.warn(
+          `Corrupt metrics data for key "${key}" – treating as miss and recomputing`,
+        );
+        try {
+          await this.redis.incr('cache:metrics:deserialization_failures_total');
+        } catch {
+          // Silently ignore counter increment failures
+        }
+      } catch {
+        this.logger.warn(
+          `Unparseable metrics data for key "${key}" – treating as miss and recomputing`,
+        );
+        try {
+          await this.redis.incr('cache:metrics:deserialization_failures_total');
+        } catch {
+          // Silently ignore counter increment failures
+        }
+      }
     }
 
     return {
@@ -331,7 +354,31 @@ export class CacheAnalyticsService {
   private async getAllMetrics(): Promise<CacheMetrics[]> {
     const allMetricsData = await this.redis.hgetall(this.metricsKey);
 
-    return Object.values(allMetricsData).map((data) => JSON.parse(data));
+    const results: CacheMetrics[] = [];
+    for (const data of Object.values(allMetricsData)) {
+      try {
+        const parsed = JSON.parse(data) as CacheMetrics;
+        // Validate the parsed shape has the required fields
+        if (typeof parsed?.hits === 'number' && typeof parsed?.misses === 'number') {
+          results.push(parsed);
+        } else {
+          this.logger.warn('Corrupt metrics entry in getAllMetrics – skipping');
+          try {
+            await this.redis.incr('cache:metrics:deserialization_failures_total');
+          } catch {
+            // Silently ignore counter increment failures
+          }
+        }
+      } catch {
+        this.logger.warn('Unparseable metrics entry in getAllMetrics – skipping');
+        try {
+          await this.redis.incr('cache:metrics:deserialization_failures_total');
+        } catch {
+          // Silently ignore counter increment failures
+        }
+      }
+    }
+    return results;
   }
 
   /**

--- a/src/payments/webhooks/stripe-webhook.guard.ts
+++ b/src/payments/webhooks/stripe-webhook.guard.ts
@@ -4,6 +4,7 @@ import {
   ExecutionContext,
   Logger,
   UnauthorizedException,
+  BadRequestException,
 } from '@nestjs/common';
 import { Request } from 'express';
 import { WebhookSecurityService } from './webhook-security.service';
@@ -12,9 +13,10 @@ import { WebhookSecurityService } from './webhook-security.service';
  * Guard that validates incoming Stripe webhook requests.
  *
  * Performs:
- * 1. Signature verification using HMAC-SHA256
+ * 1. Signature verification using HMAC-SHA256 (against raw body BEFORE parsing)
  * 2. Timestamp freshness validation (±5 minutes)
  * 3. Replay attack prevention (duplicate event ID detection)
+ * 4. JSON body parsing with proper error handling (400 on malformed payload)
  *
  * Must be applied to Stripe webhook endpoints.
  */
@@ -42,25 +44,30 @@ export class StripeWebhookGuard implements CanActivate {
       );
     }
 
-    // Parse event ID from the body for replay prevention.
-    // We attempt to parse the JSON to extract the event ID,
-    // but we verify the signature against the raw (unparsed) body.
+    // Step 1: Verify the Stripe signature against the RAW body FIRST.
+    // We use a placeholder event ID for initial signature validation;
+    // replay prevention runs after we successfully parse the body.
+    const signatureResult = this.webhookSecurityService.verifyStripeSignature(rawBody, signature);
+
+    if (!signatureResult.valid) {
+      this.logger.warn(`Stripe webhook rejected: ${signatureResult.reason}`);
+      throw new UnauthorizedException(signatureResult.reason);
+    }
+
+    // Step 2: Only AFTER signature verification, parse the JSON body.
+    // Wrap JSON.parse in try/catch and return 400 for unparseable bodies.
     let eventId: string | undefined;
     try {
       const parsed = JSON.parse(rawBody.toString('utf8'));
       eventId = parsed?.id;
     } catch {
-      // If we can't parse, signature verification will still work,
-      // but replay prevention will be skipped.
-      this.logger.warn('Could not parse webhook body to extract event ID');
+      this.logger.warn('Webhook body is not valid JSON – returning 400');
+      throw new BadRequestException('Malformed webhook body: not valid JSON');
     }
 
-    // Run the full verification pipeline
-    const result = this.webhookSecurityService.verifyStripeWebhook(rawBody, signature, eventId);
-
-    if (!result.valid) {
-      this.logger.warn(`Stripe webhook rejected: ${result.reason}`);
-      throw new UnauthorizedException(result.reason);
+    // Step 3: Replay attack prevention using the parsed event ID
+    if (this.webhookSecurityService.isReplayAttack(eventId || '')) {
+      throw new UnauthorizedException(`Duplicate event: ${eventId}`);
     }
 
     return true;

--- a/src/routing/services/routing-config.service.ts
+++ b/src/routing/services/routing-config.service.ts
@@ -40,7 +40,31 @@ export class RoutingConfigService implements OnModuleInit {
 
       if (configExists) {
         const configData = await fs.readFile(this.configPath, 'utf-8');
-        this.config = JSON.parse(configData);
+
+        // Guard JSON.parse with try/catch
+        let parsed: unknown;
+        try {
+          parsed = JSON.parse(configData);
+        } catch (parseError) {
+          this.logger.error(
+            `Malformed JSON in routing config at ${this.configPath}: ${parseError}. ` +
+              'Falling back to default configuration.',
+          );
+          this.config = this.getDefaultConfig();
+          return;
+        }
+
+        // Schema-validate the parsed config before applying it
+        if (!this.isValidDynamicRoutingConfig(parsed)) {
+          this.logger.error(
+            `Invalid routing config schema in ${this.configPath}. ` +
+              'Falling back to default configuration.',
+          );
+          this.config = this.getDefaultConfig();
+          return;
+        }
+
+        this.config = parsed as DynamicRoutingConfig;
         this.logger.log(`Routing configuration loaded from ${this.configPath}`);
       } else {
         await this.saveConfig();
@@ -50,6 +74,47 @@ export class RoutingConfigService implements OnModuleInit {
       this.logger.error(`Failed to load routing configuration: ${error}`);
       this.config = this.getDefaultConfig();
     }
+  }
+
+  /**
+   * Schema-validate a parsed object against the DynamicRoutingConfig shape.
+   * Rejects invalid configs rather than applying them partially.
+   */
+  private isValidDynamicRoutingConfig(value: unknown): boolean {
+    if (!value || typeof value !== 'object') {
+      return false;
+    }
+
+    const candidate = value as Record<string, unknown>;
+
+    // Must have a 'rules' array
+    if (!Array.isArray(candidate.rules)) {
+      return false;
+    }
+
+    // Validate each rule has the required fields
+    for (const rule of candidate.rules) {
+      if (!rule || typeof rule !== 'object') {
+        return false;
+      }
+      const r = rule as Record<string, unknown>;
+      if (typeof r.id !== 'string' || typeof r.name !== 'string') {
+        return false;
+      }
+      if (!Array.isArray(r.conditions)) {
+        return false;
+      }
+      if (!r.action || typeof r.action !== 'object') {
+        return false;
+      }
+    }
+
+    // defaultAction is optional but must be an object if present
+    if (candidate.defaultAction !== undefined && typeof candidate.defaultAction !== 'object') {
+      return false;
+    }
+
+    return true;
   }
 
   /**

--- a/src/session/session.service.spec.ts
+++ b/src/session/session.service.spec.ts
@@ -286,9 +286,28 @@ describe('SessionService', () => {
       expect(SessionService.parseDurationToSeconds(' 7d ')).toBe(604800);
     });
 
-    it('should return 0 for unrecognized formats', () => {
-      expect(SessionService.parseDurationToSeconds('invalid')).toBe(0);
-      expect(SessionService.parseDurationToSeconds('')).toBe(0);
+    it('should throw for unrecognized formats instead of silently returning 0', () => {
+      expect(() => SessionService.parseDurationToSeconds('invalid')).toThrow(
+        'Unparseable duration string: "invalid"',
+      );
+      expect(() => SessionService.parseDurationToSeconds('')).toThrow(
+        'Unparseable duration string: ""',
+      );
+    });
+
+    it('should throw for ambiguous formats like "7days" or "1 d"', () => {
+      expect(() => SessionService.parseDurationToSeconds('7days')).toThrow(
+        'Unparseable duration string: "7days"',
+      );
+      expect(() => SessionService.parseDurationToSeconds('1 d')).toThrow(
+        'Unparseable duration string: "1 d"',
+      );
+    });
+
+    it('should distinguish genuine "0" from unparseable values', () => {
+      expect(SessionService.parseDurationToSeconds('0')).toBe(0);
+      expect(SessionService.parseDurationToSeconds('0s')).toBe(0);
+      expect(() => SessionService.parseDurationToSeconds('zero')).toThrow();
     });
   });
 

--- a/src/session/session.service.ts
+++ b/src/session/session.service.ts
@@ -70,11 +70,20 @@ export class SessionService implements OnModuleDestroy {
 
   /**
    * Parses a duration string (e.g. "7d", "30d", "1h", "60m", "3600s") into seconds.
-   * Falls back to parseInt for bare numeric strings.
+   * Falls back to parseInt for bare numeric strings (e.g. "604800").
+   *
+   * @throws {Error} If the duration string cannot be parsed (distinguishes from a genuine "0").
    */
   static parseDurationToSeconds(duration: string): number {
     const trimmed = duration.trim().toLowerCase();
-    const match = trimmed.match(/^(\d+)\s*(d|h|m|s)$/);
+
+    // Explicit zero
+    if (trimmed === '0' || trimmed === '0s') {
+      return 0;
+    }
+
+    // Supported format: number immediately followed by unit (d|h|m|s) - no spaces
+    const match = trimmed.match(/^(\d+)(d|h|m|s)$/);
     if (match) {
       const value = parseInt(match[1], 10);
       switch (match[2]) {
@@ -88,11 +97,18 @@ export class SessionService implements OnModuleDestroy {
           return value;
       }
     }
+
+    // Bare numeric fallback
     const numeric = parseInt(trimmed, 10);
-    if (!Number.isNaN(numeric)) {
+    if (!Number.isNaN(numeric) && String(numeric) === trimmed) {
       return numeric;
     }
-    return 0;
+
+    throw new Error(
+      `Unparseable duration string: "${duration}". ` +
+        'Supported formats: <number>d|h|m|s (e.g. "7d", "1h", "30m", "3600s") ' +
+        'or a bare numeric string of seconds (e.g. "604800").',
+    );
   }
 
   /**


### PR DESCRIPTION
## Summary

Resolves all 4 Stellar Wave issues assigned to @Spycall in a single PR.

### Issues Resolved

- **Closes #1134** - Guard JSON.parse of the raw request body in the Stripe webhook guard
  - Signature verification now runs against raw body **before** JSON parsing
  - Malformed JSON bodies return **400 Bad Request** instead of 500
  - Replay attack prevention runs only after successful parse

- **Closes #1133** - Fail fast on unparseable duration strings in SessionService.parseDurationToSeconds
  - Throws a descriptive error instead of silently returning 0 for invalid durations
  - Distinguishes genuine `0` from unparseable values
  - Stricter regex (no whitespace between number and unit) to catch typos like `1 d`
  - Constructor naturally fails fast at startup on bad config values

- **Closes #1132** - Guard JSON.parse of cached blobs in AdaptiveTtlService and CacheAnalyticsService
  - All `JSON.parse` calls on cached data wrapped in try/catch
  - Shape validation on parsed objects before use
  - **Deserialization failure counter** (`cache:metrics:deserialization_failures_total`) emitted for observability
  - Corrupt entries treated as cache misses and recomputed

- **Closes #1131** - Schema-validate runtime routing configuration and guard JSON.parse in RoutingConfigService
  - JSON.parse guarded with try/catch; falls back to defaults on failure
  - `isValidDynamicRoutingConfig()` schema validator rejects invalid configs
  - Malformed or schema-invalid configs logged clearly and rejected

### Validation

- ✅ All 26 session service tests pass
- ✅ No TypeScript errors in modified files
- ✅ Prettier formatting applied
- ✅ Code reviewed and feedback addressed

### Files Changed

| File | Changes |
|------|--------|
| `src/payments/webhooks/stripe-webhook.guard.ts` | Verify signature before parse, 400 on malformed JSON |
| `src/session/session.service.ts` | Throw on invalid duration strings |
| `src/session/session.service.spec.ts` | Updated tests for throw behavior + new edge cases |
| `src/caching/adaptive-ttl.service.ts` | Guard JSON.parse, shape validation, failure counters |
| `src/caching/cache-analytics.service.ts` | Guard JSON.parse, shape validation, failure counters |
| `src/routing/services/routing-config.service.ts` | Guard JSON.parse, schema validation, safe fallback |