### PR TITLE
fix(invoices): add auth and ownership checks to InvoicesController (#…

### DIFF
--- a/src/payments/invoices/invoices.controller.ts
+++ b/src/payments/invoices/invoices.controller.ts
@@ -6,18 +6,37 @@ import {
   Header,
   Res,
   NotFoundException,
+  UseGuards,
 } from '@nestjs/common';
 import { Response } from 'express';
 import { createReadStream } from 'fs';
 import { InvoicesService } from './invoices.service';
+import { JwtAuthGuard } from '../../auth/guards/jwt-auth.guard';
+import { CurrentUser } from '../../auth/decorators/current-user.decorator';
+import { User, UserRole } from '../../users/entities/user.entity';
 
+@UseGuards(JwtAuthGuard)
 @Controller('invoices')
 export class InvoicesController {
   constructor(private readonly invoicesService: InvoicesService) {}
 
   @Get(':id')
-  async getInvoice(@Param('id') id: string) {
-    return this.invoicesService.getInvoice(id);
+  async getInvoice(@Param('id') id: string, @CurrentUser() currentUser: User) {
+    // Fetch invoice first; return 404 for both missing and non-owned to
+    // prevent id enumeration (no distinguishable difference to the caller).
+    const invoice = await this.invoicesService.getInvoice(id);
+
+    const isAdmin =
+      Array.isArray(currentUser.roles) &&
+      currentUser.roles.some((r) => (typeof r === 'string' ? r : r.name) === UserRole.ADMIN);
+
+    if (!isAdmin && invoice.userId !== currentUser.id) {
+      // Uniform 404 — identical to the "not found" path so callers cannot
+      // distinguish between a missing invoice and one they do not own.
+      throw new NotFoundException(`Invoice with ID ${id} not found`);
+    }
+
+    return invoice;
   }
 
   @Get(':id/download')
@@ -25,14 +44,25 @@ export class InvoicesController {
   @Header('Content-Disposition', 'attachment; filename="invoice.html"')
   async downloadInvoice(
     @Param('id') id: string,
+    @CurrentUser() currentUser: User,
     @Res({ passthrough: true }) res: Response,
   ): Promise<StreamableFile> {
     const invoice = await this.invoicesService.getInvoice(id);
+
+    const isAdmin =
+      Array.isArray(currentUser.roles) &&
+      currentUser.roles.some((r) => (typeof r === 'string' ? r : r.name) === UserRole.ADMIN);
+
+    if (!isAdmin && invoice.userId !== currentUser.id) {
+      throw new NotFoundException(`Invoice with ID ${id} not found`);
+    }
 
     if (!invoice.fileUrl) {
       throw new NotFoundException('Invoice file not generated yet');
     }
 
+    // getInvoiceFilePath validates the resolved path is within the archive
+    // root; it throws if the path escapes the archive directory.
     const filePath = this.invoicesService.getInvoiceFilePath(invoice.fileUrl);
     const file = createReadStream(filePath);
 

--- a/src/payments/invoices/invoices.service.ts
+++ b/src/payments/invoices/invoices.service.ts
@@ -1,4 +1,10 @@
-import { Injectable, Logger, NotFoundException, ConflictException } from '@nestjs/common';
+import {
+  Injectable,
+  Logger,
+  NotFoundException,
+  ConflictException,
+  ForbiddenException,
+} from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { OnEvent } from '@nestjs/event-emitter';
@@ -54,19 +60,19 @@ export class InvoicesService {
 
   /**
    * Generate a unique invoice number from PostgreSQL sequence.
-   * 
+   *
    * Atomicity guarantee:
    *  - nextval() is atomic at the database level
    *  - Each concurrent call gets a distinct sequence value
    *  - No application-level locking needed
-   * 
+   *
    * @returns Invoice number formatted as `INV-<6-digit-zero-padded-sequence>`
    * @throws Error if sequence retrieval fails
    */
   private async generateInvoiceNumber(): Promise<string> {
     try {
       const result = await this.invoiceRepository.query(
-        `SELECT LPAD(nextval('invoice_number_seq')::text, 6, '0') as seq_value;`,
+        "SELECT LPAD(nextval('invoice_number_seq')::text, 6, '0') as seq_value;",
       );
 
       if (!result || result.length === 0) {
@@ -76,10 +82,7 @@ export class InvoicesService {
       const sequenceValue = result[0].seq_value;
       return `INV-${sequenceValue}`;
     } catch (error) {
-      this.logger.error(
-        'Failed to generate invoice number from sequence',
-        (error as Error).stack,
-      );
+      this.logger.error('Failed to generate invoice number from sequence', (error as Error).stack);
       throw new Error(`Invoice number generation failed: ${(error as Error).message}`);
     }
   }
@@ -134,14 +137,14 @@ export class InvoicesService {
       throw error;
     }
 
-function escapeHtml(val: any): string {
-  return String(val ?? '')
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&#39;');
-}
+    function escapeHtml(val: any): string {
+      return String(val ?? '')
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;');
+    }
 
     // Generate HTML template
     const htmlContent = `
@@ -186,9 +189,25 @@ function escapeHtml(val: any): string {
   }
 
   getInvoiceFilePath(fileUrl: string): string {
-    if (!fs.existsSync(fileUrl)) {
+    // Resolve the candidate path to its absolute, canonical form so that
+    // sequences such as "../" or encoded variants cannot escape the archive root.
+    const resolvedPath = path.resolve(fileUrl);
+    const archiveRoot = path.resolve(this.storagePath);
+
+    // Ensure the resolved path starts with the archive root (with a trailing
+    // separator so that a directory named "archived_invoices_evil" is not
+    // accidentally accepted as a prefix match).
+    if (!resolvedPath.startsWith(archiveRoot + path.sep) && resolvedPath !== archiveRoot) {
+      this.logger.warn(
+        `Path traversal attempt blocked: "${fileUrl}" resolved to "${resolvedPath}" which is outside archive root "${archiveRoot}"`,
+      );
+      throw new ForbiddenException('Access to the requested file is not permitted');
+    }
+
+    if (!fs.existsSync(resolvedPath)) {
       throw new NotFoundException('Invoice file not found in archival storage');
     }
-    return fileUrl;
+
+    return resolvedPath;
   }
 }

--- a/test/invoices-auth.e2e-spec.ts
+++ b/test/invoices-auth.e2e-spec.ts
@@ -1,0 +1,252 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import request from 'supertest';
+import { DataSource } from 'typeorm';
+import * as bcrypt from 'bcrypt';
+import * as path from 'path';
+import { AppModule } from '../src/app.module';
+import { User, UserStatus } from '../src/users/entities/user.entity';
+import { Role } from '../src/rbac/entities/role.entity';
+import { Invoice, InvoiceStatus } from '../src/payments/entities/invoice.entity';
+import { Payment, PaymentStatus, PaymentMethod } from '../src/payments/entities/payment.entity';
+
+/**
+ * E2E tests for #970 — InvoicesController auth and ownership
+ *
+ * Covers:
+ *   1. Anonymous GET /invoices/:id → 401
+ *   2. Anonymous GET /invoices/:id/download → 401
+ *   3. Owner can fetch their own invoice → 200
+ *   4. User A requesting User B's invoice id → 404 (same shape as missing)
+ *   5. Admin can fetch any invoice → 200
+ *   6. fileUrl containing ../ traversal segments → rejected before any filesystem read
+ */
+describe('InvoicesController – auth, ownership & path traversal (e2e)', () => {
+  let app: INestApplication;
+  let dataSource: DataSource;
+
+  // Two regular users and one admin
+  let userA: User;
+  let userB: User;
+  let adminUser: User;
+
+  // Invoice owned by userA
+  let invoiceA: Invoice;
+
+  // Invoice whose fileUrl is a traversal path (owned by userA so auth passes)
+  let invoiceTraversal: Invoice;
+
+  // Bearer tokens
+  let tokenA: string;
+  let tokenB: string;
+  let tokenAdmin: string;
+
+  const rawPassword = 'Password123!';
+
+  // ─── helpers ─────────────────────────────────────────────────────────────
+
+  async function createUser(
+    email: string,
+    roleName: 'student' | 'admin',
+    ds: DataSource,
+  ): Promise<User> {
+    const hashed = await bcrypt.hash(rawPassword, 8);
+
+    const roleRepo = ds.getRepository(Role);
+    let role = await roleRepo.findOne({ where: { name: roleName } });
+    if (!role) {
+      role = roleRepo.create({ name: roleName, isSystem: true });
+      await roleRepo.save(role);
+    }
+
+    const userRepo = ds.getRepository(User);
+    const user = userRepo.create({
+      email,
+      password: hashed,
+      firstName: 'Test',
+      lastName: 'User',
+      status: UserStatus.ACTIVE,
+      roles: [role],
+    });
+    return userRepo.save(user);
+  }
+
+  async function loginAndGetToken(email: string, server: any): Promise<string> {
+    const res = await request(server).post('/auth/login').send({ email, password: rawPassword });
+    return (res.body.accessToken as string) ?? (res.body.access_token as string);
+  }
+
+  async function createInvoice(userId: string, fileUrl: string, ds: DataSource): Promise<Invoice> {
+    // We need a real Payment row first (FK constraint)
+    const paymentRepo = ds.getRepository(Payment);
+    const payment = paymentRepo.create({
+      userId,
+      amount: 99,
+      currency: 'USD',
+      status: PaymentStatus.COMPLETED,
+      method: PaymentMethod.CREDIT_CARD,
+    });
+    const savedPayment = await paymentRepo.save(payment);
+
+    const invoiceRepo = ds.getRepository(Invoice);
+    const invoice = invoiceRepo.create({
+      invoiceNumber: `INV-TEST-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`,
+      amount: 99,
+      taxAmount: 0,
+      totalAmount: 99,
+      currency: 'USD',
+      items: [{ description: 'Test item', amount: 99, quantity: 1 }],
+      status: InvoiceStatus.PAID,
+      issuedDate: new Date(),
+      paymentId: savedPayment.id,
+      userId,
+      fileUrl,
+    });
+    return invoiceRepo.save(invoice);
+  }
+
+  // ─── setup ───────────────────────────────────────────────────────────────
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    app.useGlobalPipes(new ValidationPipe({ whitelist: true }));
+    await app.init();
+
+    dataSource = app.get(DataSource);
+
+    const ts = Date.now();
+
+    // Create two regular users + one admin
+    userA = await createUser(`invoice-user-a-${ts}@test.local`, 'student', dataSource);
+    userB = await createUser(`invoice-user-b-${ts}@test.local`, 'student', dataSource);
+    adminUser = await createUser(`invoice-admin-${ts}@test.local`, 'admin', dataSource);
+
+    // Build a safe fileUrl that lives inside the archive directory
+    const safeFileUrl = path.join(process.cwd(), 'archived_invoices', `INV-TEST-${ts}.html`);
+
+    // Invoice owned by userA with a safe fileUrl
+    invoiceA = await createInvoice(userA.id, safeFileUrl, dataSource);
+
+    // Invoice owned by userA but with a traversal path as fileUrl
+    const traversalFileUrl = path.join(process.cwd(), 'archived_invoices', '..', 'package.json');
+    invoiceTraversal = await createInvoice(userA.id, traversalFileUrl, dataSource);
+
+    // Obtain tokens via the real login endpoint
+    const server = app.getHttpServer();
+    tokenA = await loginAndGetToken(userA.email, server);
+    tokenB = await loginAndGetToken(userB.email, server);
+    tokenAdmin = await loginAndGetToken(adminUser.email, server);
+  }, 60_000);
+
+  afterAll(async () => {
+    // Clean up in FK-safe order
+    const invoiceRepo = dataSource.getRepository(Invoice);
+    const paymentRepo = dataSource.getRepository(Payment);
+    const userRepo = dataSource.getRepository(User);
+
+    for (const inv of [invoiceA, invoiceTraversal]) {
+      if (inv) {
+        await invoiceRepo.delete(inv.id).catch(() => {});
+        await paymentRepo.delete(inv.paymentId).catch(() => {});
+      }
+    }
+
+    for (const u of [userA, userB, adminUser]) {
+      if (u) await userRepo.delete(u.id).catch(() => {});
+    }
+
+    await app.close();
+  }, 30_000);
+
+  // ─── authentication ───────────────────────────────────────────────────────
+
+  describe('Anonymous access', () => {
+    it('GET /invoices/:id without a token → 401', async () => {
+      await request(app.getHttpServer()).get(`/invoices/${invoiceA.id}`).expect(401);
+    });
+
+    it('GET /invoices/:id/download without a token → 401', async () => {
+      await request(app.getHttpServer()).get(`/invoices/${invoiceA.id}/download`).expect(401);
+    });
+  });
+
+  // ─── ownership ────────────────────────────────────────────────────────────
+
+  describe('Ownership checks', () => {
+    it('owner (userA) can fetch their own invoice', async () => {
+      const res = await request(app.getHttpServer())
+        .get(`/invoices/${invoiceA.id}`)
+        .set('Authorization', `Bearer ${tokenA}`)
+        .expect(200);
+
+      expect(res.body.id).toBe(invoiceA.id);
+    });
+
+    it("non-owner (userB) requesting userA's invoice id receives 404", async () => {
+      await request(app.getHttpServer())
+        .get(`/invoices/${invoiceA.id}`)
+        .set('Authorization', `Bearer ${tokenB}`)
+        .expect(404);
+    });
+
+    it('non-owner 404 body is indistinguishable from a genuinely missing invoice', async () => {
+      const missingId = '00000000-0000-0000-0000-000000000000';
+
+      const missingRes = await request(app.getHttpServer())
+        .get(`/invoices/${missingId}`)
+        .set('Authorization', `Bearer ${tokenA}`)
+        .expect(404);
+
+      const nonOwnedRes = await request(app.getHttpServer())
+        .get(`/invoices/${invoiceA.id}`)
+        .set('Authorization', `Bearer ${tokenB}`)
+        .expect(404);
+
+      // Both should have statusCode 404 — no body differences that leak ownership
+      expect(missingRes.body.statusCode).toBe(404);
+      expect(nonOwnedRes.body.statusCode).toBe(404);
+    });
+
+    it("admin can fetch any user's invoice", async () => {
+      const res = await request(app.getHttpServer())
+        .get(`/invoices/${invoiceA.id}`)
+        .set('Authorization', `Bearer ${tokenAdmin}`)
+        .expect(200);
+
+      expect(res.body.id).toBe(invoiceA.id);
+    });
+
+    it('non-owner GET /invoices/:id/download → 404', async () => {
+      await request(app.getHttpServer())
+        .get(`/invoices/${invoiceA.id}/download`)
+        .set('Authorization', `Bearer ${tokenB}`)
+        .expect(404);
+    });
+  });
+
+  // ─── path traversal ───────────────────────────────────────────────────────
+
+  describe('Path traversal protection', () => {
+    it('download with a fileUrl that escapes the archive root is rejected (403)', async () => {
+      // The invoice is owned by userA so auth passes; traversal should be blocked.
+      const res = await request(app.getHttpServer())
+        .get(`/invoices/${invoiceTraversal.id}/download`)
+        .set('Authorization', `Bearer ${tokenA}`);
+
+      // Service must reject with 403 before opening the file
+      expect(res.status).toBe(403);
+    });
+
+    it('traversal rejection occurs regardless of admin status', async () => {
+      const res = await request(app.getHttpServer())
+        .get(`/invoices/${invoiceTraversal.id}/download`)
+        .set('Authorization', `Bearer ${tokenAdmin}`);
+
+      expect(res.status).toBe(403);
+    });
+  });
+});


### PR DESCRIPTION
…970)

- Apply @UseGuards(JwtAuthGuard) at the controller class level so all invoice endpoints require a valid JWT; anonymous callers receive 401.

- Add ownership check in getInvoice and downloadInvoice: compare invoice.userId against req.user.id and allow an admin role override. Both missing and non-owned invoices return a uniform 404 so callers cannot enumerate invoice ids by observing response differences.

- Harden InvoicesService.getInvoiceFilePath: resolve the candidate path with path.resolve and assert it starts with the configured archive root (archived_invoices/). Any path that escapes the root (e.g. a fileUrl containing ../ segments) is rejected with ForbiddenException before any filesystem read occurs.

- Add e2e test suite (test/invoices-auth.e2e-spec.ts) covering:
  * Anonymous GET /invoices/:id -> 401
  * Anonymous GET /invoices/:id/download -> 401
  * Owner fetch -> 200
  * Non-owner fetch -> uniform 404 indistinguishable from missing id
  * Admin override -> 200
  * Path traversal fileUrl -> 403 for both owner and admin

Closes #970