### PR TITLE
Add standardized Retry-After header and error body on 429 responses

### DIFF
--- a/src/common/interceptors/global-exception.filter.ts
+++ b/src/common/interceptors/global-exception.filter.ts
@@ -106,6 +106,17 @@ export class GlobalExceptionFilter implements ExceptionFilter {
       );
     }
 
+    let retryAfter: number | undefined;
+    if (exception instanceof RateLimitExceededException) {
+      const resp = exception.getResponse();
+      if (typeof resp === 'object' && resp !== null && 'retryAfterSeconds' in resp) {
+        retryAfter = (resp as { retryAfterSeconds: number }).retryAfterSeconds;
+      }
+    }
+    if (retryAfter !== undefined) {
+      response.setHeader('Retry-After', retryAfter);
+    }
+
     response.status(status).json({
       success: false,
       error: {

--- a/src/rate-limiting/guards/quota.guard.ts
+++ b/src/rate-limiting/guards/quota.guard.ts
@@ -68,11 +68,14 @@ export class QuotaGuard implements CanActivate {
     res.setHeader('X-RateLimit-Remaining-Day', result.remaining.day);
 
     if (!result.allowed) {
-      res.setHeader('Retry-After', result.retryAfter ?? 60);
+      const retryAfter = result.retryAfter ?? 60;
+      const resetTime = Math.floor(Date.now() / 1000) + retryAfter;
+      res.setHeader('Retry-After', retryAfter);
+      res.setHeader('X-RateLimit-Reset', resetTime);
       this.logger.warn(
-        `Quota exceeded identifier=${identifier} tier=${tier} retryAfter=${result.retryAfter}s`,
+        `Quota exceeded identifier=${identifier} tier=${tier} retryAfter=${retryAfter}s`,
       );
-      throw new RateLimitExceededException(result.retryAfter);
+      throw new RateLimitExceededException(retryAfter);
     }
 
     return true;

--- a/src/rate-limiting/guards/tenant-quota.guard.ts
+++ b/src/rate-limiting/guards/tenant-quota.guard.ts
@@ -1,4 +1,6 @@
-import { Injectable, CanActivate, ExecutionContext, HttpException } from '@nestjs/common';
+import { Injectable, CanActivate, ExecutionContext } from '@nestjs/common';
+import { Request, Response } from 'express';
+import { RateLimitExceededException } from '../../common/exceptions/app.exceptions';
 
 @Injectable()
 export class TenantQuotaGuard implements CanActivate {
@@ -10,7 +12,8 @@ export class TenantQuotaGuard implements CanActivate {
   private counters = new Map<string, { count: number; resetAt: number }>();
 
   canActivate(context: ExecutionContext): boolean {
-    const req = context.switchToHttp().getRequest();
+    const req = context.switchToHttp().getRequest<Request>();
+    const res = context.switchToHttp().getResponse<Response>();
     const tenantId = req.headers['x-tenant-id'] as string;
     if (!tenantId) return true;
 
@@ -29,7 +32,13 @@ export class TenantQuotaGuard implements CanActivate {
 
     entry.count++;
     if (entry.count > limit) {
-      throw new HttpException('Tenant rate limit exceeded', 429);
+      const retryAfter = Math.ceil((entry.resetAt - now) / 1000);
+      const resetTime = Math.floor(now / 1000) + retryAfter;
+      res.setHeader('Retry-After', retryAfter);
+      res.setHeader('X-RateLimit-Limit', limit);
+      res.setHeader('X-RateLimit-Remaining', 0);
+      res.setHeader('X-RateLimit-Reset', resetTime);
+      throw new RateLimitExceededException(retryAfter);
     }
     return true;
   }


### PR DESCRIPTION
## Summary

Implemented standardized Retry-After header and rate-limit headers across all rate-limiting guards, with consistent error body matching the application's standard error envelope.

### Changes

- Added X-RateLimit-Reset header to QuotaGuard 429 responses for both IP- and user-scoped limits
- Replaced raw HttpException in TenantQuotaGuard with RateLimitExceededException to emit the standard error shape
- Added Retry-After, X-RateLimit-Limit, X-RateLimit-Remaining, and X-RateLimit-Reset headers to TenantQuotaGuard
- Enhanced GlobalExceptionFilter to extract retryAfterSeconds from RateLimitExceededException and set the Retry-After HTTP header on the response

Closes #1162
Closes #1163
Closes #1161
Closes #1139