### PR TITLE
Enforce max job payload size in QueueService

### DIFF
--- a/src/queues/queue.service.ts
+++ b/src/queues/queue.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Logger, NotFoundException } from '@nestjs/common';
+import { Injectable, Logger, NotFoundException, PayloadTooLargeException } from '@nestjs/common';
 import { InjectQueue } from '@nestjs/bull';
 import { Queue, Job, JobOptions as BullJobOptions } from 'bull';
 import { QUEUE_NAMES } from '../common/constants/queue.constants';
@@ -12,6 +12,15 @@ export interface AddJobResult {
   queue: string;
   name: string;
 }
+
+const DEFAULT_MAX_PAYLOAD_BYTES = 1_048_576; // 1 MB
+
+const QUEUE_MAX_PAYLOAD_OVERRIDES: Record<string, number> = {
+  // Media processing handles binary payloads; allow up to 10 MB
+  media_processing: 10_485_760,
+  // User data export payloads include serialized records; allow up to 5 MB
+  user_data_export: 5_242_880,
+};
 
 @Injectable()
 export class QueueService {
@@ -67,6 +76,15 @@ export class QueueService {
     options?: Partial<IJobOptions>,
     retryStrategy?: RetryStrategyKey,
   ): Promise<AddJobResult> {
+    const payloadBytes = Buffer.byteLength(JSON.stringify(data), 'utf-8');
+    const maxBytes =
+      QUEUE_MAX_PAYLOAD_OVERRIDES[queueName] ?? DEFAULT_MAX_PAYLOAD_BYTES;
+    if (payloadBytes > maxBytes) {
+      throw new PayloadTooLargeException(
+        `Job payload for queue "${queueName}" is ${payloadBytes} bytes, exceeding the ${maxBytes} byte limit`,
+      );
+    }
+
     const queue = this.getQueue(queueName);
     const priorityLevel = options?.priority ?? JobPriority.NORMAL;
     const bullPriority = this.prioritizationService.toBullPriority(priorityLevel);


### PR DESCRIPTION
## Summary

Added payload size validation to QueueService to reject oversized jobs before they are enqueued.

### Changes

- Validate serialized payload byte length in `addJob()` before adding to the queue
- Default limit: 1 MB
- Per-queue overrides: `media_processing` (10 MB), `user_data_export` (5 MB)
- Rejects oversized payloads with 413 Payload Too Large

Closes #1171
Closes #1169 
Closes #1170 
Closes #1172 