### PR TITLE
feat(cohorts): add pagination to unbounded find() queries in CohortsS…

### DIFF
--- a/src/cohorts/cohorts.controller.ts
+++ b/src/cohorts/cohorts.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Post, Get, Body, Param, Req, UseGuards, Delete } from '@nestjs/common';
+import { Controller, Post, Get, Body, Param, Req, UseGuards, Delete, Query } from '@nestjs/common';
 import { ApiTags, ApiBearerAuth, ApiOperation, ApiResponse } from '@nestjs/swagger';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { CohortsService } from './cohorts.service';
@@ -7,6 +7,7 @@ import { AddCohortMemberDto } from './dto/add-cohort-member.dto';
 import { CreateCohortThreadDto } from './dto/create-cohort-thread.dto';
 import { CreateCohortCommentDto } from './dto/create-cohort-comment.dto';
 import { CreateCohortAssignmentDto } from './dto/create-cohort-assignment.dto';
+import { PaginationQueryDto } from '../common/dto/pagination.dto';
 
 @ApiTags('Cohorts')
 @Controller('cohorts')
@@ -52,8 +53,8 @@ export class CohortsController {
 
   @Get(':id/members')
   @ApiOperation({ summary: 'List cohort members' })
-  listMembers(@Param('id') id: string, @Req() req: any) {
-    return this.cohortsService.listMembers(id, req.user.id);
+  listMembers(@Param('id') id: string, @Req() req: any, @Query() query?: PaginationQueryDto) {
+    return this.cohortsService.listMembers(id, req.user.id, query);
   }
 
   @Post(':id/threads')
@@ -64,8 +65,8 @@ export class CohortsController {
 
   @Get(':id/threads')
   @ApiOperation({ summary: 'List discussion threads inside a cohort' })
-  getThreads(@Param('id') id: string, @Req() req: any) {
-    return this.cohortsService.listThreads(id, req.user.id);
+  getThreads(@Param('id') id: string, @Req() req: any, @Query() query?: PaginationQueryDto) {
+    return this.cohortsService.listThreads(id, req.user.id, query);
   }
 
   @Get(':id/threads/:threadId')
@@ -96,8 +97,8 @@ export class CohortsController {
 
   @Get(':id/assignments')
   @ApiOperation({ summary: 'List assignments for a cohort' })
-  getAssignments(@Param('id') id: string, @Req() req: any) {
-    return this.cohortsService.listAssignments(id, req.user.id);
+  getAssignments(@Param('id') id: string, @Req() req: any, @Query() query?: PaginationQueryDto) {
+    return this.cohortsService.listAssignments(id, req.user.id, query);
   }
 
   @Get(':id/assignments/:assignmentId')

--- a/src/cohorts/cohorts.service.spec.ts
+++ b/src/cohorts/cohorts.service.spec.ts
@@ -1,0 +1,187 @@
+import { CohortsService } from './cohorts.service';
+import { buildOffsetResponse, clampLimit } from '../common/utils/pagination.utils';
+
+describe('CohortsService', () => {
+  let service: CohortsService;
+  let mockCohortRepo: any;
+  let mockMemberRepo: any;
+  let mockThreadRepo: any;
+  let mockCommentRepo: any;
+  let mockAssignmentRepo: any;
+
+  const mockMembership = { id: 'mem-1', cohortId: 'cohort-1', userId: 'user-1', role: 'member' };
+  const mockMember = { id: 'm-1', cohortId: 'cohort-1', userId: 'user-2', role: 'member', createdAt: new Date() };
+  const mockThread = { id: 't-1', cohortId: 'cohort-1', authorId: 'user-2', title: 'Thread', content: 'Content', createdAt: new Date() };
+  const mockAssignment = { id: 'a-1', cohortId: 'cohort-1', title: 'Assignment', createdAt: new Date() };
+
+  beforeEach(() => {
+    mockCohortRepo = {
+      findOne: jest.fn().mockResolvedValue(null),
+      create: jest.fn((dto) => dto),
+      save: jest.fn(async (data) => ({ id: 'cohort-1', ...data })),
+      createQueryBuilder: jest.fn(() => ({
+        innerJoin: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        orderBy: jest.fn().mockReturnThis(),
+        getOne: jest.fn().mockResolvedValue(null),
+        getMany: jest.fn().mockResolvedValue([]),
+      })),
+    };
+
+    mockMemberRepo = {
+      findOne: jest.fn().mockResolvedValue(mockMembership),
+      create: jest.fn((dto) => dto),
+      save: jest.fn(async (data) => ({ id: 'new-id', ...data })),
+      findAndCount: jest.fn().mockResolvedValue([[mockMember], 1]),
+    };
+
+    mockThreadRepo = {
+      findOne: jest.fn().mockResolvedValue(null),
+      create: jest.fn((dto) => dto),
+      save: jest.fn(async (data) => ({ id: 'new-id', ...data })),
+      findAndCount: jest.fn().mockResolvedValue([[mockThread], 1]),
+    };
+
+    mockCommentRepo = {
+      create: jest.fn((dto) => dto),
+      save: jest.fn(async (data) => ({ id: 'new-id', ...data })),
+    };
+
+    mockAssignmentRepo = {
+      findOne: jest.fn().mockResolvedValue(null),
+      create: jest.fn((dto) => dto),
+      save: jest.fn(async (data) => ({ id: 'new-id', ...data })),
+      findAndCount: jest.fn().mockResolvedValue([[mockAssignment], 1]),
+    };
+
+    service = new CohortsService(
+      mockCohortRepo,
+      mockMemberRepo,
+      mockThreadRepo,
+      mockCommentRepo,
+      mockAssignmentRepo,
+    );
+
+    mockCohortRepo.findOne.mockResolvedValue({ id: 'cohort-1', ownerId: 'user-1' });
+  });
+
+  describe('listMembers', () => {
+    it('should return paginated members with default page size', async () => {
+      mockMemberRepo.findAndCount.mockResolvedValue([[mockMember], 1]);
+
+      const result = await service.listMembers('cohort-1', 'user-1');
+
+      expect(result.data).toEqual([mockMember]);
+      expect(result.total).toBe(1);
+      expect(result.page).toBe(1);
+      expect(result.limit).toBe(10);
+      expect(result.totalPages).toBe(1);
+      expect(mockMemberRepo.findAndCount).toHaveBeenCalledWith(
+        expect.objectContaining({ skip: 0, take: 10 }),
+      );
+    });
+
+    it('should respect custom page and limit', async () => {
+      const items = Array.from({ length: 5 }, (_, i) => ({
+        ...mockMember,
+        id: `m-${i + 1}`,
+        createdAt: new Date(),
+      }));
+      mockMemberRepo.findAndCount.mockResolvedValue([items, 25]);
+
+      const result = await service.listMembers('cohort-1', 'user-1', { page: 2, limit: 5 });
+
+      expect(result.data).toHaveLength(5);
+      expect(result.total).toBe(25);
+      expect(result.page).toBe(2);
+      expect(result.limit).toBe(5);
+      expect(result.totalPages).toBe(5);
+      expect(result.hasNextPage).toBe(true);
+      expect(result.hasPrevPage).toBe(true);
+      expect(mockMemberRepo.findAndCount).toHaveBeenCalledWith(
+        expect.objectContaining({ skip: 5, take: 5 }),
+      );
+    });
+
+    it('should enforce max page size via clampLimit', async () => {
+      mockMemberRepo.findAndCount.mockResolvedValue([[mockMember], 1]);
+
+      await service.listMembers('cohort-1', 'user-1', { page: 1, limit: 999 });
+
+      expect(mockMemberRepo.findAndCount).toHaveBeenCalledWith(
+        expect.objectContaining({ take: 100 }),
+      );
+    });
+
+    it('should return first page when no query is provided', async () => {
+      mockMemberRepo.findAndCount.mockResolvedValue([[mockMember], 1]);
+
+      const result = await service.listMembers('cohort-1', 'user-1', undefined);
+
+      expect(result.page).toBe(1);
+      expect(mockMemberRepo.findAndCount).toHaveBeenCalledWith(
+        expect.objectContaining({ skip: 0, take: 10 }),
+      );
+    });
+
+    it('should reject non-members with ForbiddenException', async () => {
+      mockMemberRepo.findOne.mockResolvedValue(null);
+
+      await expect(service.listMembers('cohort-1', 'user-2')).rejects.toThrow('Access denied');
+    });
+  });
+
+  describe('listThreads', () => {
+    it('should return paginated threads ordered by createdAt DESC', async () => {
+      mockThreadRepo.findAndCount.mockResolvedValue([[mockThread], 1]);
+
+      const result = await service.listThreads('cohort-1', 'user-1', { page: 1, limit: 10 });
+
+      expect(result.data).toEqual([mockThread]);
+      expect(result.total).toBe(1);
+      expect(result.page).toBe(1);
+      expect(mockThreadRepo.findAndCount).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { cohortId: 'cohort-1' },
+          order: { createdAt: 'DESC' },
+          skip: 0,
+          take: 10,
+        }),
+      );
+    });
+  });
+
+  describe('listAssignments', () => {
+    it('should return paginated assignments ordered by createdAt DESC', async () => {
+      mockAssignmentRepo.findAndCount.mockResolvedValue([[mockAssignment], 1]);
+
+      const result = await service.listAssignments('cohort-1', 'user-1', { page: 1, limit: 10 });
+
+      expect(result.data).toEqual([mockAssignment]);
+      expect(result.total).toBe(1);
+      expect(result.page).toBe(1);
+      expect(mockAssignmentRepo.findAndCount).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { cohortId: 'cohort-1' },
+          order: { createdAt: 'DESC' },
+          skip: 0,
+          take: 10,
+        }),
+      );
+    });
+  });
+
+  describe('clampLimit', () => {
+    it('should default to DEFAULT_PAGE_SIZE when limit is undefined', () => {
+      expect(clampLimit(undefined)).toBe(10);
+    });
+
+    it('should cap at MAX_PAGE_SIZE', () => {
+      expect(clampLimit(200)).toBe(100);
+    });
+
+    it('should enforce minimum of 1', () => {
+      expect(clampLimit(0)).toBe(1);
+    });
+  });
+});

--- a/src/cohorts/cohorts.service.ts
+++ b/src/cohorts/cohorts.service.ts
@@ -16,6 +16,9 @@ import { AddCohortMemberDto } from './dto/add-cohort-member.dto';
 import { CreateCohortThreadDto } from './dto/create-cohort-thread.dto';
 import { CreateCohortCommentDto } from './dto/create-cohort-comment.dto';
 import { CreateCohortAssignmentDto } from './dto/create-cohort-assignment.dto';
+import { PaginationQueryDto } from '../common/dto/pagination.dto';
+import { OffsetPaginatedResponse } from '../common/interfaces/pagination.interface';
+import { buildOffsetResponse, clampLimit } from '../common/utils/pagination.utils';
 
 @Injectable()
 export class CohortsService {
@@ -106,9 +109,23 @@ export class CohortsService {
     await this.memberRepo.remove(membership);
   }
 
-  async listMembers(cohortId: string, userId: string): Promise<CohortMember[]> {
+  async listMembers(
+    cohortId: string,
+    userId: string,
+    query?: PaginationQueryDto,
+  ): Promise<OffsetPaginatedResponse<CohortMember>> {
     await this.requireMembership(cohortId, userId);
-    return this.memberRepo.find({ where: { cohortId }, order: { createdAt: 'ASC' } });
+    const limit = clampLimit(query?.limit);
+    const page = query?.page ?? 1;
+    const skip = (page - 1) * limit;
+
+    const [data, total] = await this.memberRepo.findAndCount({
+      where: { cohortId },
+      order: { createdAt: 'ASC' },
+      skip,
+      take: limit,
+    });
+    return buildOffsetResponse(data, total, page, limit);
   }
 
   async createThread(
@@ -127,12 +144,23 @@ export class CohortsService {
     return this.threadRepo.save(thread);
   }
 
-  async listThreads(cohortId: string, userId: string): Promise<CohortThread[]> {
+  async listThreads(
+    cohortId: string,
+    userId: string,
+    query?: PaginationQueryDto,
+  ): Promise<OffsetPaginatedResponse<CohortThread>> {
     await this.requireMembership(cohortId, userId);
-    return this.threadRepo.find({
+    const limit = clampLimit(query?.limit);
+    const page = query?.page ?? 1;
+    const skip = (page - 1) * limit;
+
+    const [data, total] = await this.threadRepo.findAndCount({
       where: { cohortId },
       order: { createdAt: 'DESC' },
+      skip,
+      take: limit,
     });
+    return buildOffsetResponse(data, total, page, limit);
   }
 
   async getThread(threadId: string, userId: string): Promise<CohortThread> {
@@ -189,9 +217,23 @@ export class CohortsService {
     return this.assignmentRepo.save(assignment);
   }
 
-  async listAssignments(cohortId: string, userId: string): Promise<CohortAssignment[]> {
+  async listAssignments(
+    cohortId: string,
+    userId: string,
+    query?: PaginationQueryDto,
+  ): Promise<OffsetPaginatedResponse<CohortAssignment>> {
     await this.requireMembership(cohortId, userId);
-    return this.assignmentRepo.find({ where: { cohortId }, order: { createdAt: 'DESC' } });
+    const limit = clampLimit(query?.limit);
+    const page = query?.page ?? 1;
+    const skip = (page - 1) * limit;
+
+    const [data, total] = await this.assignmentRepo.findAndCount({
+      where: { cohortId },
+      order: { createdAt: 'DESC' },
+      skip,
+      take: limit,
+    });
+    return buildOffsetResponse(data, total, page, limit);
   }
 
   async getAssignment(

--- a/src/cohorts/entities/cohort-assignment.entity.ts
+++ b/src/cohorts/entities/cohort-assignment.entity.ts
@@ -15,6 +15,7 @@ export enum CohortAssignmentStatus {
 }
 
 @Entity('cohort_assignments')
+@Index(['cohortId', 'createdAt'])
 export class CohortAssignment {
   @PrimaryGeneratedColumn('uuid')
   id: string;

--- a/src/cohorts/entities/cohort-member.entity.ts
+++ b/src/cohorts/entities/cohort-member.entity.ts
@@ -10,6 +10,7 @@ import {
 import { Cohort } from './cohort.entity';
 
 @Entity('cohort_members')
+@Index(['cohortId', 'createdAt'])
 export class CohortMember {
   @PrimaryGeneratedColumn('uuid')
   id: string;

--- a/src/cohorts/entities/cohort-thread.entity.ts
+++ b/src/cohorts/entities/cohort-thread.entity.ts
@@ -12,6 +12,7 @@ import { Cohort } from './cohort.entity';
 import { CohortComment } from './cohort-comment.entity';
 
 @Entity('cohort_threads')
+@Index(['cohortId', 'createdAt'])
 export class CohortThread {
   @PrimaryGeneratedColumn('uuid')
   id: string;


### PR DESCRIPTION
…ervice

- Add PaginationQueryDto with page/limit and enforced maximum to getMembers, getThreads, and getAssignments
- Return standard paginated envelope consistent with rest of codebase
- Add composite indexes on (cohortId, createdAt) to back ordering
- Update cohorts controller to accept pagination query params
- Add tests asserting bounded page sizes on all three endpoints

Closes #1135