### PR TITLE
feat: transactional outbox, auth rate limiting, and currency API docs

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -23,6 +23,7 @@ import { RateLimitingModule } from './rate-limiting/rate-limiting.module';
 import { QuotaGuard } from './rate-limiting/guards/quota.guard';
 import { IdempotencyModule } from './common/modules/idempotency.module';
 import { IdempotencyInterceptor } from './common/interceptors/idempotency.interceptor';
+import { OutboxModule } from './common/events/outbox.module';
 import { getDatabaseConfig } from './config/database.config';
 import { loadFeatureFlags } from './config/feature-flags.config';
 import { SessionModule } from './session/session.module';
@@ -74,6 +75,11 @@ const featureFlags = loadFeatureFlags();
     // wired into any controller (Payments, Payouts, Subscriptions,
     // PaymentMethods, etc.) resolves a single shared IdempotencyInterceptor.
     IdempotencyModule,
+    // Issue #1221 — transactional outbox. Registered at the root so the
+    // OutboxRelayService runs for the process lifetime; producer modules
+    // import OutboxModule again for the write-side OutboxService (NestJS
+    // shares the module instance, so the relay still starts exactly once).
+    OutboxModule,
     // Issue #808 — rate limiting is ON by default. Only load
     // RateLimitingModule when the operator has NOT set
     // DISABLE_RATE_LIMITING=true (legacy: ENABLE_RATE_LIMITING=false).

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -9,6 +9,9 @@ import {
   UseGuards,
   ConflictException,
 } from '@nestjs/common';
+import { Throttle } from '@nestjs/throttler';
+import { THROTTLE } from '../common/constants/throttle.constants';
+import { CustomThrottleGuard } from '../common/guards/throttle.guard';
 import { AuthService } from './auth.service';
 import { MfaService } from './mfa/mfa.service';
 import { LoginDto } from './dto/login.dto';
@@ -25,6 +28,7 @@ import { ApiTags, ApiOperation, ApiResponse, ApiBearerAuth } from '@nestjs/swagg
 
 @ApiTags('Auth')
 @Controller('auth')
+@UseGuards(CustomThrottleGuard)
 export class AuthController {
   constructor(
     private readonly authService: AuthService,
@@ -36,6 +40,7 @@ export class AuthController {
 
   @Post('register')
   @HttpCode(HttpStatus.CREATED)
+  @Throttle({ default: THROTTLE.STRICT })
   @LimitType('user')
   @UseGuards(TenantLimitGuard)
   @ApiOperation({ summary: 'Register a new user account' })
@@ -82,6 +87,7 @@ export class AuthController {
 
   @Post('login')
   @HttpCode(HttpStatus.OK)
+  @Throttle({ default: THROTTLE.AUTH_LOGIN })
   @ApiOperation({ summary: 'Log in with email and password' })
   @ApiResponse({ status: 200, description: 'Successfully authenticated' })
   @ApiResponse({ status: 401, description: 'Invalid credentials' })
@@ -139,6 +145,7 @@ export class AuthController {
 
   @Post('refresh')
   @HttpCode(HttpStatus.OK)
+  @Throttle({ default: THROTTLE.REFRESH })
   @ApiOperation({ summary: 'Refresh access and refresh tokens' })
   @ApiResponse({ status: 200, description: 'Successfully refreshed tokens' })
   @ApiResponse({ status: 401, description: 'Invalid or revoked refresh token' })
@@ -154,6 +161,7 @@ export class AuthController {
 
   @Post('logout')
   @UseGuards(JwtAuthGuard)
+  @Throttle({ default: THROTTLE.AUTH_DEFAULT })
   @ApiBearerAuth()
   @HttpCode(HttpStatus.OK)
   @ApiOperation({ summary: 'Log out and invalidate refresh token' })

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -2,7 +2,9 @@ import { ConfigModule, ConfigService } from '@nestjs/config';
 import { Module } from '@nestjs/common';
 import { JwtModule } from '@nestjs/jwt';
 import { PassportModule } from '@nestjs/passport';
+import { ThrottlerModule } from '@nestjs/throttler';
 import { TypeOrmModule } from '@nestjs/typeorm';
+import { TIME } from '../common/constants/time.constants';
 import { AuditLogModule } from '../audit-log/audit-log.module';
 import { RbacModule } from '../rbac/rbac.module';
 import { SecurityModule } from '../security/security.module';
@@ -34,6 +36,15 @@ import { GoogleStrategy } from './strategies/google.strategy';
  */
 @Module({
   imports: [
+    // Shared throttler used by the auth controllers. The per-route limits come
+    // from the documented THROTTLE presets (docs/rate-limiting.md); this
+    // default only applies to handlers without an explicit @Throttle.
+    ThrottlerModule.forRoot([
+      {
+        ttl: TIME.ONE_MINUTE_MS,
+        limit: 100,
+      },
+    ]),
     PassportModule.register({ defaultStrategy: 'jwt' }),
     JwtModule.registerAsync({
       imports: [ConfigModule],

--- a/src/auth/controllers/social-auth.controller.ts
+++ b/src/auth/controllers/social-auth.controller.ts
@@ -1,13 +1,18 @@
 import { Controller, Get, Req, UseGuards, HttpCode, HttpStatus } from '@nestjs/common';
 import { ApiTags, ApiOperation } from '@nestjs/swagger';
+import { Throttle } from '@nestjs/throttler';
+import { THROTTLE } from '../../common/constants/throttle.constants';
+import { CustomThrottleGuard } from '../../common/guards/throttle.guard';
 import { Request } from 'express';
 import { GoogleOAuthGuard } from '../guards/google-oauth.guard';
 import { GitHubOAuthGuard } from '../guards/github-oauth.guard';
 
 @ApiTags('auth')
 @Controller('auth')
+@UseGuards(CustomThrottleGuard)
 export class SocialAuthController {
   @Get('google')
+  @Throttle({ default: THROTTLE.AUTH_DEFAULT })
   @UseGuards(GoogleOAuthGuard)
   @ApiOperation({ summary: 'Initiate Google OAuth2 login' })
   @HttpCode(HttpStatus.FOUND)
@@ -16,6 +21,7 @@ export class SocialAuthController {
   }
 
   @Get('google/callback')
+  @Throttle({ default: THROTTLE.MODERATE })
   @UseGuards(GoogleOAuthGuard)
   @ApiOperation({ summary: 'Google OAuth2 callback' })
   googleCallback(@Req() req: Request): { user: Express.User | undefined } {
@@ -23,6 +29,7 @@ export class SocialAuthController {
   }
 
   @Get('github')
+  @Throttle({ default: THROTTLE.AUTH_DEFAULT })
   @UseGuards(GitHubOAuthGuard)
   @ApiOperation({ summary: 'Initiate GitHub OAuth2 login' })
   @HttpCode(HttpStatus.FOUND)
@@ -31,6 +38,7 @@ export class SocialAuthController {
   }
 
   @Get('github/callback')
+  @Throttle({ default: THROTTLE.MODERATE })
   @UseGuards(GitHubOAuthGuard)
   @ApiOperation({ summary: 'GitHub OAuth2 callback' })
   githubCallback(@Req() req: Request): { user: Express.User | undefined } {

--- a/src/caching/cache-invalidation.listener.ts
+++ b/src/caching/cache-invalidation.listener.ts
@@ -9,6 +9,9 @@ interface EntityEventPayload {
 
 /**
  * Listens for cache invalidation events and clears stale entries on write.
+ *
+ * Handlers are idempotent: deleting a cache key/pattern twice has the same
+ * effect as deleting it once, so outbox redelivery (issue #1221) is safe.
  */
 @Injectable()
 export class CacheInvalidationListener {

--- a/src/common/events/outbox-relay.service.spec.ts
+++ b/src/common/events/outbox-relay.service.spec.ts
@@ -1,0 +1,111 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { EventEmitter2 } from '@nestjs/event-emitter';
+import { OutboxEvent } from './outbox.entity';
+import { OutboxRelayService } from './outbox-relay.service';
+
+describe('OutboxRelayService', () => {
+  let service: OutboxRelayService;
+  let repo: {
+    find: jest.Mock;
+    update: jest.Mock;
+  };
+  let emitter: { emit: jest.Mock };
+
+  const pendingRow = (overrides: Partial<OutboxEvent> = {}): OutboxEvent =>
+    ({
+      id: 'evt-1',
+      eventName: 'cache.course.created',
+      payload: { id: 'course-1' },
+      createdAt: new Date(),
+      publishedAt: null,
+      attempts: 0,
+      ...overrides,
+    }) as OutboxEvent;
+
+  beforeEach(async () => {
+    repo = {
+      find: jest.fn(),
+      update: jest.fn().mockResolvedValue({ affected: 1 }),
+    };
+    emitter = { emit: jest.fn() };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        OutboxRelayService,
+        { provide: getRepositoryToken(OutboxEvent), useValue: repo },
+        { provide: EventEmitter2, useValue: emitter },
+      ],
+    }).compile();
+
+    service = module.get(OutboxRelayService);
+    service.stop(); // unit tests drive poll() directly
+  });
+
+  afterEach(() => {
+    service.stop();
+  });
+
+  it('dispatches unpublished events and marks them published', async () => {
+    repo.find.mockResolvedValue([pendingRow()]);
+
+    const dispatched = await service.poll();
+
+    expect(dispatched).toBe(1);
+    expect(emitter.emit).toHaveBeenCalledWith('cache.course.created', {
+      id: 'course-1',
+    });
+    expect(repo.update).toHaveBeenCalledWith('evt-1', {
+      publishedAt: expect.any(Date),
+    });
+  });
+
+  it('queries only unpublished rows in FIFO order', async () => {
+    repo.find.mockResolvedValue([]);
+
+    await service.poll();
+
+    // The relay relies on the WHERE clause to exclude already-published rows
+    // and on the ORDER BY for oldest-first delivery.
+    expect(repo.find).toHaveBeenCalledWith({
+      where: { publishedAt: expect.anything() },
+      order: { createdAt: 'ASC' },
+      take: expect.any(Number),
+    });
+  });
+
+  it('leaves the row unpublished and bumps attempts when dispatch throws', async () => {
+    repo.find.mockResolvedValue([pendingRow()]);
+    emitter.emit.mockImplementation(() => {
+      throw new Error('handler failed');
+    });
+
+    const dispatched = await service.poll();
+
+    expect(dispatched).toBe(0);
+    expect(repo.update).toHaveBeenCalledWith('evt-1', { attempts: 1 });
+    // publishedAt must NOT be set so the event is retried (at-least-once).
+    expect(repo.update).not.toHaveBeenCalledWith('evt-1', {
+      publishedAt: expect.any(Date),
+    });
+  });
+
+  it('does not re-enter poll while a poll cycle is in flight', async () => {
+    let resolveFind!: (rows: OutboxEvent[]) => void;
+    repo.find.mockReturnValue(
+      new Promise<OutboxEvent[]>((resolve) => {
+        resolveFind = resolve;
+      }),
+    );
+
+    const first = service.poll();
+    // Second call while the first is awaiting the DB read.
+    const second = service.poll();
+
+    resolveFind([pendingRow()]);
+
+    await Promise.all([first, second]);
+
+    expect(emitter.emit).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/common/events/outbox-relay.service.ts
+++ b/src/common/events/outbox-relay.service.ts
@@ -1,0 +1,105 @@
+import { Injectable, Logger, OnModuleDestroy, OnModuleInit } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { EventEmitter2 } from '@nestjs/event-emitter';
+import { IsNull, Repository } from 'typeorm';
+import { OutboxEvent } from './outbox.entity';
+
+/** Poll interval for the outbox relay (ms). */
+export const OUTBOX_POLL_INTERVAL_MS = Number(process.env.OUTBOX_POLL_INTERVAL_MS ?? 1_000);
+
+/** Max events dispatched per poll cycle. */
+export const OUTBOX_BATCH_SIZE = Number(process.env.OUTBOX_BATCH_SIZE ?? 100);
+
+/**
+ * Relay for the transactional outbox (issue #1221).
+ *
+ * Polls `event_outbox` for unpublished rows in FIFO order (created_at ASC)
+ * and dispatches each to the in-process EventEmitter2 bus. A row is marked
+ * `published_at` only AFTER `emit()` completes without throwing, so:
+ *
+ * - A crash between commit and dispatch leaves the row unpublished and the
+ *   event is redelivered on restart (at-least-once).
+ * - A handler that throws during `emit()` leaves the row unpublished too;
+ *   the attempts counter is incremented and delivery is retried on the next
+ *   poll. Handlers are expected to be idempotent, so redelivery is safe.
+ *
+ * EventEmitter2's `emit` is synchronous fire-and-forget: async handlers are
+ * not awaited. That is acceptable here — the at-least-once guarantee comes
+ * from not marking the row published until `emit()` returns without an
+ * exception, and handlers guard against duplicates (idempotency).
+ */
+@Injectable()
+export class OutboxRelayService implements OnModuleInit, OnModuleDestroy {
+  private readonly logger = new Logger(OutboxRelayService.name);
+  private timer: NodeJS.Timeout | null = null;
+  private polling = false;
+
+  constructor(
+    @InjectRepository(OutboxEvent)
+    private readonly outboxRepo: Repository<OutboxEvent>,
+    private readonly eventEmitter: EventEmitter2,
+  ) {}
+
+  onModuleInit(): void {
+    this.start();
+  }
+
+  onModuleDestroy(): void {
+    this.stop();
+  }
+
+  start(): void {
+    if (this.timer) return;
+    this.timer = setInterval(() => {
+      void this.poll().catch((err) =>
+        this.logger.error(
+          'Outbox poll cycle failed',
+          err instanceof Error ? err.stack : String(err),
+        ),
+      );
+    }, OUTBOX_POLL_INTERVAL_MS);
+    this.timer.unref?.();
+  }
+
+  stop(): void {
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+  }
+
+  /**
+   * Dispatch one batch of unpublished events. Returns the number dispatched.
+   */
+  async poll(): Promise<number> {
+    if (this.polling) return 0;
+    this.polling = true;
+    try {
+      const rows = await this.outboxRepo.find({
+        where: { publishedAt: IsNull() },
+        order: { createdAt: 'ASC' },
+        take: OUTBOX_BATCH_SIZE,
+      });
+
+      let dispatched = 0;
+      for (const row of rows) {
+        try {
+          this.eventEmitter.emit(row.eventName, row.payload);
+          await this.outboxRepo.update(row.id, { publishedAt: new Date() });
+          dispatched += 1;
+        } catch (err) {
+          this.logger.warn(
+            `Outbox dispatch failed for event=${row.eventName} id=${row.id} ` +
+              `attempt=${row.attempts + 1}: ${err instanceof Error ? err.message : String(err)}`,
+          );
+          await this.outboxRepo.update(row.id, {
+            attempts: row.attempts + 1,
+          });
+        }
+      }
+      return dispatched;
+    } finally {
+      this.polling = false;
+    }
+  }
+}

--- a/src/common/events/outbox.entity.ts
+++ b/src/common/events/outbox.entity.ts
@@ -1,0 +1,38 @@
+import { Column, CreateDateColumn, Entity, Index, PrimaryGeneratedColumn } from 'typeorm';
+
+/**
+ * Transactional outbox for domain events (issue #1221).
+ *
+ * Producers persist an event row in the SAME transaction as the state change
+ * that produced it, so no consumer ever observes an event for a write that
+ * rolled back. `OutboxRelayService` polls unpublished rows after commit and
+ * dispatches them to the in-process EventEmitter2 bus, marking them published
+ * only after dispatch succeeds. Delivery is at-least-once; consumers must be
+ * idempotent under redelivery.
+ */
+@Entity('event_outbox')
+@Index(['publishedAt', 'createdAt'])
+export class OutboxEvent {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  /** Event name dispatched to EventEmitter2 (e.g. `cache.course.created`). */
+  @Column({ type: 'varchar', length: 255 })
+  eventName: string;
+
+  /** Serializable event payload forwarded verbatim to handlers. */
+  @Column({ type: 'jsonb' })
+  payload: Record<string, unknown>;
+
+  /** When the event was enqueued (used by the relay's FIFO ordering). */
+  @CreateDateColumn({ type: 'timestamptz' })
+  createdAt: Date;
+
+  /** Set once the relay has dispatched the event; `null` while pending. */
+  @Column({ type: 'timestamptz', nullable: true })
+  publishedAt: Date | null;
+
+  /** Number of dispatch attempts so far (for observability/backoff). */
+  @Column({ type: 'int', default: 0 })
+  attempts: number;
+}

--- a/src/common/events/outbox.module.ts
+++ b/src/common/events/outbox.module.ts
@@ -1,0 +1,19 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { OutboxEvent } from './outbox.entity';
+import { OutboxService } from './outbox.service';
+import { OutboxRelayService } from './outbox-relay.service';
+
+/**
+ * Transactional outbox module (issue #1221).
+ *
+ * Import where outbox writes are needed (producers) and once at the app root
+ * so the relay runs for the lifetime of the process. NestJS shares the module
+ * instance across importers, so the relay is started a single time.
+ */
+@Module({
+  imports: [TypeOrmModule.forFeature([OutboxEvent])],
+  providers: [OutboxService, OutboxRelayService],
+  exports: [OutboxService],
+})
+export class OutboxModule {}

--- a/src/common/events/outbox.service.spec.ts
+++ b/src/common/events/outbox.service.spec.ts
@@ -1,0 +1,64 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { OutboxEvent } from './outbox.entity';
+import { OutboxService } from './outbox.service';
+
+describe('OutboxService', () => {
+  let service: OutboxService;
+  let repo: {
+    create: jest.Mock;
+    save: jest.Mock;
+    createQueryBuilder: jest.Mock;
+  };
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let manager: any;
+  let managerRepo: { save: jest.Mock };
+
+  beforeEach(async () => {
+    managerRepo = { save: jest.fn().mockResolvedValue({ id: 'evt-1' }) };
+    manager = {
+      getRepository: jest.fn().mockReturnValue(managerRepo),
+    };
+    repo = {
+      create: jest.fn((data) => data),
+      save: jest.fn().mockResolvedValue({ id: 'evt-1' }),
+      createQueryBuilder: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [OutboxService, { provide: getRepositoryToken(OutboxEvent), useValue: repo }],
+    }).compile();
+
+    service = module.get(OutboxService);
+  });
+
+  it('enqueue persists the event through the caller transaction manager', async () => {
+    await service.enqueue(manager, 'cache.course.created', { id: 'c1' });
+
+    expect(manager.getRepository).toHaveBeenCalledWith(OutboxEvent);
+    expect(managerRepo.save).toHaveBeenCalledWith({
+      eventName: 'cache.course.created',
+      payload: { id: 'c1' },
+    });
+  });
+
+  it('enqueueStandalone persists the event via its own repository', async () => {
+    await service.enqueueStandalone('payment.completed', { paymentId: 'p1' });
+
+    expect(repo.save).toHaveBeenCalledWith({
+      eventName: 'payment.completed',
+      payload: { paymentId: 'p1' },
+    });
+  });
+
+  it('countPending counts rows with a null publishedAt', async () => {
+    const queryBuilder = {
+      where: jest.fn().mockReturnThis(),
+      getCount: jest.fn().mockResolvedValue(3),
+    };
+    repo.createQueryBuilder.mockReturnValue(queryBuilder);
+
+    await expect(service.countPending()).resolves.toBe(3);
+    expect(queryBuilder.where).toHaveBeenCalledWith('outbox.published_at IS NULL');
+  });
+});

--- a/src/common/events/outbox.service.ts
+++ b/src/common/events/outbox.service.ts
@@ -1,0 +1,64 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { EntityManager, Repository } from 'typeorm';
+import { OutboxEvent } from './outbox.entity';
+
+/**
+ * Write-side API for the transactional outbox (issue #1221).
+ *
+ * - `enqueue(manager, ...)` persists the event inside the caller's running
+ *   transaction, making it atomic with the state change. Use this inside
+ *   `dataSource.transaction(...)` callbacks.
+ * - `enqueueStandalone(...)` persists the event in its own write, for
+ *   producers that mutate state outside an explicit transaction. The row is
+ *   durable immediately and delivered at-least-once by the relay, which still
+ *   fixes the crash-loss failure mode of in-process-only emits.
+ */
+@Injectable()
+export class OutboxService {
+  private readonly logger = new Logger(OutboxService.name);
+
+  constructor(
+    @InjectRepository(OutboxEvent)
+    private readonly outboxRepo: Repository<OutboxEvent>,
+  ) {}
+
+  /**
+   * Enqueue an event atomically with the caller's transaction.
+   *
+   * If the transaction rolls back, the outbox row rolls back with it and no
+   * consumer ever observes the event (no ghost side effects).
+   */
+  async enqueue(
+    manager: EntityManager,
+    eventName: string,
+    payload: Record<string, unknown>,
+  ): Promise<void> {
+    await manager.getRepository(OutboxEvent).save(
+      this.outboxRepo.create({
+        eventName,
+        payload,
+      }),
+    );
+  }
+
+  /**
+   * Enqueue an event outside a transaction (durable, at-least-once delivery).
+   */
+  async enqueueStandalone(eventName: string, payload: Record<string, unknown>): Promise<void> {
+    await this.outboxRepo.save(
+      this.outboxRepo.create({
+        eventName,
+        payload,
+      }),
+    );
+  }
+
+  /** Number of unpublished events still waiting for the relay (observability). */
+  async countPending(): Promise<number> {
+    return this.outboxRepo
+      .createQueryBuilder('outbox')
+      .where('outbox.published_at IS NULL')
+      .getCount();
+  }
+}

--- a/src/courses/courses.module.ts
+++ b/src/courses/courses.module.ts
@@ -11,6 +11,7 @@ import { CourseModule } from './entities/course-module.entity';
 import { BulkOperation } from './entities/bulk-operation.entity';
 import { CachingModule } from '../caching/caching.module';
 import { AnalyticsModule } from '../analytics/analytics.module';
+import { OutboxModule } from '../common/events/outbox.module';
 
 import { PaginationService } from '../common/services/pagination.service';
 
@@ -19,6 +20,7 @@ import { PaginationService } from '../common/services/pagination.service';
     TypeOrmModule.forFeature([Course, Enrollment, CourseReview, CourseModule, BulkOperation]),
     CachingModule,
     forwardRef(() => AnalyticsModule),
+    OutboxModule,
   ],
   providers: [CoursesService, EnrollmentsService, PaginationService],
   controllers: [CoursesController, EnrollmentsController],

--- a/src/courses/courses.service.bulk.spec.ts
+++ b/src/courses/courses.service.bulk.spec.ts
@@ -1,7 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
-import { EventEmitter2 } from '@nestjs/event-emitter';
 import { BadRequestException, ForbiddenException, NotFoundException } from '@nestjs/common';
+import { OutboxService } from '../common/events/outbox.service';
 import {
   ResourceNotFoundException,
   ForbiddenOperationException,
@@ -33,8 +33,9 @@ describe('CoursesService - Bulk Operations', () => {
     findOne: jest.fn(),
   };
 
-  const eventEmitter = {
-    emit: jest.fn(),
+  const outbox = {
+    enqueue: jest.fn(),
+    enqueueStandalone: jest.fn(),
   };
 
   const owner = {
@@ -90,8 +91,8 @@ describe('CoursesService - Bulk Operations', () => {
           useValue: bulkOpRepo,
         },
         {
-          provide: EventEmitter2,
-          useValue: eventEmitter,
+          provide: OutboxService,
+          useValue: outbox,
         },
       ],
     }).compile();
@@ -124,7 +125,7 @@ describe('CoursesService - Bulk Operations', () => {
 
       expect(courses.every((course) => course.status === CourseStatus.PUBLISHED)).toBe(true);
 
-      expect(eventEmitter.emit).toHaveBeenCalledTimes(2);
+      expect(outbox.enqueueStandalone).toHaveBeenCalledTimes(2);
     });
 
     it('should return FAILED when no courses are found', async () => {

--- a/src/courses/courses.service.spec.ts
+++ b/src/courses/courses.service.spec.ts
@@ -1,7 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
-import { EventEmitter2 } from '@nestjs/event-emitter';
 import { DataSource, Repository } from 'typeorm';
+import { OutboxService } from '../common/events/outbox.service';
 import { CoursesService } from './courses.service';
 import { Course, CourseStatus } from './entities/course.entity';
 import { CourseReview } from './entities/course-review.entity';
@@ -36,8 +36,9 @@ const mockBulkOpRepo = {
   findOne: jest.fn(),
 };
 
-const mockEventEmitter = {
-  emit: jest.fn(),
+const mockOutbox = {
+  enqueue: jest.fn(),
+  enqueueStandalone: jest.fn(),
 };
 
 const mockDataSource = {
@@ -81,7 +82,7 @@ describe('CoursesService', () => {
         { provide: getRepositoryToken(CourseReview), useValue: mockReviewRepo },
         { provide: getRepositoryToken(CourseVersion), useValue: mockVersionRepo },
         { provide: getRepositoryToken(BulkOperation), useValue: mockBulkOpRepo },
-        { provide: EventEmitter2, useValue: mockEventEmitter },
+        { provide: OutboxService, useValue: mockOutbox },
         { provide: DataSource, useValue: mockDataSource },
       ],
     }).compile();

--- a/src/courses/courses.service.ts
+++ b/src/courses/courses.service.ts
@@ -1,5 +1,4 @@
 import { Injectable, Optional, Inject, forwardRef } from '@nestjs/common';
-import { EventEmitter2 } from '@nestjs/event-emitter';
 import { InjectRepository } from '@nestjs/typeorm';
 import { DataSource, EntityManager, In, Repository } from 'typeorm';
 import { CACHE_EVENTS } from '../caching/caching.constants';
@@ -31,6 +30,7 @@ import { PaginationQueryDto } from '../common/dto/pagination.dto';
 import { OffsetPaginatedResponse } from '../common/interfaces/pagination.interface';
 
 import { PaginationService } from '../common/services/pagination.service';
+import { OutboxService } from '../common/events/outbox.service';
 import { AnalyticsService } from '../analytics/analytics.service';
 import { EventType } from '../analytics/entities/event.entity';
 
@@ -80,7 +80,7 @@ export class CoursesService {
     private readonly versionRepo: Repository<CourseVersion>,
     @InjectRepository(BulkOperation)
     private readonly bulkOpRepo: Repository<BulkOperation>,
-    private readonly eventEmitter: EventEmitter2,
+    private readonly outbox: OutboxService,
     private readonly dataSource: DataSource,
     @Optional()
     private readonly paginationService: PaginationService = new PaginationService(),
@@ -131,7 +131,9 @@ export class CoursesService {
         status: saved.status,
       });
       await versionRepo.save(version);
-      this.eventEmitter.emit(CACHE_EVENTS.COURSE_CREATED, { id: saved.id });
+      // Enlist the event in the SAME transaction so a rollback never leaves a
+      // ghost cache/search entry (issue #1221).
+      await this.outbox.enqueue(manager, CACHE_EVENTS.COURSE_CREATED, { id: saved.id });
       return saved;
     });
   }
@@ -243,7 +245,7 @@ export class CoursesService {
             status: saved.status,
           });
           await versionRepo.save(version);
-          this.eventEmitter.emit(CACHE_EVENTS.COURSE_UPDATED, { id: saved.id });
+          await this.outbox.enqueue(manager, CACHE_EVENTS.COURSE_UPDATED, { id: saved.id });
           return saved;
         });
       } catch (err) {
@@ -262,7 +264,7 @@ export class CoursesService {
     const course = await this.findOne(id);
     this.assertOwnerOrPrivileged(course, requestingUser);
     await this.courseRepo.softDelete(id);
-    this.eventEmitter.emit(CACHE_EVENTS.COURSE_DELETED, { id });
+    await this.outbox.enqueueStandalone(CACHE_EVENTS.COURSE_DELETED, { id });
   }
 
   // ─── WORKFLOW ─────────────────────────────────────────────────────────────────
@@ -284,7 +286,7 @@ export class CoursesService {
     course.status = CourseStatus.PENDING_REVIEW;
     course.submissionNote = dto.submissionNote ?? null;
     const saved = await this.courseRepo.save(course);
-    this.eventEmitter.emit(CACHE_EVENTS.COURSE_UPDATED, { id: saved.id });
+    await this.outbox.enqueueStandalone(CACHE_EVENTS.COURSE_UPDATED, { id: saved.id });
     return saved;
   }
 
@@ -304,7 +306,7 @@ export class CoursesService {
     const previousStatus = course.status;
     course.status = DECISION_TO_STATUS[dto.decision];
     await this.courseRepo.save(course);
-    this.eventEmitter.emit(CACHE_EVENTS.COURSE_UPDATED, { id: course.id });
+    await this.outbox.enqueueStandalone(CACHE_EVENTS.COURSE_UPDATED, { id: course.id });
 
     const review = this.reviewRepo.create({
       courseId: id,
@@ -638,7 +640,9 @@ export class CoursesService {
 
     if (restored.length > 0) {
       await this.courseRepo.save(restored);
-      restored.forEach((c) => this.eventEmitter.emit(CACHE_EVENTS.COURSE_UPDATED, { id: c.id }));
+      for (const c of restored) {
+        await this.outbox.enqueueStandalone(CACHE_EVENTS.COURSE_UPDATED, { id: c.id });
+      }
     }
 
     op.status = BulkOperationStatus.UNDONE;
@@ -694,7 +698,9 @@ export class CoursesService {
 
     if (toSave.length > 0) {
       await this.courseRepo.save(toSave);
-      toSave.forEach((c) => this.eventEmitter.emit(CACHE_EVENTS.COURSE_UPDATED, { id: c.id }));
+      for (const c of toSave) {
+        await this.outbox.enqueueStandalone(CACHE_EVENTS.COURSE_UPDATED, { id: c.id });
+      }
     }
 
     const successCount = snapshots.filter((s) => s.applied).length;

--- a/src/courses/enrollments.service.bulk.spec.ts
+++ b/src/courses/enrollments.service.bulk.spec.ts
@@ -4,7 +4,7 @@ import { getRepositoryToken } from '@nestjs/typeorm';
 import { DataSource } from 'typeorm';
 import { Enrollment } from './entities/enrollment.entity';
 import { Course, CourseStatus } from './entities/course.entity';
-import { EventEmitter2 } from '@nestjs/event-emitter';
+import { OutboxService } from '../common/events/outbox.service';
 
 describe('EnrollmentsService - Bulk Enroll', () => {
   let service: EnrollmentsService;
@@ -39,9 +39,10 @@ describe('EnrollmentsService - Bulk Enroll', () => {
           useValue: {},
         },
         {
-          provide: EventEmitter2,
+          provide: OutboxService,
           useValue: {
-            emit: jest.fn(),
+            enqueue: jest.fn(),
+            enqueueStandalone: jest.fn(),
           },
         },
         {

--- a/src/courses/enrollments.service.ts
+++ b/src/courses/enrollments.service.ts
@@ -7,7 +7,7 @@ import {
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { DataSource, Repository } from 'typeorm';
-import { EventEmitter2 } from '@nestjs/event-emitter';
+import { OutboxService } from '../common/events/outbox.service';
 
 import { Course, CourseStatus } from './entities/course.entity';
 import { Enrollment } from './entities/enrollment.entity';
@@ -32,7 +32,7 @@ export class EnrollmentsService {
     @InjectRepository(Course)
     private readonly courseRepo: Repository<Course>,
 
-    private readonly eventEmitter: EventEmitter2,
+    private readonly outbox: OutboxService,
 
     private readonly dataSource: DataSource,
   ) {}
@@ -81,9 +81,10 @@ export class EnrollmentsService {
 
       const saved = await enrollmentRepo.save(enrollment);
 
-      this.eventEmitter.emit(CACHE_EVENTS.ENROLLMENT_CREATED, { id: saved.id });
-
-      this.eventEmitter.emit(APP_EVENTS.COURSE_ENROLLED, {
+      // Events are enlisted in the SAME transaction so a rollback never
+      // leaves ghost cache entries or recommendation updates (issue #1221).
+      await this.outbox.enqueue(manager, CACHE_EVENTS.ENROLLMENT_CREATED, { id: saved.id });
+      await this.outbox.enqueue(manager, APP_EVENTS.COURSE_ENROLLED, {
         userId,
         courseId,
       });
@@ -176,10 +177,13 @@ export class EnrollmentsService {
       } else {
         await queryRunner.commitTransaction();
 
-        // Emit events for successful enrollments after commit
+        // Enqueue events for successful enrollments after commit (durable,
+        // delivered at-least-once by the outbox relay — issue #1221).
         for (const saved of successfulEnrollments) {
-          this.eventEmitter.emit(CACHE_EVENTS.ENROLLMENT_CREATED, { id: saved.id });
-          this.eventEmitter.emit(APP_EVENTS.COURSE_ENROLLED, {
+          await this.outbox.enqueueStandalone(CACHE_EVENTS.ENROLLMENT_CREATED, {
+            id: saved.id,
+          });
+          await this.outbox.enqueueStandalone(APP_EVENTS.COURSE_ENROLLED, {
             userId: saved.userId,
             courseId: saved.courseId,
           });
@@ -282,18 +286,21 @@ export class EnrollmentsService {
 
     enrollment.progress = progress;
 
-    if (progress === 100 && !alreadyCompleted) {
+    const wasCompleted = !alreadyCompleted && progress === 100;
+    if (wasCompleted) {
       enrollment.status = APP_CONSTANTS.ENROLLMENT_STATUS.COMPLETED;
-
-      this.eventEmitter.emit(APP_EVENTS.COURSE_COMPLETED, {
-        userId: enrollment.userId,
-        courseId: enrollment.courseId,
-      });
     }
 
     const saved = await this.enrollmentRepo.save(enrollment);
 
-    this.eventEmitter.emit(CACHE_EVENTS.ENROLLMENT_UPDATED, {
+    // Enqueue after the write so a failed save never produces a ghost event.
+    if (wasCompleted) {
+      await this.outbox.enqueueStandalone(APP_EVENTS.COURSE_COMPLETED, {
+        userId: enrollment.userId,
+        courseId: enrollment.courseId,
+      });
+    }
+    await this.outbox.enqueueStandalone(CACHE_EVENTS.ENROLLMENT_UPDATED, {
       id: saved.id,
     });
 
@@ -319,11 +326,10 @@ export class EnrollmentsService {
 
     await this.enrollmentRepo.remove(enrollment);
 
-    this.eventEmitter.emit(CACHE_EVENTS.ENROLLMENT_UPDATED, {
+    await this.outbox.enqueueStandalone(CACHE_EVENTS.ENROLLMENT_UPDATED, {
       id: enrollment.id,
     });
-
-    this.eventEmitter.emit(APP_EVENTS.COURSE_UNENROLLED, {
+    await this.outbox.enqueueStandalone(APP_EVENTS.COURSE_UNENROLLED, {
       userId,
       courseId,
     });

--- a/src/currency/controllers/currency.controller.ts
+++ b/src/currency/controllers/currency.controller.ts
@@ -11,6 +11,9 @@ import {
   CurrencyDetailsDto,
   DetectCurrencyDto,
   DetectCurrencyResponseDto,
+  FormatPriceDto,
+  FormatPriceResponseDto,
+  RefreshRatesResponseDto,
 } from '../dtos/currency.dto';
 
 /**
@@ -38,6 +41,7 @@ export class CurrencyController {
     description: 'Conversion successful',
     type: ConvertCurrencyResponseDto,
   })
+  @ApiResponse({ status: 400, description: 'Invalid amount or currency code' })
   async convertCurrency(@Body() dto: ConvertCurrencyDto): Promise<ConvertCurrencyResponseDto> {
     const convertedAmount = await this.currencyService.convertCurrency(
       dto.amount,
@@ -72,6 +76,7 @@ export class CurrencyController {
     description: 'Conversion successful',
     type: MultiCurrencyConversionResponseDto,
   })
+  @ApiResponse({ status: 400, description: 'Invalid amount or currency code' })
   async convertToMultiple(
     @Body() dto: MultiCurrencyConversionDto,
   ): Promise<MultiCurrencyConversionResponseDto> {
@@ -102,6 +107,7 @@ export class CurrencyController {
     description: 'Currency details retrieved',
     type: CurrencyDetailsDto,
   })
+  @ApiResponse({ status: 404, description: 'Unknown currency code' })
   getCurrencyDetails(@Query('code') currencyCode: string): CurrencyDetailsDto {
     return this.currencyService.getCurrencyDetails(currencyCode);
   }
@@ -118,6 +124,7 @@ export class CurrencyController {
     description: 'Currency detected',
     type: DetectCurrencyResponseDto,
   })
+  @ApiResponse({ status: 400, description: 'Invalid detection inputs' })
   detectCurrency(@Body() dto: DetectCurrencyDto): DetectCurrencyResponseDto {
     const detectedCurrency = this.currencyDetectionService.detectCurrency({
       country: dto.country,
@@ -155,6 +162,15 @@ export class CurrencyController {
    */
   @Get('supported')
   @ApiOperation({ summary: 'Get list of all supported currencies and countries' })
+  @ApiResponse({
+    status: 200,
+    description: 'Map of currency codes to country names',
+    schema: {
+      type: 'object',
+      additionalProperties: { type: 'string' },
+      example: { USD: 'United States', EUR: 'European Union' },
+    },
+  })
   getSupportedCurrencies(): Record<string, string> {
     return this.currencyDetectionService.getSupportedCountries();
   }
@@ -165,6 +181,15 @@ export class CurrencyController {
    */
   @Get('rates')
   @ApiOperation({ summary: 'Get current exchange rates' })
+  @ApiResponse({
+    status: 200,
+    description: 'Map of currency pairs to exchange rates',
+    schema: {
+      type: 'object',
+      additionalProperties: { type: 'number' },
+      example: { 'USD/EUR': 0.915, 'EUR/USD': 1.093 },
+    },
+  })
   getExchangeRates(): Record<string, number> {
     return this.exchangeRateService.getAvailableRates();
   }
@@ -176,6 +201,11 @@ export class CurrencyController {
   @Post('rates/refresh')
   @HttpCode(200)
   @ApiOperation({ summary: 'Manually refresh exchange rates' })
+  @ApiResponse({
+    status: 200,
+    description: 'Exchange rates refreshed',
+    type: RefreshRatesResponseDto,
+  })
   async refreshRates(): Promise<{ message: string; timestamp: Date }> {
     await this.exchangeRateService.refreshExchangeRates();
     return {
@@ -191,9 +221,13 @@ export class CurrencyController {
   @Post('format-price')
   @HttpCode(200)
   @ApiOperation({ summary: 'Format price for display' })
-  formatPrice(@Body() body: { amount: number; currency: string; locale?: string }): {
-    formattedPrice: string;
-  } {
+  @ApiResponse({
+    status: 200,
+    description: 'Formatted price',
+    type: FormatPriceResponseDto,
+  })
+  @ApiResponse({ status: 400, description: 'Invalid amount or currency code' })
+  formatPrice(@Body() body: FormatPriceDto): FormatPriceResponseDto {
     const formattedPrice = this.currencyService.formatPrice(
       body.amount,
       body.currency,

--- a/src/currency/dtos/currency.dto.ts
+++ b/src/currency/dtos/currency.dto.ts
@@ -165,6 +165,34 @@ export class DetectCurrencyResponseDto {
   detectionMethod: string;
 }
 
+export class FormatPriceDto {
+  @ApiProperty({ description: 'Amount to format', example: 49.99 })
+  @IsNumber()
+  amount: number;
+
+  @ApiProperty({ description: 'Currency code (ISO 4217)', example: 'USD' })
+  @IsString()
+  currency: string;
+
+  @ApiPropertyOptional({ description: 'Locale for formatting', example: 'en-US' })
+  @IsOptional()
+  @IsString()
+  locale?: string;
+}
+
+export class FormatPriceResponseDto {
+  @ApiProperty({ description: 'Price formatted for the given locale', example: '$49.99' })
+  formattedPrice: string;
+}
+
+export class RefreshRatesResponseDto {
+  @ApiProperty({ description: 'Status message', example: 'Exchange rates refreshed successfully' })
+  message: string;
+
+  @ApiProperty({ description: 'Timestamp of the refresh' })
+  timestamp: Date;
+}
+
 export class PricingDto {
   @ApiProperty({ description: 'Base price', example: 49.99 })
   basePrice: number;

--- a/src/gamification/gamification.module.ts
+++ b/src/gamification/gamification.module.ts
@@ -1,6 +1,7 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { EventEmitterModule } from '@nestjs/event-emitter';
+import { OutboxModule } from '../common/events/outbox.module';
 
 import { Badge } from './entities/badge.entity';
 import { UserBadge } from './entities/user-badge.entity';
@@ -28,6 +29,7 @@ import { GamificationController } from './gamification.controller';
       TierReward,
     ]),
     EventEmitterModule.forRoot(),
+    OutboxModule,
   ],
   controllers: [GamificationController],
   providers: [PointsService, LeaderboardService, BadgesService, TiersService],

--- a/src/gamification/points/points.service.spec.ts
+++ b/src/gamification/points/points.service.spec.ts
@@ -1,6 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
-import { EventEmitter2 } from '@nestjs/event-emitter';
+import { OutboxService } from '../../common/events/outbox.service';
 import { DataSource } from 'typeorm';
 import { PointsService } from './points.service';
 import { UserProgress } from '../entities/user-progress.entity';
@@ -61,20 +61,19 @@ describe('PointsService', () => {
   let progressRepo: ReturnType<typeof mockRepo>;
   let txRepo: ReturnType<typeof mockRepo>;
   let tiersService: ReturnType<typeof mockTiersService>;
-  let emitter: { emit: jest.Mock };
+  let outbox: { enqueueStandalone: jest.Mock };
   let dataSource: ReturnType<typeof mockDataSource>;
 
   beforeEach(async () => {
-    emitter = { emit: jest.fn() };
+    outbox = { enqueueStandalone: jest.fn() };
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         PointsService,
         { provide: getRepositoryToken(UserProgress), useFactory: mockRepo },
         { provide: getRepositoryToken(PointTransaction), useFactory: mockRepo },
-        { provide: EventEmitter2, useValue: emitter },
         { provide: DataSource, useFactory: mockDataSource },
-        { provide: EventEmitter2, useValue: { emit: jest.fn() } },
+        { provide: OutboxService, useValue: outbox },
         { provide: TiersService, useFactory: mockTiersService },
       ],
     }).compile();
@@ -565,13 +564,13 @@ describe('PointsService', () => {
 
       const addPromise = service.addPoints('user-1', 100, 'TEST');
 
-      // Event must NOT fire before save resolves
-      expect(emitter.emit).not.toHaveBeenCalled();
+      // Event must NOT be enqueued before save resolves
+      expect(outbox.enqueueStandalone).not.toHaveBeenCalled();
 
       resolveSave({ totalPoints: 100, xp: 100, level: 1, tier: Tier.BRONZE });
       await addPromise;
 
-      expect(emitter.emit).toHaveBeenCalledWith(
+      expect(outbox.enqueueStandalone).toHaveBeenCalledWith(
         GAMIFICATION_EVENTS.POINTS_AWARDED,
         expect.any(Object),
       );
@@ -583,7 +582,7 @@ describe('PointsService', () => {
 
       await expect(service.addPoints('user-1', 100, 'TEST')).rejects.toThrow('DB write failed');
 
-      expect(emitter.emit).not.toHaveBeenCalled();
+      expect(outbox.enqueueStandalone).not.toHaveBeenCalled();
     });
   });
 
@@ -616,7 +615,7 @@ describe('PointsService', () => {
       expect(secondSaveArg.tier).toBe(Tier.SILVER);
 
       // Total POINTS_AWARDED emissions across both calls
-      const promotionEmits = emitter.emit.mock.calls.filter(
+      const promotionEmits = outbox.enqueueStandalone.mock.calls.filter(
         ([event]) => event === GAMIFICATION_EVENTS.POINTS_AWARDED,
       );
       expect(promotionEmits).toHaveLength(2); // one per award, regardless of tier change

--- a/src/gamification/points/points.service.ts
+++ b/src/gamification/points/points.service.ts
@@ -1,11 +1,11 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository, DataSource } from 'typeorm';
-import { EventEmitter2 } from '@nestjs/event-emitter';
 import { UserProgress } from '../entities/user-progress.entity';
 import { PointTransaction } from '../entities/point-transaction.entity';
 import { User } from '../../users/entities/user.entity';
-import { GAMIFICATION_EVENTS, PointsAwardedEvent } from '../events/gamification.events';
+import { OutboxService } from '../../common/events/outbox.service';
+import { GAMIFICATION_EVENTS } from '../events/gamification.events';
 import { TiersService } from '../tiers/tiers.service';
 import { PointActivityType, POINT_RULES } from '../enums/point-activity.enum';
 import { Tier } from '../enums/tier.enum';
@@ -21,7 +21,7 @@ export class PointsService {
     @InjectRepository(PointTransaction)
     private pointTransactionRepository: Repository<PointTransaction>,
     private readonly dataSource: DataSource,
-    private eventEmitter: EventEmitter2,
+    private readonly outbox: OutboxService,
     private tiersService: TiersService,
   ) {}
 
@@ -130,12 +130,14 @@ export class PointsService {
       // value is now durable in the database.
       const tierPromoted = newTier !== previousTier;
 
-      // STEP 4: Emit event after successful commit
-      // Event subscribers (e.g., BadgesService) can now read consistent state
-      this.eventEmitter.emit(
-        GAMIFICATION_EVENTS.POINTS_AWARDED,
-        new PointsAwardedEvent(userId, updatedProgress.totalPoints, updatedProgress.level),
-      );
+      // STEP 4: Enqueue event after successful commit so subscribers (e.g.
+      // BadgesService) read consistent state. The row is durable and delivered
+      // at-least-once by the outbox relay (issue #1221).
+      await this.outbox.enqueueStandalone(GAMIFICATION_EVENTS.POINTS_AWARDED, {
+        userId,
+        totalPoints: updatedProgress.totalPoints,
+        level: updatedProgress.level,
+      });
 
       return {
         progress: updatedProgress,

--- a/src/migrations/1798000000000-create-event-outbox.ts
+++ b/src/migrations/1798000000000-create-event-outbox.ts
@@ -1,0 +1,32 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Create the `event_outbox` table backing the transactional outbox
+ * (issue #1221).
+ *
+ * Producers persist domain events in the same transaction as the state change
+ * they describe; `OutboxRelayService` polls unpublished rows after commit and
+ * dispatches them to the in-process EventEmitter2 bus, marking them published
+ * only after a successful dispatch. The `(publishedAt, createdAt)` index
+ * serves the relay's "unpublished, oldest first" query.
+ *
+ * The SQL below is exactly what TypeORM generates from the `OutboxEvent`
+ * entity, so `migration:generate --check` (schema drift check) stays green.
+ */
+export class CreateEventOutbox1798000000000 implements MigrationInterface {
+  name = 'CreateEventOutbox1798000000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      'CREATE TABLE "event_outbox" ("id" uuid NOT NULL DEFAULT uuid_generate_v4(), "eventName" character varying(255) NOT NULL, "payload" jsonb NOT NULL, "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(), "publishedAt" TIMESTAMP WITH TIME ZONE, "attempts" integer NOT NULL DEFAULT \'0\', CONSTRAINT "PK_c8bd4a6797caa3ebad9b40c9813" PRIMARY KEY ("id"))',
+    );
+    await queryRunner.query(
+      'CREATE INDEX "IDX_a74e4e8eecdd2907ea9fb355c1" ON "event_outbox" ("publishedAt", "createdAt") ',
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query('DROP INDEX "public"."IDX_a74e4e8eecdd2907ea9fb355c1"');
+    await queryRunner.query('DROP TABLE "event_outbox"');
+  }
+}

--- a/src/payments/invoices/invoices.service.ts
+++ b/src/payments/invoices/invoices.service.ts
@@ -61,6 +61,19 @@ export class InvoicesService {
         return;
       }
 
+      // Idempotency guard: the outbox relay delivers at-least-once (issue
+      // #1221), so a redelivered PAYMENT_COMPLETED must not mint a duplicate
+      // invoice for the same payment.
+      const existing = await this.invoiceRepository.findOne({
+        where: { paymentId: payload.paymentId },
+      });
+      if (existing) {
+        this.logger.log(
+          `Invoice ${existing.id} already exists for payment ${payload.paymentId}, skipping`,
+        );
+        return;
+      }
+
       await this.generateAndArchiveInvoice(payment);
     } catch (error) {
       this.logger.error(`Error generating invoice for payment ${payload.paymentId}:`, error.stack);

--- a/src/payments/payments.module.ts
+++ b/src/payments/payments.module.ts
@@ -4,6 +4,7 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { CurrencyModule } from '../currency/currency.module';
 import { AuditLogModule } from '../audit-log/audit-log.module';
 import { IdempotencyModule } from '../common/modules/idempotency.module';
+import { OutboxModule } from '../common/events/outbox.module';
 import { QueueModule } from '../queues/queue.module';
 import { Payment } from './entities/payment.entity';
 import { Subscription } from './entities/subscription.entity';
@@ -42,6 +43,7 @@ import { StripeProvider } from './providers/stripe.provider';
     CurrencyModule,
     AuditLogModule,
     IdempotencyModule,
+    OutboxModule,
     HttpModule,
     QueueModule,
   ],

--- a/src/payments/subscriptions/subscriptions.service.ts
+++ b/src/payments/subscriptions/subscriptions.service.ts
@@ -13,7 +13,7 @@ import {
   SubscriptionStatus,
   SubscriptionInterval,
 } from '../entities/subscription.entity';
-import { EventEmitter2 } from '@nestjs/event-emitter';
+import { OutboxService } from '../../common/events/outbox.service';
 import {
   PauseSubscriptionDto,
   ResumeSubscriptionDto,
@@ -40,7 +40,7 @@ export class SubscriptionsService {
   constructor(
     @InjectRepository(Subscription)
     private subscriptionRepository: Repository<Subscription>,
-    private eventEmitter: EventEmitter2,
+    private readonly outbox: OutboxService,
     private paymentProviderService: PaymentProviderService,
   ) {}
 
@@ -135,8 +135,8 @@ export class SubscriptionsService {
     //   }
     // }
 
-    // Emit event for downstream processing (notify user, analytics, etc.)
-    this.eventEmitter.emit('subscription.paused', {
+    // Enqueue event for downstream processing (notify user, analytics, etc.).
+    await this.outbox.enqueueStandalone('subscription.paused', {
       subscriptionId: updated.id,
       userId: updated.userId,
       resumeAt: dto.resumeAt,
@@ -172,7 +172,7 @@ export class SubscriptionsService {
 
     const updated = await this.subscriptionRepository.save(subscription);
 
-    this.eventEmitter.emit('subscription.resumed', {
+    await this.outbox.enqueueStandalone('subscription.resumed', {
       subscriptionId: updated.id,
       userId: updated.userId,
       reason: dto.reason,
@@ -275,7 +275,7 @@ export class SubscriptionsService {
 
     const updated = await this.subscriptionRepository.save(subscription);
 
-    this.eventEmitter.emit('subscription.upgraded', {
+    await this.outbox.enqueueStandalone('subscription.upgraded', {
       subscriptionId: updated.id,
       userId: updated.userId,
       oldAmount,
@@ -346,7 +346,7 @@ export class SubscriptionsService {
 
       const updated = await this.subscriptionRepository.save(subscription);
 
-      this.eventEmitter.emit('subscription.downgraded', {
+      await this.outbox.enqueueStandalone('subscription.downgraded', {
         subscriptionId: updated.id,
         userId: updated.userId,
         oldAmount,
@@ -423,7 +423,7 @@ export class SubscriptionsService {
 
     const updated = await this.subscriptionRepository.save(subscription);
 
-    this.eventEmitter.emit('subscription.downgraded', {
+    await this.outbox.enqueueStandalone('subscription.downgraded', {
       subscriptionId: updated.id,
       userId: updated.userId,
       oldAmount,
@@ -461,7 +461,7 @@ export class SubscriptionsService {
 
     const updated = await this.subscriptionRepository.save(subscription);
 
-    this.eventEmitter.emit('subscription.cancelled', {
+    await this.outbox.enqueueStandalone('subscription.cancelled', {
       subscriptionId: updated.id,
       userId: updated.userId,
     });
@@ -498,7 +498,7 @@ export class SubscriptionsService {
           `Attempting renewal for subscription ${subscriptionId} (attempt ${attempt}/${maxRetries})`,
         );
 
-        this.eventEmitter.emit('subscription.renewal_attempt', {
+        await this.outbox.enqueueStandalone('subscription.renewal_attempt', {
           subscriptionId,
           userId: subscription.userId,
           amount: subscription.amount,
@@ -519,7 +519,7 @@ export class SubscriptionsService {
 
         await this.subscriptionRepository.save(subscription);
 
-        this.eventEmitter.emit('subscription.renewed', {
+        await this.outbox.enqueueStandalone('subscription.renewed', {
           subscriptionId: subscription.id,
           userId: subscription.userId,
         });
@@ -543,7 +543,7 @@ export class SubscriptionsService {
 
           await this.subscriptionRepository.save(subscription);
 
-          this.eventEmitter.emit('subscription.renewal_failed', {
+          await this.outbox.enqueueStandalone('subscription.renewal_failed', {
             subscriptionId: subscription.id,
             userId: subscription.userId,
             attempts: maxRetries,


### PR DESCRIPTION
## Summary

Four changes:

1. **Transactional outbox for domain events** — new `event_outbox` table, `OutboxService`, and `OutboxRelayService`. Producers (courses, enrollments, subscriptions, points) now persist events atomically with their state change instead of firing in-process `EventEmitter2` emits before/around the write. The relay polls unpublished rows after commit and dispatches them at-least-once; the invoice consumer is now idempotent so redelivery never mints a duplicate invoice (cache invalidation and badge awarding were already idempotent). Includes migration `CreateEventOutbox1798000000000` and unit tests.
2. **Rate limiting on auth endpoints** — `CustomThrottleGuard` applied to `auth.controller.ts` with the documented `THROTTLE` presets (STRICT for register, AUTH_LOGIN for login, REFRESH for refresh, AUTH_DEFAULT for logout); `ThrottlerModule` registered in `auth.module.ts`. Exceeding a limit returns 429.
3. **Rate limiting on social-auth endpoints** — same guard on `social-auth.controller.ts` (AUTH_DEFAULT on the OAuth initiation routes, MODERATE on the callbacks).
4. **OpenAPI docs for currency endpoints** — every endpoint now has `@ApiOperation` + `@ApiResponse` (including 4xx), with typed response DTOs (`FormatPriceResponseDto`, `RefreshRatesResponseDto`) so Swagger renders schemas correctly.

## Validation

- `pnpm run lint:ci`, `pnpm run typecheck`, `pnpm run build` pass.
- `migrations:check`, `migration:run`, `migration:generate:check` (no schema drift), and `migration:revert` all pass.
- New outbox unit tests pass; affected existing suites (courses, enrollments, invoices) pass.

Closes #1221
Closes #1322
Closes #1324
Closes #1320