### PR TITLE
feat: rate-limit secrets endpoints and complete OpenAPI docs

### DIFF
--- a/src/ab-testing/ab-testing.controller.ts
+++ b/src/ab-testing/ab-testing.controller.ts
@@ -12,7 +12,7 @@ import {
   HttpStatus,
   UseGuards,
 } from '@nestjs/common';
-import { ApiBearerAuth, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { ApiBearerAuth, ApiOperation, ApiParam, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { ABTestingService } from './ab-testing.service';
 import { ExperimentService } from './experiments/experiment.service';
 import { StatisticalAnalysisService } from './analysis/statistical-analysis.service';
@@ -55,6 +55,7 @@ export class ABTestingController {
    * Get available experiment templates
    */
   @Get('templates')
+  @ApiOperation({ summary: 'List available experiment templates' })
   @ApiResponse({
     status: 200,
     description: 'Available experiment templates',
@@ -81,6 +82,8 @@ export class ABTestingController {
   @Post('experiments/:id/analyze')
   @HttpCode(HttpStatus.OK)
   @Roles(UserRole.ADMIN)
+  @ApiOperation({ summary: 'Analyze an experiment and evaluate auto-stop conditions' })
+  @ApiParam({ name: 'id', description: 'Experiment ID' })
   @ApiResponse({
     status: 200,
     description: 'Analysis complete',
@@ -103,6 +106,7 @@ export class ABTestingController {
       },
     },
   })
+  @ApiResponse({ status: 404, description: 'Experiment not found' })
   async analyzeAndAutoStop(@Param('id') experimentId: string): Promise<any> {
     this.logger.log(`Analyzing experiment for auto-stop: ${experimentId}`);
     return await this.abTestingService.analyzeAndAutoStop(experimentId);
@@ -112,6 +116,8 @@ export class ABTestingController {
    * Get comprehensive experiment results dashboard
    */
   @Get('experiments/:id/dashboard')
+  @ApiOperation({ summary: 'Get the comprehensive results dashboard for an experiment' })
+  @ApiParam({ name: 'id', description: 'Experiment ID' })
   @ApiResponse({
     status: 200,
     description: 'Experiment results dashboard',
@@ -128,6 +134,7 @@ export class ABTestingController {
       },
     },
   })
+  @ApiResponse({ status: 404, description: 'Experiment not found' })
   async getResultsDashboard(@Param('id') experimentId: string): Promise<any> {
     this.logger.log(`Fetching results dashboard for experiment: ${experimentId}`);
     return await this.abTestingService.getExperimentResults(experimentId);
@@ -139,6 +146,8 @@ export class ABTestingController {
    */
   @Get('experiments')
   @Roles(UserRole.ADMIN, UserRole.TEACHER)
+  @ApiOperation({ summary: 'List all experiments' })
+  @ApiResponse({ status: 200, description: 'List of experiments' })
   async getAllExperiments(): Promise<any> {
     this.logger.log('Fetching all experiments');
     return await this.abTestingService.getAllExperiments();
@@ -150,6 +159,10 @@ export class ABTestingController {
    * @returns The operation result.
    */
   @Get('experiments/:id')
+  @ApiOperation({ summary: 'Get a single experiment by ID' })
+  @ApiParam({ name: 'id', description: 'Experiment ID' })
+  @ApiResponse({ status: 200, description: 'The requested experiment' })
+  @ApiResponse({ status: 404, description: 'Experiment not found' })
   async getExperimentById(@Param('id') id: string): Promise<any> {
     this.logger.log(`Fetching experiment: ${id}`);
     return await this.abTestingService.getExperimentById(id);
@@ -163,6 +176,9 @@ export class ABTestingController {
   @Post('experiments')
   @HttpCode(HttpStatus.CREATED)
   @Roles(UserRole.ADMIN)
+  @ApiOperation({ summary: 'Create a new experiment' })
+  @ApiResponse({ status: 201, description: 'Experiment created' })
+  @ApiResponse({ status: 400, description: 'Validation failed' })
   async createExperiment(@Body() createExperimentDto: CreateExperimentDto): Promise<any> {
     this.logger.log(`Creating new experiment: ${createExperimentDto.name}`);
     return await this.abTestingService.createExperiment(createExperimentDto);
@@ -176,6 +192,10 @@ export class ABTestingController {
   @Post('experiments/:id/start')
   @HttpCode(HttpStatus.OK)
   @Roles(UserRole.ADMIN)
+  @ApiOperation({ summary: 'Start an experiment' })
+  @ApiParam({ name: 'id', description: 'Experiment ID' })
+  @ApiResponse({ status: 200, description: 'Experiment started' })
+  @ApiResponse({ status: 404, description: 'Experiment not found' })
   async startExperiment(@Param('id') id: string): Promise<any> {
     this.logger.log(`Starting experiment: ${id}`);
     return await this.abTestingService.startExperiment(id);
@@ -189,6 +209,10 @@ export class ABTestingController {
   @Post('experiments/:id/stop')
   @HttpCode(HttpStatus.OK)
   @Roles(UserRole.ADMIN)
+  @ApiOperation({ summary: 'Stop an experiment' })
+  @ApiParam({ name: 'id', description: 'Experiment ID' })
+  @ApiResponse({ status: 200, description: 'Experiment stopped' })
+  @ApiResponse({ status: 404, description: 'Experiment not found' })
   async stopExperiment(@Param('id') id: string): Promise<any> {
     this.logger.log(`Stopping experiment: ${id}`);
     return await this.abTestingService.stopExperiment(id);
@@ -203,6 +227,11 @@ export class ABTestingController {
   @Put('experiments/:id')
   @HttpCode(HttpStatus.OK)
   @Roles(UserRole.ADMIN)
+  @ApiOperation({ summary: 'Update an experiment' })
+  @ApiParam({ name: 'id', description: 'Experiment ID' })
+  @ApiResponse({ status: 200, description: 'Experiment updated' })
+  @ApiResponse({ status: 400, description: 'Validation failed' })
+  @ApiResponse({ status: 404, description: 'Experiment not found' })
   async updateExperiment(
     @Param('id') id: string,
     @Body() updateData: UpdateExperimentDto,
@@ -219,6 +248,10 @@ export class ABTestingController {
   @Delete('experiments/:id')
   @HttpCode(HttpStatus.OK)
   @Roles(UserRole.ADMIN)
+  @ApiOperation({ summary: 'Delete an experiment' })
+  @ApiParam({ name: 'id', description: 'Experiment ID' })
+  @ApiResponse({ status: 200, description: 'Experiment deleted successfully' })
+  @ApiResponse({ status: 404, description: 'Experiment not found' })
   async deleteExperiment(@Param('id') id: string): Promise<any> {
     this.logger.log(`Deleting experiment: ${id}`);
     // Implementation would go here
@@ -231,6 +264,10 @@ export class ABTestingController {
    * @returns The operation result.
    */
   @Get('experiments/:id/results')
+  @ApiOperation({ summary: 'Get raw results for an experiment' })
+  @ApiParam({ name: 'id', description: 'Experiment ID' })
+  @ApiResponse({ status: 200, description: 'Experiment results' })
+  @ApiResponse({ status: 404, description: 'Experiment not found' })
   async getExperimentResults(@Param('id') id: string): Promise<any> {
     this.logger.log(`Fetching results for experiment: ${id}`);
     return await this.experimentService.getExperimentResults(id);
@@ -245,6 +282,11 @@ export class ABTestingController {
   @Post('experiments/:id/variants')
   @HttpCode(HttpStatus.CREATED)
   @Roles(UserRole.ADMIN)
+  @ApiOperation({ summary: 'Add a variant to an experiment' })
+  @ApiParam({ name: 'id', description: 'Experiment ID' })
+  @ApiResponse({ status: 201, description: 'Variant added' })
+  @ApiResponse({ status: 400, description: 'Validation failed' })
+  @ApiResponse({ status: 404, description: 'Experiment not found' })
   async addVariant(
     @Param('id') experimentId: string,
     @Body() variantData: CreateVariantDto,
@@ -261,6 +303,10 @@ export class ABTestingController {
   @Delete('variants/:id')
   @HttpCode(HttpStatus.OK)
   @Roles(UserRole.ADMIN)
+  @ApiOperation({ summary: 'Remove a variant' })
+  @ApiParam({ name: 'id', description: 'Variant ID' })
+  @ApiResponse({ status: 200, description: 'Variant removed successfully' })
+  @ApiResponse({ status: 404, description: 'Variant not found' })
   async removeVariant(@Param('id') variantId: string): Promise<any> {
     this.logger.log(`Removing variant: ${variantId}`);
     await this.experimentService.removeVariant(variantId);
@@ -276,6 +322,11 @@ export class ABTestingController {
   @Put('experiments/:id/traffic-allocation')
   @HttpCode(HttpStatus.OK)
   @Roles(UserRole.ADMIN)
+  @ApiOperation({ summary: 'Update traffic allocation across variants' })
+  @ApiParam({ name: 'id', description: 'Experiment ID' })
+  @ApiResponse({ status: 200, description: 'Traffic allocation updated successfully' })
+  @ApiResponse({ status: 400, description: 'Invalid allocation values' })
+  @ApiResponse({ status: 404, description: 'Experiment not found' })
   async updateTrafficAllocation(
     @Param('id') experimentId: string,
     @Body() updateTrafficAllocationDto: UpdateTrafficAllocationDto,
@@ -294,6 +345,10 @@ export class ABTestingController {
    * @returns The operation result.
    */
   @Get('experiments/:id/statistical-analysis')
+  @ApiOperation({ summary: 'Calculate statistical significance for an experiment' })
+  @ApiParam({ name: 'id', description: 'Experiment ID' })
+  @ApiResponse({ status: 200, description: 'Statistical analysis result' })
+  @ApiResponse({ status: 404, description: 'Experiment not found' })
   async getStatisticalAnalysis(@Param('id') id: string): Promise<any> {
     this.logger.log(`Performing statistical analysis for experiment: ${id}`);
     return await this.statisticalAnalysisService.calculateStatisticalSignificance(id);
@@ -305,6 +360,10 @@ export class ABTestingController {
    * @returns The operation result.
    */
   @Get('experiments/:id/effect-size')
+  @ApiOperation({ summary: 'Calculate the effect size for an experiment' })
+  @ApiParam({ name: 'id', description: 'Experiment ID' })
+  @ApiResponse({ status: 200, description: 'Effect size result' })
+  @ApiResponse({ status: 404, description: 'Experiment not found' })
   async getEffectSize(@Param('id') id: string): Promise<any> {
     this.logger.log(`Calculating effect size for experiment: ${id}`);
     return await this.statisticalAnalysisService.calculateEffectSize(id);
@@ -319,6 +378,10 @@ export class ABTestingController {
   @Post('experiments/:id/auto-select-winner')
   @HttpCode(HttpStatus.OK)
   @Roles(UserRole.ADMIN)
+  @ApiOperation({ summary: 'Automatically select the winning variant' })
+  @ApiParam({ name: 'id', description: 'Experiment ID' })
+  @ApiResponse({ status: 200, description: 'Winner selection result' })
+  @ApiResponse({ status: 404, description: 'Experiment not found' })
   async autoSelectWinner(
     @Param('id') id: string,
     @Body() criteria?: AutoSelectWinnerDto,
@@ -339,6 +402,10 @@ export class ABTestingController {
    * @returns The operation result.
    */
   @Get('experiments/:id/decision-recommendations')
+  @ApiOperation({ summary: 'Get automated decision recommendations for an experiment' })
+  @ApiParam({ name: 'id', description: 'Experiment ID' })
+  @ApiResponse({ status: 200, description: 'Decision recommendations' })
+  @ApiResponse({ status: 404, description: 'Experiment not found' })
   async getDecisionRecommendations(@Param('id') id: string): Promise<any> {
     this.logger.log(`Getting decision recommendations for experiment: ${id}`);
     return await this.automatedDecisionService.getDecisionRecommendations(id);
@@ -352,6 +419,10 @@ export class ABTestingController {
   @Post('experiments/:id/auto-allocate-traffic')
   @HttpCode(HttpStatus.OK)
   @Roles(UserRole.ADMIN)
+  @ApiOperation({ summary: 'Automatically re-allocate traffic across variants' })
+  @ApiParam({ name: 'id', description: 'Experiment ID' })
+  @ApiResponse({ status: 200, description: 'Traffic auto-allocated successfully' })
+  @ApiResponse({ status: 404, description: 'Experiment not found' })
   async autoAllocateTraffic(@Param('id') id: string): Promise<any> {
     this.logger.log(`Auto-allocating traffic for experiment: ${id}`);
     await this.automatedDecisionService.autoAllocateTraffic(id);
@@ -365,6 +436,8 @@ export class ABTestingController {
    */
   @Get('reports/dashboard')
   @Roles(UserRole.ADMIN, UserRole.TEACHER)
+  @ApiOperation({ summary: 'Get the reporting dashboard summary' })
+  @ApiResponse({ status: 200, description: 'Dashboard summary' })
   async getDashboardSummary(@Query() filters?: DashboardFiltersDto): Promise<any> {
     this.logger.log('Generating dashboard summary');
     return await this.reportsService.getDashboardSummary(filters);
@@ -376,6 +449,10 @@ export class ABTestingController {
    * @returns The operation result.
    */
   @Get('reports/experiment/:id')
+  @ApiOperation({ summary: 'Generate a full report for an experiment' })
+  @ApiParam({ name: 'id', description: 'Experiment ID' })
+  @ApiResponse({ status: 200, description: 'Experiment report' })
+  @ApiResponse({ status: 404, description: 'Experiment not found' })
   async generateExperimentReport(@Param('id') id: string): Promise<any> {
     this.logger.log(`Generating report for experiment: ${id}`);
     return await this.reportsService.generateExperimentReport(id);
@@ -386,6 +463,8 @@ export class ABTestingController {
    * @returns The operation result.
    */
   @Get('reports/performance-comparison')
+  @ApiOperation({ summary: 'Generate a cross-experiment performance comparison report' })
+  @ApiResponse({ status: 200, description: 'Performance comparison report' })
   async getPerformanceComparisonReport(): Promise<any> {
     this.logger.log('Generating performance comparison report');
     return await this.reportsService.generatePerformanceComparisonReport();
@@ -396,6 +475,8 @@ export class ABTestingController {
    * @returns The operation result.
    */
   @Get('reports/timeline')
+  @ApiOperation({ summary: 'Get the experiment activity timeline' })
+  @ApiResponse({ status: 200, description: 'Experiment timeline' })
   async getExperimentTimeline(): Promise<any> {
     this.logger.log('Generating experiment timeline');
     return await this.reportsService.getExperimentTimeline();
@@ -407,6 +488,10 @@ export class ABTestingController {
    * @returns The operation result.
    */
   @Get('reports/experiment/:id/export')
+  @ApiOperation({ summary: 'Export experiment data as CSV' })
+  @ApiParam({ name: 'id', description: 'Experiment ID' })
+  @ApiResponse({ status: 200, description: 'CSV export payload with filename' })
+  @ApiResponse({ status: 404, description: 'Experiment not found' })
   async exportExperimentData(@Param('id') id: string): Promise<any> {
     this.logger.log(`Exporting data for experiment: ${id}`);
     const csvData = await this.reportsService.exportExperimentData(id);
@@ -424,6 +509,10 @@ export class ABTestingController {
   @Post('experiments/:id/pause')
   @HttpCode(HttpStatus.OK)
   @Roles(UserRole.ADMIN)
+  @ApiOperation({ summary: 'Pause an experiment' })
+  @ApiParam({ name: 'id', description: 'Experiment ID' })
+  @ApiResponse({ status: 200, description: 'Experiment paused' })
+  @ApiResponse({ status: 404, description: 'Experiment not found' })
   async pauseExperiment(@Param('id') id: string): Promise<any> {
     this.logger.log(`Pausing experiment: ${id}`);
     return await this.experimentService.pauseExperiment(id);
@@ -437,6 +526,10 @@ export class ABTestingController {
   @Post('experiments/:id/resume')
   @HttpCode(HttpStatus.OK)
   @Roles(UserRole.ADMIN)
+  @ApiOperation({ summary: 'Resume a paused experiment' })
+  @ApiParam({ name: 'id', description: 'Experiment ID' })
+  @ApiResponse({ status: 200, description: 'Experiment resumed' })
+  @ApiResponse({ status: 404, description: 'Experiment not found' })
   async resumeExperiment(@Param('id') id: string): Promise<any> {
     this.logger.log(`Resuming experiment: ${id}`);
     return await this.experimentService.resumeExperiment(id);
@@ -450,6 +543,10 @@ export class ABTestingController {
   @Post('experiments/:id/archive')
   @HttpCode(HttpStatus.OK)
   @Roles(UserRole.ADMIN)
+  @ApiOperation({ summary: 'Archive an experiment' })
+  @ApiParam({ name: 'id', description: 'Experiment ID' })
+  @ApiResponse({ status: 200, description: 'Experiment archived' })
+  @ApiResponse({ status: 404, description: 'Experiment not found' })
   async archiveExperiment(@Param('id') id: string): Promise<any> {
     this.logger.log(`Archiving experiment: ${id}`);
     return await this.experimentService.archiveExperiment(id);
@@ -463,6 +560,11 @@ export class ABTestingController {
    */
   @Get('experiments/:id/assign-user/:userId')
   @Roles(UserRole.ADMIN)
+  @ApiOperation({ summary: 'Assign a user to a variant for an experiment' })
+  @ApiParam({ name: 'id', description: 'Experiment ID' })
+  @ApiParam({ name: 'userId', description: 'User ID' })
+  @ApiResponse({ status: 200, description: 'The variant the user was assigned to' })
+  @ApiResponse({ status: 404, description: 'Experiment not found' })
   async assignUserToVariant(
     @Param('id') experimentId: string,
     @Param('userId') userId: string,

--- a/src/dashboard/dashboard.controller.ts
+++ b/src/dashboard/dashboard.controller.ts
@@ -7,22 +7,44 @@ import {
   Param,
   UseGuards,
 } from '@nestjs/common';
-import { ApiTags, ApiOperation, ApiQuery, ApiParam, ApiBearerAuth } from '@nestjs/swagger';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiQuery,
+  ApiParam,
+  ApiBearerAuth,
+  ApiResponse,
+} from '@nestjs/swagger';
 import { DashboardService, RevenuePeriod } from './dashboard.service';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { RolesGuard } from '../auth/guards/roles.guard';
 import { Roles } from '../auth/decorators/roles.decorator';
+import {
+  ConversionFunnelDto,
+  CoursePerformanceDto,
+  DashboardOverviewDto,
+  InstructorDashboardDto,
+  RevenueMetricsDto,
+  UserGrowthDto,
+} from './dto/dashboard-response.dto';
 
 @ApiTags('dashboard')
 @ApiBearerAuth()
 @UseGuards(JwtAuthGuard, RolesGuard)
 @Roles('instructor', 'admin')
+@ApiResponse({ status: 401, description: 'Authentication required' })
+@ApiResponse({ status: 403, description: 'Insufficient role (instructor or admin required)' })
 @Controller('dashboard')
 export class DashboardController {
   constructor(private readonly dashboardService: DashboardService) {}
 
   @Get()
   @ApiOperation({ summary: 'Business metrics dashboard overview' })
+  @ApiResponse({
+    status: 200,
+    description: 'Aggregated dashboard overview',
+    type: DashboardOverviewDto,
+  })
   getOverview() {
     return this.dashboardService.getOverview();
   }
@@ -31,6 +53,12 @@ export class DashboardController {
   @Roles('admin')
   @ApiOperation({ summary: 'Revenue metrics by period' })
   @ApiQuery({ name: 'period', enum: ['daily', 'weekly', 'monthly'], required: false })
+  @ApiResponse({
+    status: 200,
+    description: 'Revenue metrics for the requested period',
+    type: RevenueMetricsDto,
+  })
+  @ApiResponse({ status: 400, description: 'period must be daily, weekly, or monthly' })
   getRevenue(@Query('period') period?: string) {
     const p = (period ?? 'monthly') as RevenuePeriod;
     if (!['daily', 'weekly', 'monthly'].includes(p)) {
@@ -41,12 +69,22 @@ export class DashboardController {
 
   @Get('users/growth')
   @ApiOperation({ summary: 'User growth metrics' })
+  @ApiResponse({
+    status: 200,
+    description: 'Total users and monthly signup series',
+    type: UserGrowthDto,
+  })
   getUserGrowth() {
     return this.dashboardService.getUserGrowthMetrics();
   }
 
   @Get('courses/performance')
   @ApiOperation({ summary: 'Course performance metrics' })
+  @ApiResponse({
+    status: 200,
+    description: 'Top courses ranked by enrollment',
+    type: [CoursePerformanceDto],
+  })
   getCoursePerformance() {
     return this.dashboardService.getCoursePerformanceMetrics();
   }
@@ -54,6 +92,11 @@ export class DashboardController {
   @Get('funnel')
   @Roles('admin')
   @ApiOperation({ summary: 'Conversion funnel tracking' })
+  @ApiResponse({
+    status: 200,
+    description: 'Conversion funnel stages and rates',
+    type: ConversionFunnelDto,
+  })
   getFunnel() {
     return this.dashboardService.getConversionFunnel();
   }
@@ -61,12 +104,23 @@ export class DashboardController {
   @Get('instructors/:instructorId')
   @ApiOperation({ summary: 'Instructor course analytics dashboard' })
   @ApiParam({ name: 'instructorId', description: 'UUID of the instructor' })
+  @ApiResponse({
+    status: 200,
+    description: 'Instructor analytics dashboard',
+    type: InstructorDashboardDto,
+  })
+  @ApiResponse({ status: 404, description: 'Instructor not found' })
   async getInstructorDashboard(@Param('instructorId') instructorId: string) {
     return this.dashboardService.getInstructorDashboard(instructorId);
   }
 
   @Get('export/csv')
   @ApiOperation({ summary: 'Export dashboard metrics to CSV' })
+  @ApiResponse({
+    status: 200,
+    description: 'CSV export of dashboard metrics',
+    content: { 'text/csv': { schema: { type: 'string' } } },
+  })
   @Header('Content-Type', 'text/csv')
   @Header('Content-Disposition', 'attachment; filename="dashboard-metrics.csv"')
   async exportCsv(): Promise<string> {

--- a/src/dashboard/dto/dashboard-response.dto.ts
+++ b/src/dashboard/dto/dashboard-response.dto.ts
@@ -1,0 +1,147 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+/**
+ * Typed response schemas for the dashboard endpoints so the generated Swagger
+ * documentation renders accurate models instead of opaque `object` payloads.
+ */
+
+export class RevenueSummaryDto {
+  @ApiProperty({ example: 12500.75, description: 'Gross revenue for the period' })
+  grossRevenue: number;
+
+  @ApiProperty({ example: 11200.5, description: 'Net revenue after refunds/fees' })
+  netRevenue: number;
+
+  @ApiProperty({ example: 1300.25, description: 'Total refunds issued in the period' })
+  totalRefunds: number;
+
+  @ApiProperty({ example: 'USD', description: 'ISO 4217 currency code' })
+  currency: string;
+}
+
+export class RevenueBucketDto {
+  @ApiProperty({ example: '2025-01', description: 'Bucket label for the period' })
+  period: string;
+
+  @ApiProperty({ example: 4200.5, description: 'Revenue recognised within the bucket' })
+  amount: number;
+}
+
+export class RevenueMetricsDto {
+  @ApiProperty({ enum: ['daily', 'weekly', 'monthly'], example: 'monthly' })
+  period: 'daily' | 'weekly' | 'monthly';
+
+  @ApiProperty({ type: [RevenueBucketDto] })
+  buckets: RevenueBucketDto[];
+
+  @ApiProperty({ type: RevenueSummaryDto })
+  summary: RevenueSummaryDto;
+}
+
+export class MonthlySignupDto {
+  @ApiProperty({ example: '2025-01' })
+  period: string;
+
+  @ApiProperty({ example: 320, description: 'New users registered in the month' })
+  newUsers: number;
+
+  @ApiProperty({ example: 5400, description: 'Cumulative users up to and including the month' })
+  totalUsers: number;
+}
+
+export class UserGrowthDto {
+  @ApiProperty({ example: 5400 })
+  totalUsers: number;
+
+  @ApiProperty({ type: [MonthlySignupDto] })
+  monthlySignups: MonthlySignupDto[];
+}
+
+export class CoursePerformanceDto {
+  @ApiProperty({ example: 'c1a2b3', format: 'uuid' })
+  courseId: string;
+
+  @ApiProperty({ example: 'Intro to TypeScript' })
+  title: string;
+
+  @ApiProperty({ example: 1280, description: 'Number of enrollments' })
+  enrollments: number;
+
+  @ApiProperty({ example: 49.99 })
+  price: number;
+
+  @ApiProperty({ example: 'published' })
+  status: string;
+}
+
+export class FunnelStageDto {
+  @ApiProperty({ example: 'signup' })
+  name: string;
+
+  @ApiProperty({ example: 5400 })
+  count: number;
+}
+
+export class FunnelConversionRatesDto {
+  @ApiProperty({ example: 0.42 })
+  signupToEnrollment: number;
+
+  @ApiProperty({ example: 0.65 })
+  enrollmentToPayment: number;
+
+  @ApiProperty({ example: 0.58 })
+  paymentToCompletion: number;
+}
+
+export class ConversionFunnelDto {
+  @ApiProperty({ type: [FunnelStageDto] })
+  stages: FunnelStageDto[];
+
+  @ApiProperty({ type: FunnelConversionRatesDto })
+  conversionRates: FunnelConversionRatesDto;
+}
+
+export class DashboardOverviewDto {
+  @ApiProperty({ type: RevenueMetricsDto })
+  revenue: RevenueMetricsDto;
+
+  @ApiProperty({ type: UserGrowthDto })
+  userGrowth: UserGrowthDto;
+
+  @ApiProperty({ type: [CoursePerformanceDto] })
+  coursePerformance: CoursePerformanceDto[];
+
+  @ApiProperty({ type: ConversionFunnelDto })
+  funnel: ConversionFunnelDto;
+
+  @ApiProperty({ example: '2025-01-31T12:00:00.000Z', description: 'ISO timestamp of generation' })
+  generatedAt: string;
+}
+
+export class InstructorDashboardDto {
+  @ApiProperty({ example: 'c1a2b3', format: 'uuid' })
+  instructorId: string;
+
+  @ApiProperty({
+    description: 'Revenue breakdown for the instructor',
+    type: 'object',
+    additionalProperties: true,
+  })
+  revenue: Record<string, unknown>;
+
+  @ApiProperty({ description: 'Enrollment trend series', type: 'array', items: { type: 'object' } })
+  enrollmentTrends: unknown[];
+
+  @ApiProperty({ example: 0.73, description: 'Average course completion rate (0–1)' })
+  completionRate: number;
+
+  @ApiProperty({
+    description: 'Aggregated video watch-time metrics',
+    type: 'object',
+    additionalProperties: true,
+  })
+  videoWatchTime: Record<string, unknown>;
+
+  @ApiProperty({ description: 'Per-course summary rows', type: 'array', items: { type: 'object' } })
+  courseSummary: unknown[];
+}

--- a/src/rbac/permissions/permissions.controller.ts
+++ b/src/rbac/permissions/permissions.controller.ts
@@ -34,8 +34,13 @@ export class PermissionsController {
   @Roles(UserRole.ADMIN)
   @ApiOperation({ summary: 'Create a new permission (Admin only)' })
   @ApiResponse({ status: 201, description: 'Permission created', type: Permission })
+  @ApiResponse({ status: 400, description: 'Validation failed' })
   @ApiResponse({ status: 401, description: 'Authentication required' })
   @ApiResponse({ status: 403, description: 'Admin role required' })
+  @ApiResponse({
+    status: 409,
+    description: 'A permission with this resource/action already exists',
+  })
   async create(@Body() dto: CreatePermissionDto): Promise<Permission> {
     return this.permissionsService.createPermission(dto.resource, dto.action, dto.description);
   }
@@ -47,6 +52,7 @@ export class PermissionsController {
     description: 'Returns paginated permissions',
     type: PaginatedSwaggerDto(Permission),
   })
+  @ApiResponse({ status: 401, description: 'Authentication required' })
   async findAll(@Query() query?: PaginationQueryDto) {
     return this.permissionsService.findAllPermissions(query);
   }
@@ -54,6 +60,7 @@ export class PermissionsController {
   @Get(':id')
   @ApiOperation({ summary: 'Get permission by ID' })
   @ApiResponse({ status: 200, description: 'Permission found', type: Permission })
+  @ApiResponse({ status: 401, description: 'Authentication required' })
   @ApiResponse({ status: 404, description: 'Permission not found' })
   async findOne(@Param('id') id: string): Promise<Permission> {
     return this.permissionsService.findPermissionById(id);
@@ -64,6 +71,7 @@ export class PermissionsController {
   @HttpCode(HttpStatus.OK)
   @ApiOperation({ summary: 'Update a permission (Admin only)' })
   @ApiResponse({ status: 200, description: 'Permission updated', type: Permission })
+  @ApiResponse({ status: 400, description: 'Validation failed' })
   @ApiResponse({ status: 401, description: 'Authentication required' })
   @ApiResponse({ status: 403, description: 'Admin role required' })
   @ApiResponse({ status: 404, description: 'Permission not found' })

--- a/src/security/secrets/secrets.controller.ts
+++ b/src/security/secrets/secrets.controller.ts
@@ -1,18 +1,33 @@
 import { Controller, Get, Post, Param, UseGuards } from '@nestjs/common';
 import { ApiTags, ApiOperation, ApiBearerAuth, ApiResponse } from '@nestjs/swagger';
+import { Throttle } from '@nestjs/throttler';
 import { SecretsManagerService } from './secrets-manager.service';
 import { VaultSecretsService } from './vault-secrets.service';
 import { Roles } from '../../auth/decorators/roles.decorator';
 import { JwtAuthGuard } from '../../auth/guards/jwt-auth.guard';
 import { RolesGuard } from '../../auth/guards/roles.guard';
+import { CustomThrottleGuard } from '../../common/guards/throttle.guard';
+import { THROTTLE } from '../../common/constants/throttle.constants';
 import { UserRole } from '../../users/entities/user.entity';
 
+/**
+ * Secret-management endpoints are highly sensitive: they read and rotate
+ * credentials held in AWS Secrets Manager / HashiCorp Vault. On top of the
+ * admin-only authorization we throttle every handler so a leaked or misused
+ * admin token cannot be used to brute-force or hammer the secret backends.
+ *
+ * Limits come from the shared {@link THROTTLE} presets (documented and
+ * configurable) rather than hardcoded magic numbers — rotation, the most
+ * destructive action, uses the strictest preset.
+ */
 @ApiTags('secrets')
 @Controller('secrets')
-@UseGuards(JwtAuthGuard, RolesGuard)
+@UseGuards(JwtAuthGuard, RolesGuard, CustomThrottleGuard)
+@Throttle({ default: THROTTLE.MODERATE })
 @ApiBearerAuth()
 @ApiResponse({ status: 401, description: 'Authentication required' })
 @ApiResponse({ status: 403, description: 'Admin role required' })
+@ApiResponse({ status: 429, description: 'Too many requests — rate limit exceeded' })
 export class SecretsController {
   constructor(
     private readonly secretsManagerService: SecretsManagerService,
@@ -39,6 +54,7 @@ export class SecretsController {
 
   @Post('aws/rotate/:secretName')
   @Roles(UserRole.ADMIN)
+  @Throttle({ default: THROTTLE.STRICT })
   @ApiOperation({ summary: 'Rotate secret in AWS Secrets Manager' })
   @ApiResponse({ status: 201, description: 'AWS secret rotated' })
   async rotateAWSSecret(@Param('secretName') secretName: string) {
@@ -48,6 +64,7 @@ export class SecretsController {
 
   @Post('vault/rotate/:secretName')
   @Roles(UserRole.ADMIN)
+  @Throttle({ default: THROTTLE.STRICT })
   @ApiOperation({ summary: 'Rotate secret in HashiCorp Vault' })
   @ApiResponse({ status: 201, description: 'Vault secret rotated' })
   async rotateVaultSecret(@Param('secretName') secretName: string) {

--- a/src/security/secrets/secrets.module.ts
+++ b/src/security/secrets/secrets.module.ts
@@ -1,9 +1,17 @@
 import { Module } from '@nestjs/common';
+import { ThrottlerModule } from '@nestjs/throttler';
 import { SecretsManagerService } from './secrets-manager.service';
 import { VaultSecretsService } from './vault-secrets.service';
 import { SecretsController } from './secrets.controller';
+import { THROTTLE } from '../../common/constants/throttle.constants';
 
 @Module({
+  // Register a throttler so CustomThrottleGuard has storage/config to enforce
+  // the per-handler @Throttle presets applied in SecretsController. The
+  // baseline mirrors the MODERATE preset; individual handlers tighten it.
+  imports: [
+    ThrottlerModule.forRoot([{ ttl: THROTTLE.MODERATE.ttl, limit: THROTTLE.MODERATE.limit }]),
+  ],
   controllers: [SecretsController],
   providers: [SecretsManagerService, VaultSecretsService],
   exports: [SecretsManagerService, VaultSecretsService],


### PR DESCRIPTION
## Summary

This PR hardens and documents several controller surfaces.

- **Secrets** — applies the shared `CustomThrottleGuard` to every handler in `secrets.controller.ts` (strictest preset on secret rotation) and wires `ThrottlerModule` in `SecretsModule`. Exceeding a limit now returns `429` with a structured message. Limits are taken from the documented, configurable `THROTTLE` presets rather than hardcoded magic numbers, and normal usage is unaffected.
- **Dashboard** — adds typed response DTOs (`dashboard/dto/dashboard-response.dto.ts`) and per-endpoint `@ApiResponse` (success + relevant `4xx`, plus class-level `401/403`) so the generated Swagger models render accurately.
- **A/B testing** — adds `@ApiOperation`, `@ApiResponse` and `@ApiParam` to every handler that was previously undocumented, keeping the existing schema examples.
- **Permissions** — fills in the missing `400/401/409` response annotations.

## Testing

- `pnpm run typecheck`
- `pnpm run lint:ci`
- `pnpm run build`

## Issues

Closes #1325
Closes #1319
Closes #1318
Closes #1314
