### PR TITLE
feat: throttle admin/payment/email endpoints and document user preferences API

### DIFF
--- a/src/email-unsubscribe/email-unsubscribe.controller.ts
+++ b/src/email-unsubscribe/email-unsubscribe.controller.ts
@@ -1,9 +1,22 @@
-import { Controller, Post, Get, Body, Param, HttpCode, HttpStatus } from '@nestjs/common';
+import {
+  Controller,
+  Post,
+  Get,
+  Body,
+  Param,
+  HttpCode,
+  HttpStatus,
+  UseGuards,
+} from '@nestjs/common';
 import { ApiTags, ApiOperation, ApiResponse } from '@nestjs/swagger';
+import { Throttle } from '@nestjs/throttler';
+import { THROTTLE } from '../common/constants/throttle.constants';
+import { CustomThrottleGuard } from '../common/guards/throttle.guard';
 import { EmailUnsubscribeService } from './email-unsubscribe.service';
 import { UnsubscribeDto, ResubscribeDto, UpdateEmailPreferencesDto } from './dto/unsubscribe.dto';
 
 @ApiTags('email-unsubscribe')
+@UseGuards(CustomThrottleGuard)
 @Controller('email-unsubscribe')
 export class EmailUnsubscribeController {
   constructor(private readonly emailUnsubscribeService: EmailUnsubscribeService) {}
@@ -12,6 +25,7 @@ export class EmailUnsubscribeController {
   @HttpCode(HttpStatus.NO_CONTENT)
   @ApiOperation({ summary: 'One-click unsubscribe via token' })
   @ApiResponse({ status: 204, description: 'Successfully unsubscribed' })
+  @Throttle({ default: THROTTLE.AUTH_DEFAULT })
   async unsubscribe(@Body() dto: UnsubscribeDto): Promise<void> {
     await this.emailUnsubscribeService.unsubscribe(dto);
   }
@@ -20,18 +34,21 @@ export class EmailUnsubscribeController {
   @HttpCode(HttpStatus.NO_CONTENT)
   @ApiOperation({ summary: 'Resubscribe to emails' })
   @ApiResponse({ status: 204, description: 'Successfully resubscribed' })
+  @Throttle({ default: THROTTLE.MODERATE })
   async resubscribe(@Body() dto: ResubscribeDto): Promise<void> {
     await this.emailUnsubscribeService.resubscribe(dto);
   }
 
   @Post('preferences')
   @ApiOperation({ summary: 'Update email type preferences' })
+  @Throttle({ default: THROTTLE.MODERATE })
   async updatePreferences(@Body() dto: UpdateEmailPreferencesDto) {
     return this.emailUnsubscribeService.updatePreferences(dto);
   }
 
   @Get('status/:email')
   @ApiOperation({ summary: 'Get subscription status for an email' })
+  @Throttle({ default: THROTTLE.MODERATE })
   async getStatus(@Param('email') email: string) {
     return this.emailUnsubscribeService.getSubscriptionStatus(email);
   }

--- a/src/email-unsubscribe/email-unsubscribe.module.ts
+++ b/src/email-unsubscribe/email-unsubscribe.module.ts
@@ -1,12 +1,22 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
+import { ThrottlerModule } from '@nestjs/throttler';
+import { TIME } from '../common/constants/time.constants';
 import { EmailUnsubscribeController } from './email-unsubscribe.controller';
 import { EmailUnsubscribeService } from './email-unsubscribe.service';
 import { UnsubscribeToken } from './entities/unsubscribe-token.entity';
 import { EmailSubscription } from '../email-marketing/entities/email-subscription.entity';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([UnsubscribeToken, EmailSubscription])],
+  imports: [
+    ThrottlerModule.forRoot([
+      {
+        ttl: TIME.ONE_MINUTE_MS,
+        limit: 100,
+      },
+    ]),
+    TypeOrmModule.forFeature([UnsubscribeToken, EmailSubscription]),
+  ],
   controllers: [EmailUnsubscribeController],
   providers: [EmailUnsubscribeService],
   exports: [EmailUnsubscribeService],

--- a/src/incident-management/incident-management.controller.ts
+++ b/src/incident-management/incident-management.controller.ts
@@ -9,7 +9,11 @@ import {
   HttpCode,
   HttpStatus,
   Logger,
+  UseGuards,
 } from '@nestjs/common';
+import { Throttle } from '@nestjs/throttler';
+import { THROTTLE } from '../common/constants/throttle.constants';
+import { CustomThrottleGuard } from '../common/guards/throttle.guard';
 import { IncidentManagementService } from './incident-management.service';
 import {
   CreateIncidentDto,
@@ -27,6 +31,7 @@ import { Incident } from './entities/incident.entity';
 import { RemediationAction } from './entities/remediation-action.entity';
 import { RunbookExecution } from './entities/runbook-execution.entity';
 
+@UseGuards(CustomThrottleGuard)
 @Controller('incidents')
 export class IncidentManagementController {
   private readonly logger = new Logger(IncidentManagementController.name);
@@ -38,6 +43,7 @@ export class IncidentManagementController {
    */
   @Post()
   @HttpCode(HttpStatus.CREATED)
+  @Throttle({ default: THROTTLE.MODERATE })
   async createIncident(@Body() createIncidentDto: CreateIncidentDto): Promise<IncidentResponseDto> {
     this.logger.log(`Creating incident: ${createIncidentDto.title}`);
     const incident = await this.incidentManagementService.createIncident(createIncidentDto);
@@ -74,6 +80,7 @@ export class IncidentManagementController {
    * Update incident
    */
   @Put(':incidentId')
+  @Throttle({ default: THROTTLE.MODERATE })
   async updateIncident(
     @Param('incidentId') incidentId: string,
     @Body() updateIncidentDto: UpdateIncidentDto,
@@ -89,6 +96,7 @@ export class IncidentManagementController {
    * Resolve incident
    */
   @Post(':incidentId/resolve')
+  @Throttle({ default: THROTTLE.MODERATE })
   async resolveIncident(
     @Param('incidentId') incidentId: string,
     @Body() resolveIncidentDto: ResolveIncidentDto,
@@ -105,6 +113,7 @@ export class IncidentManagementController {
    * Escalate incident
    */
   @Post(':incidentId/escalate')
+  @Throttle({ default: THROTTLE.MODERATE })
   async escalateIncident(
     @Param('incidentId') incidentId: string,
     @Body() escalateIncidentDto: EscalateIncidentDto,
@@ -123,6 +132,7 @@ export class IncidentManagementController {
    */
   @Post(':incidentId/remediation-actions')
   @HttpCode(HttpStatus.CREATED)
+  @Throttle({ default: THROTTLE.MODERATE })
   async createRemediationAction(
     @Param('incidentId') incidentId: string,
     @Body() createDto: CreateRemediationActionDto,
@@ -152,6 +162,7 @@ export class IncidentManagementController {
    */
   @Post(':incidentId/runbook-executions')
   @HttpCode(HttpStatus.CREATED)
+  @Throttle({ default: THROTTLE.MODERATE })
   async executeRunbook(
     @Param('incidentId') incidentId: string,
     @Body() createDto: CreateRunbookExecutionDto,

--- a/src/incident-management/incident-management.module.ts
+++ b/src/incident-management/incident-management.module.ts
@@ -1,6 +1,8 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { ConfigModule } from '@nestjs/config';
+import { ThrottlerModule } from '@nestjs/throttler';
+import { TIME } from '../common/constants/time.constants';
 import { IncidentManagementController } from './incident-management.controller';
 import { IncidentManagementService } from './incident-management.service';
 import { Incident, RemediationAction, RunbookExecution } from './entities';
@@ -14,6 +16,12 @@ import { CommonModule } from '../common/common.module';
 
 @Module({
   imports: [
+    ThrottlerModule.forRoot([
+      {
+        ttl: TIME.ONE_MINUTE_MS,
+        limit: 100,
+      },
+    ]),
     TypeOrmModule.forFeature([Incident, RemediationAction, RunbookExecution]),
     ConfigModule,
     CommonModule,

--- a/src/payments/payment-methods/payment-methods.controller.ts
+++ b/src/payments/payment-methods/payment-methods.controller.ts
@@ -1,10 +1,24 @@
-import { Body, Controller, Delete, Get, Param, Patch, Post, Query } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  Patch,
+  Post,
+  Query,
+  UseGuards,
+} from '@nestjs/common';
 import { ApiOperation, ApiQuery, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { Throttle } from '@nestjs/throttler';
+import { THROTTLE } from '../../common/constants/throttle.constants';
+import { CustomThrottleGuard } from '../../common/guards/throttle.guard';
 import { PaymentMethodsService } from './payment-methods.service';
 import { CreatePaymentMethodDto, UpdatePaymentMethodDto } from './payment-methods.dto';
 import { Idempotent } from '../../common/decorators/idempotency.decorator';
 
 @ApiTags('Payment Methods')
+@UseGuards(CustomThrottleGuard)
 @Controller('payment-methods')
 export class PaymentMethodsController {
   constructor(private readonly paymentMethodsService: PaymentMethodsService) {}
@@ -13,6 +27,7 @@ export class PaymentMethodsController {
   @ApiOperation({ summary: 'List saved payment methods for the current user' })
   @ApiQuery({ name: 'userId', required: true, description: 'User identifier' })
   @ApiResponse({ status: 200, description: 'Saved payment methods' })
+  @Throttle({ default: THROTTLE.MODERATE })
   async list(@Query('userId') userId: string) {
     return this.paymentMethodsService.listMethods(userId);
   }
@@ -22,6 +37,7 @@ export class PaymentMethodsController {
   @ApiOperation({ summary: 'Add a new payment method' })
   @ApiQuery({ name: 'userId', required: true, description: 'User identifier' })
   @ApiResponse({ status: 201, description: 'Payment method added' })
+  @Throttle({ default: THROTTLE.MODERATE })
   async create(@Query('userId') userId: string, @Body() dto: CreatePaymentMethodDto) {
     return this.paymentMethodsService.addMethod(userId, dto);
   }
@@ -30,6 +46,7 @@ export class PaymentMethodsController {
   @ApiOperation({ summary: 'Update an existing payment method' })
   @ApiQuery({ name: 'userId', required: true, description: 'User identifier' })
   @ApiResponse({ status: 200, description: 'Payment method updated' })
+  @Throttle({ default: THROTTLE.MODERATE })
   async update(
     @Param('id') id: string,
     @Query('userId') userId: string,
@@ -42,6 +59,7 @@ export class PaymentMethodsController {
   @ApiOperation({ summary: 'Set a payment method as the default' })
   @ApiQuery({ name: 'userId', required: true, description: 'User identifier' })
   @ApiResponse({ status: 200, description: 'Default payment method updated' })
+  @Throttle({ default: THROTTLE.MODERATE })
   async setDefault(@Param('id') id: string, @Query('userId') userId: string) {
     return this.paymentMethodsService.setDefaultMethod(userId, id);
   }
@@ -50,6 +68,7 @@ export class PaymentMethodsController {
   @ApiOperation({ summary: 'Remove a payment method' })
   @ApiQuery({ name: 'userId', required: true, description: 'User identifier' })
   @ApiResponse({ status: 204, description: 'Payment method removed' })
+  @Throttle({ default: THROTTLE.MODERATE })
   async remove(@Param('id') id: string, @Query('userId') userId: string) {
     await this.paymentMethodsService.removeMethod(userId, id);
     return { success: true };

--- a/src/payments/payment-methods/payment-methods.module.ts
+++ b/src/payments/payment-methods/payment-methods.module.ts
@@ -1,11 +1,21 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
+import { ThrottlerModule } from '@nestjs/throttler';
+import { TIME } from '../../common/constants/time.constants';
 import { PaymentMethod } from '../entities/payment-method.entity';
 import { PaymentMethodsController } from './payment-methods.controller';
 import { PaymentMethodsService } from './payment-methods.service';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([PaymentMethod])],
+  imports: [
+    ThrottlerModule.forRoot([
+      {
+        ttl: TIME.ONE_MINUTE_MS,
+        limit: 100,
+      },
+    ]),
+    TypeOrmModule.forFeature([PaymentMethod]),
+  ],
   controllers: [PaymentMethodsController],
   providers: [PaymentMethodsService],
   exports: [PaymentMethodsService],

--- a/src/user-preferences/dto/user-preference-response.dto.ts
+++ b/src/user-preferences/dto/user-preference-response.dto.ts
@@ -1,0 +1,65 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { AppLanguage, AppTheme } from '../entities/user-preference.entity';
+
+/**
+ * Typed response shape for user-preferences endpoints so the generated
+ * Swagger schemas render accurately.
+ */
+export class UserPreferenceResponseDto {
+  @ApiProperty({ description: 'Preference record UUID' })
+  id: string;
+
+  @ApiProperty({ description: 'User the preferences belong to' })
+  userId: string;
+
+  @ApiProperty({ enum: AppTheme, description: 'UI theme preference' })
+  theme: AppTheme;
+
+  @ApiProperty({ enum: AppLanguage, description: 'UI language preference' })
+  language: AppLanguage;
+
+  @ApiPropertyOptional({
+    description: 'Locale used for number/date formatting',
+    example: 'en-US',
+  })
+  locale?: string;
+
+  @ApiPropertyOptional({
+    description: 'IANA timezone identifier',
+    example: 'UTC',
+  })
+  timezone?: string;
+
+  @ApiPropertyOptional({ description: 'Preferred currency code', example: 'USD' })
+  currency?: string;
+
+  @ApiProperty({ description: 'Receive email notifications' })
+  emailNotifications: boolean;
+
+  @ApiProperty({ description: 'Receive push notifications' })
+  pushNotifications: boolean;
+
+  @ApiProperty({ description: 'Receive in-app notifications' })
+  inAppNotifications: boolean;
+
+  @ApiProperty({ description: 'Receive marketing emails' })
+  marketingEmails: boolean;
+
+  @ApiProperty({ description: 'Receive course updates' })
+  courseUpdates: boolean;
+
+  @ApiProperty({ description: 'Receive the weekly digest' })
+  weeklyDigest: boolean;
+
+  @ApiPropertyOptional({
+    description: 'Advanced custom settings',
+    type: Object,
+  })
+  customSettings?: Record<string, unknown>;
+
+  @ApiProperty({ description: 'Creation timestamp' })
+  createdAt: Date;
+
+  @ApiProperty({ description: 'Last update timestamp' })
+  updatedAt: Date;
+}

--- a/src/user-preferences/user-preferences.controller.ts
+++ b/src/user-preferences/user-preferences.controller.ts
@@ -1,7 +1,8 @@
 import { Controller, Get, Patch, Delete, Body, Param, UseGuards } from '@nestjs/common';
-import { ApiTags, ApiOperation, ApiBearerAuth } from '@nestjs/swagger';
+import { ApiTags, ApiOperation, ApiBearerAuth, ApiResponse } from '@nestjs/swagger';
 import { UserPreferencesService } from './user-preferences.service';
 import { UpdateUserPreferenceDto } from './dto/update-user-preference.dto';
+import { UserPreferenceResponseDto } from './dto/user-preference-response.dto';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 
 @ApiTags('user-preferences')
@@ -13,18 +14,40 @@ export class UserPreferencesController {
 
   @Get()
   @ApiOperation({ summary: 'Get user preferences' })
+  @ApiResponse({
+    status: 200,
+    description: 'The user preferences',
+    type: UserPreferenceResponseDto,
+  })
+  @ApiResponse({ status: 401, description: 'Unauthorized — valid JWT required' })
+  @ApiResponse({ status: 404, description: 'Preferences not found for the user' })
   getPreferences(@Param('userId') userId: string) {
     return this.userPreferencesService.getPreferences(userId);
   }
 
   @Patch()
   @ApiOperation({ summary: 'Update user preferences' })
+  @ApiResponse({
+    status: 200,
+    description: 'The updated user preferences',
+    type: UserPreferenceResponseDto,
+  })
+  @ApiResponse({ status: 400, description: 'Invalid preference payload' })
+  @ApiResponse({ status: 401, description: 'Unauthorized — valid JWT required' })
+  @ApiResponse({ status: 404, description: 'Preferences not found for the user' })
   updatePreferences(@Param('userId') userId: string, @Body() dto: UpdateUserPreferenceDto) {
     return this.userPreferencesService.updatePreferences(userId, dto);
   }
 
   @Delete()
   @ApiOperation({ summary: 'Reset preferences to defaults' })
+  @ApiResponse({
+    status: 200,
+    description: 'The reset user preferences',
+    type: UserPreferenceResponseDto,
+  })
+  @ApiResponse({ status: 401, description: 'Unauthorized — valid JWT required' })
+  @ApiResponse({ status: 404, description: 'Preferences not found for the user' })
   resetPreferences(@Param('userId') userId: string) {
     return this.userPreferencesService.resetPreferences(userId);
   }


### PR DESCRIPTION
## Summary

Four changes:

1. **Rate limit incident-management** — `CustomThrottleGuard` applied to all state-changing endpoints (create/update/resolve/escalate, remediation actions, runbook executions) with the documented `MODERATE` preset (10/hour); `ThrottlerModule` wired into the module. Exceeding a limit returns 429.
2. **Rate limit email-unsubscribe** — same guard: `AUTH_DEFAULT` (5/hour) on one-click unsubscribe, `MODERATE` on resubscribe/preferences/status; `ThrottlerModule` wired in.
3. **Rate limit payment-methods** — all endpoints throttled with `MODERATE`, matching the documented preset for payment paths; `ThrottlerModule` wired in.
4. **OpenAPI docs for user-preferences** — every endpoint now has `@ApiOperation` + `@ApiResponse` (200/400/401/404) and references a typed `UserPreferenceResponseDto` so Swagger renders schemas correctly; the controller stays grouped under `@ApiTags(‘user-preferences’)`.

## Validation

- `pnpm run lint:ci` (0 errors; remaining warnings are pre-existing), `pnpm run typecheck`, and `pnpm run build` pass.
- Limits use the shared `THROTTLE` presets (documented, not hardcoded magic numbers); a rate-limited request returns HTTP 429 via `RateLimitExceededException`.

Closes #1331
Closes #1328
Closes #1326
Closes #1321