### PR TITLE
fix: wrap multi-step writes in database transactions (#1344)

### DIFF
--- a/src/ab-testing/experiments/experiment.service.ts
+++ b/src/ab-testing/experiments/experiment.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { DataSource, Repository } from 'typeorm';
 import { Experiment, ExperimentStatus } from '../entities/experiment.entity';
 import { IExperimentVariant } from '../entities/experiment-variant.entity';
 import { ExperimentMetric } from '../entities/experiment-metric.entity';
@@ -23,6 +23,7 @@ export class ExperimentService {
     private experimentMetricRepository: Repository<ExperimentMetric>,
     @InjectRepository(VariantMetric)
     private variantMetricRepository: Repository<VariantMetric>,
+    private readonly dataSource: DataSource,
   ) {}
 
   // Method to create a new experiment
@@ -90,12 +91,17 @@ export class ExperimentService {
       throw new Error('Traffic allocations must sum to 1 (e.g. 0.5 + 0.5)');
     }
 
-    for (const variant of experiment.variants) {
-      if (allocations[variant.id] !== undefined) {
-        variant.trafficAllocation = allocations[variant.id];
-        await this.variantRepository.save(variant);
+    // All variant allocation updates are one logical operation: they commit
+    // together or not at all (issue #1344).
+    await this.dataSource.transaction(async (manager) => {
+      const variantRepository = manager.getRepository(IExperimentVariant);
+      for (const variant of experiment.variants) {
+        if (allocations[variant.id] !== undefined) {
+          variant.trafficAllocation = allocations[variant.id];
+          await variantRepository.save(variant);
+        }
       }
-    }
+    });
     this.logger.log(`Traffic allocation updated for experiment: ${experiment.name}`);
   }
 

--- a/src/achievements/achievements.service.ts
+++ b/src/achievements/achievements.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, Logger, NotFoundException, Inject } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository, MoreThan } from 'typeorm';
+import { DataSource, EntityManager, Repository, MoreThan } from 'typeorm';
 import { Achievement, AchievementType } from './entities/achievement.entity';
 import { AchievementProgress } from './entities/achievement-progress.entity';
 import { UserAchievement } from './entities/user-achievement.entity';
@@ -43,6 +43,7 @@ export class AchievementsService {
     @InjectRepository(AchievementStatistics)
     private statisticsRepository: Repository<AchievementStatistics>,
     @Inject(CACHE_MANAGER) private cacheManager: Cache,
+    private readonly dataSource: DataSource,
   ) {}
 
   // =====================================================
@@ -219,41 +220,62 @@ export class AchievementsService {
     achievementId: string,
     dto: UpdateAchievementProgressDto,
   ): Promise<AchievementProgressDto> {
-    let progress = await this.progressRepository.findOne({
-      where: {
-        user: { id: userId },
-        achievement: { id: achievementId },
-      },
-      relations: ['achievement'],
+    // Progress save + potential unlock are one logical operation: if the unlock
+    // writes fail, the progress change must roll back with them (issue #1344).
+    return this.dataSource.transaction(async (manager) => {
+      const progressRepository = manager.getRepository(AchievementProgress);
+      const achievementRepository = manager.getRepository(Achievement);
+
+      let progress = await progressRepository.findOne({
+        where: {
+          user: { id: userId },
+          achievement: { id: achievementId },
+        },
+        relations: ['achievement'],
+      });
+
+      if (!progress) {
+        // Initialize if it doesn't exist (same logic as initializeProgress).
+        const achievement = await achievementRepository.findOne({
+          where: { id: achievementId },
+        });
+        if (!achievement) {
+          throw new NotFoundException(`Achievement not found: ${achievementId}`);
+        }
+        const targetProgress = achievement.progressConfig?.maxProgress || 1;
+        progress = progressRepository.create({
+          user: { id: userId } as User,
+          achievement,
+          currentProgress: 0,
+          targetProgress,
+          percentageComplete: 0,
+          isUnlocked: false,
+        });
+      }
+
+      progress.currentProgress = Math.min(dto.currentProgress, progress.targetProgress);
+      progress.percentageComplete = Math.round(
+        (progress.currentProgress / progress.targetProgress) * 100,
+      );
+      progress.lastProgressUpdate = new Date();
+
+      if (dto.metadata) {
+        progress.metadata = { ...progress.metadata, ...dto.metadata };
+      }
+
+      const saved = await progressRepository.save(progress);
+
+      this.logger.log(
+        `Progress updated for user ${userId}: achievement ${achievementId} - ${progress.percentageComplete}%`,
+      );
+
+      // Check if achievement should be unlocked
+      if (!progress.isUnlocked && progress.currentProgress >= progress.targetProgress) {
+        await this.unlockWithManager(manager, userId, achievementId);
+      }
+
+      return this.toAchievementProgressDto(saved);
     });
-
-    if (!progress) {
-      // Initialize if doesn't exist
-      progress = await this.initializeProgress(userId, achievementId);
-    }
-
-    progress.currentProgress = Math.min(dto.currentProgress, progress.targetProgress);
-    progress.percentageComplete = Math.round(
-      (progress.currentProgress / progress.targetProgress) * 100,
-    );
-    progress.lastProgressUpdate = new Date();
-
-    if (dto.metadata) {
-      progress.metadata = { ...progress.metadata, ...dto.metadata };
-    }
-
-    const saved = await this.progressRepository.save(progress);
-
-    this.logger.log(
-      `Progress updated for user ${userId}: achievement ${achievementId} - ${progress.percentageComplete}%`,
-    );
-
-    // Check if achievement should be unlocked
-    if (!progress.isUnlocked && progress.currentProgress >= progress.targetProgress) {
-      await this.unlockAchievement(userId, achievementId);
-    }
-
-    return this.toAchievementProgressDto(saved);
   }
 
   /**
@@ -343,8 +365,25 @@ export class AchievementsService {
     achievementId: string,
     metadata?: any,
   ): Promise<AchievementUnlockedEventDto> {
+    // The unlock row, progress update and unlocked-count bump are one logical
+    // operation: all commit together or none do (issue #1344).
+    return this.dataSource.transaction(async (manager) =>
+      this.unlockWithManager(manager, userId, achievementId, metadata),
+    );
+  }
+
+  private async unlockWithManager(
+    manager: EntityManager,
+    userId: string,
+    achievementId: string,
+    metadata?: any,
+  ): Promise<AchievementUnlockedEventDto> {
+    const userAchievementRepository = manager.getRepository(UserAchievement);
+    const progressRepository = manager.getRepository(AchievementProgress);
+    const achievementRepository = manager.getRepository(Achievement);
+
     // Check if already unlocked
-    const existing = await this.userAchievementRepository.findOne({
+    const existing = await userAchievementRepository.findOne({
       where: {
         user: { id: userId },
         achievement: { id: achievementId },
@@ -356,7 +395,7 @@ export class AchievementsService {
       return this.toAchievementUnlockedEventDto(existing);
     }
 
-    const achievement = await this.achievementRepository.findOne({
+    const achievement = await achievementRepository.findOne({
       where: { id: achievementId },
     });
 
@@ -364,7 +403,7 @@ export class AchievementsService {
       throw new NotFoundException(`Achievement not found: ${achievementId}`);
     }
 
-    const userAchievement = this.userAchievementRepository.create({
+    const userAchievement = userAchievementRepository.create({
       user: { id: userId } as User,
       achievement,
       unlockedAt: new Date(),
@@ -374,10 +413,10 @@ export class AchievementsService {
       notificationSent: false,
     });
 
-    const saved = await this.userAchievementRepository.save(userAchievement);
+    const saved = await userAchievementRepository.save(userAchievement);
 
     // Update progress record
-    await this.progressRepository.update(
+    await progressRepository.update(
       {
         user: { id: userId },
         achievement: { id: achievementId },
@@ -386,7 +425,7 @@ export class AchievementsService {
     );
 
     // Increment unlocked count
-    await this.achievementRepository.increment({ id: achievementId }, 'unlockedBy', 1);
+    await achievementRepository.increment({ id: achievementId }, 'unlockedBy', 1);
 
     this.logger.log(
       `Achievement unlocked for user ${userId}: ${achievementId} - earned ${achievement.pointsReward} points, ${achievement.experienceReward} XP`,
@@ -603,14 +642,18 @@ export class AchievementsService {
     userId: string,
     achievementIds: string[],
   ): Promise<AchievementUnlockedEventDto[]> {
-    const results: AchievementUnlockedEventDto[] = [];
+    // The whole batch is one logical operation: a failure in any unlock rolls
+    // back every unlock in the batch (issue #1344).
+    return this.dataSource.transaction(async (manager) => {
+      const results: AchievementUnlockedEventDto[] = [];
 
-    for (const achievementId of achievementIds) {
-      const result = await this.unlockAchievement(userId, achievementId);
-      results.push(result);
-    }
+      for (const achievementId of achievementIds) {
+        const result = await this.unlockWithManager(manager, userId, achievementId);
+        results.push(result);
+      }
 
-    return results;
+      return results;
+    });
   }
 
   // =====================================================

--- a/src/cohorts/cohorts.service.spec.ts
+++ b/src/cohorts/cohorts.service.spec.ts
@@ -78,6 +78,9 @@ describe('CohortsService', () => {
       mockThreadRepo,
       mockCommentRepo,
       mockAssignmentRepo,
+      {
+        transaction: jest.fn((cb: any) => cb({ getRepository: () => mockCohortRepo })),
+      } as any,
     );
 
     mockCohortRepo.findOne.mockResolvedValue({ id: 'cohort-1', ownerId: 'user-1' });

--- a/src/cohorts/cohorts.service.ts
+++ b/src/cohorts/cohorts.service.ts
@@ -5,7 +5,7 @@ import {
   BadRequestException,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { DataSource, Repository } from 'typeorm';
 import { Cohort } from './entities/cohort.entity';
 import { CohortMember } from './entities/cohort-member.entity';
 import { CohortThread } from './entities/cohort-thread.entity';
@@ -33,24 +33,33 @@ export class CohortsService {
     private readonly commentRepo: Repository<CohortComment>,
     @InjectRepository(CohortAssignment)
     private readonly assignmentRepo: Repository<CohortAssignment>,
+    private readonly dataSource: DataSource,
   ) {}
 
   async createCohort(dto: CreateCohortDto, ownerId: string): Promise<Cohort> {
-    const cohort = this.cohortRepo.create({
-      name: dto.name,
-      description: dto.description,
-      ownerId,
-    });
+    // The cohort and its owner membership are one logical operation: if the
+    // owner-member write fails, the cohort must not survive as an orphan that
+    // rejects everyone (issue #1344).
+    return this.dataSource.transaction(async (manager) => {
+      const cohortRepo = manager.getRepository(Cohort);
+      const memberRepo = manager.getRepository(CohortMember);
 
-    const saved = await this.cohortRepo.save(cohort);
-    const ownerMembership = this.memberRepo.create({
-      cohortId: saved.id,
-      userId: ownerId,
-      role: 'owner',
-    });
+      const cohort = cohortRepo.create({
+        name: dto.name,
+        description: dto.description,
+        ownerId,
+      });
 
-    await this.memberRepo.save(ownerMembership);
-    return saved;
+      const saved = await cohortRepo.save(cohort);
+      const ownerMembership = memberRepo.create({
+        cohortId: saved.id,
+        userId: ownerId,
+        role: 'owner',
+      });
+
+      await memberRepo.save(ownerMembership);
+      return saved;
+    });
   }
 
   async getCohorts(

--- a/src/email-unsubscribe/email-unsubscribe.service.ts
+++ b/src/email-unsubscribe/email-unsubscribe.service.ts
@@ -5,7 +5,7 @@ import {
   InvalidTokenException,
 } from '../common/exceptions/app.exceptions';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { DataSource, Repository } from 'typeorm';
 import { randomBytes } from 'crypto';
 import { UnsubscribeToken } from './entities/unsubscribe-token.entity';
 import { EmailSubscription } from '../email-marketing/entities/email-subscription.entity';
@@ -21,6 +21,7 @@ export class EmailUnsubscribeService {
     private readonly tokenRepository: Repository<UnsubscribeToken>,
     @InjectRepository(EmailSubscription)
     private readonly subscriptionRepository: Repository<EmailSubscription>,
+    private readonly dataSource: DataSource,
   ) {}
 
   async generateUnsubscribeToken(
@@ -46,27 +47,35 @@ export class EmailUnsubscribeService {
     if (record.used) throw new BusinessValidationException('Token already used');
     if (record.expiresAt < new Date()) throw new InvalidTokenException('Token has expired');
 
-    await this.tokenRepository.update(record.id, { used: true });
+    // Consuming the token and updating the subscription are one logical
+    // operation: if the subscription write fails, the token must stay usable
+    // (issue #1344).
+    await this.dataSource.transaction(async (manager) => {
+      const tokenRepository = manager.getRepository(UnsubscribeToken);
+      const subscriptionRepository = manager.getRepository(EmailSubscription);
 
-    let subscription = await this.subscriptionRepository.findOne({
-      where: { email: record.email },
-    });
-    if (!subscription) {
-      subscription = this.subscriptionRepository.create({
-        email: record.email,
-        userId: record.userId,
+      await tokenRepository.update(record.id, { used: true });
+
+      let subscription = await subscriptionRepository.findOne({
+        where: { email: record.email },
       });
-    }
+      if (!subscription) {
+        subscription = subscriptionRepository.create({
+          email: record.email,
+          userId: record.userId,
+        });
+      }
 
-    subscription.isSubscribed = false;
-    subscription.unsubscribedAt = new Date();
+      subscription.isSubscribed = false;
+      subscription.unsubscribedAt = new Date();
 
-    if (record.emailType && subscription.preferences) {
-      subscription.preferences = subscription.preferences.filter((p) => p !== record.emailType);
-    }
+      if (record.emailType && subscription.preferences) {
+        subscription.preferences = subscription.preferences.filter((p) => p !== record.emailType);
+      }
 
-    await this.subscriptionRepository.save(subscription);
-    this.logger.log(`Unsubscribed: ${record.email}`);
+      await subscriptionRepository.save(subscription);
+      this.logger.log(`Unsubscribed: ${record.email}`);
+    });
   }
 
   async resubscribe(dto: ResubscribeDto): Promise<void> {

--- a/src/incident-management/incident-management.service.ts
+++ b/src/incident-management/incident-management.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, Logger } from '@nestjs/common';
-import { Repository } from 'typeorm';
+import { DataSource, Repository } from 'typeorm';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Incident, IncidentStatus, IncidentSeverity } from './entities/incident.entity';
 import { RemediationAction, RemediationStatus } from './entities/remediation-action.entity';
@@ -31,6 +31,7 @@ export class IncidentManagementService {
     private autoRemediationService: AutoRemediationService,
     private runbookExecutionService: RunbookExecutionService,
     private notificationService: NotificationAndEscalationService,
+    private readonly dataSource: DataSource,
   ) {}
 
   /**
@@ -78,32 +79,43 @@ export class IncidentManagementService {
         return;
       }
 
-      const remediationIds: string[] = [];
+      // Remediation actions + the incident update are one logical operation: if
+      // any action write fails, none of them (nor the incident update) persist
+      // (issue #1344). Notifications fire only after the commit succeeds.
+      const created: {
+        action: RemediationAction;
+        autoRollback: boolean;
+      }[] = [];
 
-      for (const suggestion of suggestedActions) {
-        const remediationAction = await this.autoRemediationService.executeRemediationAction(
-          incident,
-          suggestion.actionType,
-          suggestion.description,
-          suggestion.parameters,
-          suggestion.autoRollback,
-        );
+      await this.dataSource.transaction(async (manager) => {
+        const incidentRepo = manager.getRepository(Incident);
 
-        remediationIds.push(remediationAction.id);
+        for (const suggestion of suggestedActions) {
+          const remediationAction = await this.autoRemediationService.executeRemediationAction(
+            incident,
+            suggestion.actionType,
+            suggestion.description,
+            suggestion.parameters,
+            suggestion.autoRollback,
+            manager,
+          );
+          created.push({ action: remediationAction, autoRollback: suggestion.autoRollback });
+        }
 
-        // Notify remediation action execution
+        incident.remediationActionIds = created.map((c) => c.action.id);
+        await incidentRepo.save(incident);
+      });
+
+      // Side effects run only after the transaction has committed.
+      for (const { action: remediationAction, autoRollback } of created) {
         await this.notificationService.notifyRemediationExecuted(incident, remediationAction);
 
         // Auto-rollback on failure if configured
-        if (suggestion.autoRollback && remediationAction.status === RemediationStatus.FAILED) {
+        if (autoRollback && remediationAction.status === RemediationStatus.FAILED) {
           this.logger.log(`Auto-rolling back failed remediation action: ${remediationAction.id}`);
           await this.autoRemediationService.rollbackRemediationAction(remediationAction);
         }
       }
-
-      // Update incident with remediation action IDs
-      incident.remediationActionIds = remediationIds;
-      await this.incidentRepository.save(incident);
     } catch (error) {
       const errorMsg = error instanceof Error ? error.message : String(error);
       this.logger.error(`Error executing auto remediation: ${errorMsg}`);

--- a/src/incident-management/services/auto-remediation.service.ts
+++ b/src/incident-management/services/auto-remediation.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, Logger } from '@nestjs/common';
-import { Repository } from 'typeorm';
+import { EntityManager, Repository } from 'typeorm';
 import { InjectRepository } from '@nestjs/typeorm';
 import { RemediationAction, RemediationStatus } from '../entities/remediation-action.entity';
 import { Incident } from '../entities/incident.entity';
@@ -184,11 +184,19 @@ export class AutoRemediationService {
     description: string,
     parameters: Record<string, unknown>,
     autoRollback = false,
+    manager?: EntityManager,
   ): Promise<RemediationAction> {
     this.logger.log(`Executing remediation action: ${actionType} for incident ${incident.id}`);
 
+    // When called inside a caller-owned transaction, all writes go through the
+    // transactional manager so the action commits/rolls back with the incident
+    // (issue #1344).
+    const remediationRepository = manager
+      ? manager.getRepository(RemediationAction)
+      : this.remediationRepository;
+
     // Create remediation action record
-    let remediationAction = this.remediationRepository.create({
+    let remediationAction = remediationRepository.create({
       incidentId: incident.id,
       actionType,
       description,
@@ -197,7 +205,7 @@ export class AutoRemediationService {
       autoRollback,
     });
 
-    remediationAction = await this.remediationRepository.save(remediationAction);
+    remediationAction = await remediationRepository.save(remediationAction);
 
     try {
       // Find handler for this action type
@@ -230,7 +238,7 @@ export class AutoRemediationService {
       this.logger.error(`Error executing remediation action: ${errorMsg}`);
     }
 
-    return this.remediationRepository.save(remediationAction);
+    return remediationRepository.save(remediationAction);
   }
 
   /**

--- a/src/notifications/notifications.service.spec.ts
+++ b/src/notifications/notifications.service.spec.ts
@@ -12,7 +12,14 @@ describe('NotificationsService', () => {
       save: jest.fn(async (data) => ({ id: 'notif-1', ...data })),
     };
 
-    service = new NotificationsService(mockRepository);
+    service = new NotificationsService(
+      mockRepository,
+      {} as any,
+      {} as any,
+      {
+        transaction: jest.fn((cb: any) => cb({ getRepository: () => mockRepository })),
+      } as any,
+    );
   });
 
   it('should deliver EMAIL and PUSH with same content (different types)', async () => {

--- a/src/notifications/notifications.service.ts
+++ b/src/notifications/notifications.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, Optional, NotFoundException, BadRequestException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository, MoreThan, In } from 'typeorm';
+import { DataSource, Repository, MoreThan, In } from 'typeorm';
 import * as crypto from 'crypto';
 import { Notification, NotificationType, NotificationStatus } from './entities/notification.entity';
 import { PaginationService } from '../common/services/pagination.service';
@@ -17,6 +17,7 @@ export class NotificationsService {
     private notificationRepository: Repository<Notification>,
     private readonly preferencesService: PreferencesService,
     private readonly templateService: NotificationTemplateService,
+    private readonly dataSource: DataSource,
     @Optional()
     private paginationService: PaginationService = new PaginationService(),
   ) {}
@@ -83,41 +84,60 @@ export class NotificationsService {
   }
 
   async send(dto: CreateNotificationDto) {
-    const notification = await this.create(dto);
+    // The base notification plus every channel dispatch is one logical
+    // operation: if any channel write fails, none of them persist (issue
+    // #1344).
+    return this.dataSource.transaction(async (manager) => {
+      const notificationRepository = manager.getRepository(Notification);
 
-    const prefs = await this.preferencesService.getPreferences(dto.userId);
-
-    if (prefs.globalUnsubscribe) {
-      return notification;
-    }
-
-    const channels: { enabled: boolean; type: NotificationType }[] = [
-      { enabled: prefs.inAppEnabled, type: NotificationType.IN_APP },
-      { enabled: prefs.emailEnabled, type: NotificationType.EMAIL },
-      { enabled: prefs.pushEnabled, type: NotificationType.PUSH },
-      { enabled: prefs.smsEnabled, type: NotificationType.SMS },
-    ];
-
-    const dispatches: Promise<Notification>[] = [];
-
-    for (const channel of channels) {
-      if (channel.enabled) {
-        const channelNotification = this.notificationRepository.create({
+      const notification = await notificationRepository.save(
+        notificationRepository.create({
           userId: dto.userId,
           title: dto.title,
           content: dto.content,
-          type: channel.type,
+          contentHash: this.hashContent(dto.content),
+          type: dto.type ?? NotificationType.IN_APP,
           priority: dto.priority,
           metadata: dto.metadata,
-          status: NotificationStatus.SENT,
-        });
-        dispatches.push(this.notificationRepository.save(channelNotification));
+          status: NotificationStatus.PENDING,
+        }),
+      );
+
+      const prefs = await this.preferencesService.getPreferences(dto.userId);
+
+      if (prefs.globalUnsubscribe) {
+        return notification;
       }
-    }
 
-    await Promise.all(dispatches);
+      const channels: { enabled: boolean; type: NotificationType }[] = [
+        { enabled: prefs.inAppEnabled, type: NotificationType.IN_APP },
+        { enabled: prefs.emailEnabled, type: NotificationType.EMAIL },
+        { enabled: prefs.pushEnabled, type: NotificationType.PUSH },
+        { enabled: prefs.smsEnabled, type: NotificationType.SMS },
+      ];
 
-    return notification;
+      const dispatches: Promise<Notification>[] = [];
+
+      for (const channel of channels) {
+        if (channel.enabled) {
+          const channelNotification = notificationRepository.create({
+            userId: dto.userId,
+            title: dto.title,
+            content: dto.content,
+            contentHash: this.hashContent(dto.content),
+            type: channel.type,
+            priority: dto.priority,
+            metadata: dto.metadata,
+            status: NotificationStatus.SENT,
+          });
+          dispatches.push(notificationRepository.save(channelNotification));
+        }
+      }
+
+      await Promise.all(dispatches);
+
+      return notification;
+    });
   }
 
   async sendTemplated(dto: SendTemplatedNotificationDto) {
@@ -144,27 +164,32 @@ export class NotificationsService {
       { enabled: prefs.smsEnabled, type: NotificationType.SMS },
     ];
 
-    const saved: Notification[] = [];
+    // All channel dispatches are one logical operation (issue #1344).
+    return this.dataSource.transaction(async (manager) => {
+      const notificationRepository = manager.getRepository(Notification);
+      const saved: Notification[] = [];
 
-    for (const channel of channels) {
-      if (channel.enabled) {
-        const notification = this.notificationRepository.create({
-          userId: dto.userId,
-          title: rendered.subject ?? dto.templateName,
-          content: rendered.body,
-          type: channel.type,
-          status: NotificationStatus.SENT,
-          metadata: {
-            templateName: dto.templateName,
-            templateVersion: rendered.templateVersion,
-            eventType: dto.eventType,
-          },
-        });
-        saved.push(await this.notificationRepository.save(notification));
+      for (const channel of channels) {
+        if (channel.enabled) {
+          const notification = notificationRepository.create({
+            userId: dto.userId,
+            title: rendered.subject ?? dto.templateName,
+            content: rendered.body,
+            contentHash: this.hashContent(rendered.body),
+            type: channel.type,
+            status: NotificationStatus.SENT,
+            metadata: {
+              templateName: dto.templateName,
+              templateVersion: rendered.templateVersion,
+              eventType: dto.eventType,
+            },
+          });
+          saved.push(await notificationRepository.save(notification));
+        }
       }
-    }
 
-    return saved;
+      return saved;
+    });
   }
 
   async findForUser(userId: string, query?: PaginationQueryDto) {

--- a/src/tenancy/admin/tenant-admin.service.ts
+++ b/src/tenancy/admin/tenant-admin.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { ResourceNotFoundException } from '../../common/exceptions/app.exceptions';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { DataSource, Repository } from 'typeorm';
 import { sanitizeSqlLike } from '../../common/utils/sanitization.utils';
 import { Tenant, TenantStatus, TenantPlan } from '../entities/tenant.entity';
 import { TenantConfig } from '../entities/tenant-config.entity';
@@ -37,6 +37,7 @@ export class TenantAdminService {
     private readonly billingRepository: Repository<TenantBilling>,
     @InjectRepository(TenantCustomization)
     private readonly customizationRepository: Repository<TenantCustomization>,
+    private readonly dataSource: DataSource,
   ) {}
 
   async getTenantStatistics(tenantId: string): Promise<ITenantStatistics> {
@@ -168,15 +169,23 @@ export class TenantAdminService {
       throw new ResourceNotFoundException('Tenant', tenantId);
     }
 
-    tenant.currentUserCount = 0;
-    tenant.currentStorageUsage = 0;
-    await this.tenantRepository.save(tenant);
+    // Resetting the tenant counters and clearing billing usage are one logical
+    // operation: if the billing write fails, the tenant counters must not be
+    // reset (issue #1344).
+    await this.dataSource.transaction(async (manager) => {
+      const tenantRepository = manager.getRepository(Tenant);
+      const billingRepository = manager.getRepository(TenantBilling);
 
-    const billing = await this.billingRepository.findOne({ where: { tenantId } });
-    if (billing) {
-      billing.usageMetrics = {};
-      await this.billingRepository.save(billing);
-    }
+      tenant.currentUserCount = 0;
+      tenant.currentStorageUsage = 0;
+      await tenantRepository.save(tenant);
+
+      const billing = await billingRepository.findOne({ where: { tenantId } });
+      if (billing) {
+        billing.usageMetrics = {};
+        await billingRepository.save(billing);
+      }
+    });
   }
 
   async exportTenantData(tenantId: string): Promise<any> {

--- a/src/tenancy/billing/tenant-billing.service.ts
+++ b/src/tenancy/billing/tenant-billing.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { ResourceNotFoundException } from '../../common/exceptions/app.exceptions';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { DataSource, Repository } from 'typeorm';
 import { TenantBilling, BillingCycle } from '../entities/tenant-billing.entity';
 import { Tenant } from '../entities/tenant.entity';
 import { TENANT_BILLING_RATES } from '../tenancy.constants';
@@ -31,6 +31,7 @@ export class TenantBillingService {
     private readonly billingRepository: Repository<TenantBilling>,
     @InjectRepository(Tenant)
     private readonly tenantRepository: Repository<Tenant>,
+    private readonly dataSource: DataSource,
   ) {}
   /**
    * Get billing information for a tenant
@@ -84,46 +85,62 @@ export class TenantBillingService {
     amount: number,
     invoiceId?: string,
   ): Promise<TenantBilling> {
-    const billing = await this.getBillingInfo(tenantId);
+    // The history append and balance/total updates are one logical mutation:
+    // they commit together or not at all (issue #1344).
+    return this.dataSource.transaction(async (manager) => {
+      const billingRepository = manager.getRepository(TenantBilling);
+      const billing = await billingRepository.findOne({ where: { tenantId } });
+      if (!billing) {
+        throw new ResourceNotFoundException(`TenantBilling for tenant '${tenantId}'`);
+      }
 
-    const billingRecord: IBillingRecord = {
-      date: new Date(),
-      amount,
-      status: 'paid',
-      invoiceId,
-    };
+      const billingRecord: IBillingRecord = {
+        date: new Date(),
+        amount,
+        status: 'paid',
+        invoiceId,
+      };
 
-    billing.billingHistory = billing.billingHistory || [];
-    billing.billingHistory.push(billingRecord);
-    billing.totalPaid = Number(billing.totalPaid) + amount;
-    billing.currentBalance = Number(billing.currentBalance) - amount;
-    billing.lastBillingDate = new Date();
+      billing.billingHistory = billing.billingHistory || [];
+      billing.billingHistory.push(billingRecord);
+      billing.totalPaid = Number(billing.totalPaid) + amount;
+      billing.currentBalance = Number(billing.currentBalance) - amount;
+      billing.lastBillingDate = new Date();
 
-    return await this.billingRepository.save(billing);
+      return await billingRepository.save(billing);
+    });
   }
 
   /**
    * Generate invoice
    */
   async generateInvoice(tenantId: string): Promise<IBillingRecord> {
-    const billing = await this.getBillingInfo(tenantId);
-    const amount = Number(billing.monthlyFee);
+    // Balance + history + next billing date are one logical mutation: they
+    // commit together or not at all (issue #1344).
+    return this.dataSource.transaction(async (manager) => {
+      const billingRepository = manager.getRepository(TenantBilling);
+      const billing = await billingRepository.findOne({ where: { tenantId } });
+      if (!billing) {
+        throw new ResourceNotFoundException(`TenantBilling for tenant '${tenantId}'`);
+      }
+      const amount = Number(billing.monthlyFee);
 
-    const invoice: IBillingRecord = {
-      date: new Date(),
-      amount,
-      status: 'pending',
-      invoiceId: `INV-${tenantId}-${Date.now()}`,
-    };
+      const invoice: IBillingRecord = {
+        date: new Date(),
+        amount,
+        status: 'pending',
+        invoiceId: `INV-${tenantId}-${Date.now()}`,
+      };
 
-    billing.currentBalance = Number(billing.currentBalance) + amount;
-    billing.billingHistory = billing.billingHistory || [];
-    billing.billingHistory.push(invoice);
-    billing.nextBillingDate = this.calculateNextBillingDate(billing.billingCycle);
+      billing.currentBalance = Number(billing.currentBalance) + amount;
+      billing.billingHistory = billing.billingHistory || [];
+      billing.billingHistory.push(invoice);
+      billing.nextBillingDate = this.calculateNextBillingDate(billing.billingCycle);
 
-    await this.billingRepository.save(billing);
+      await billingRepository.save(billing);
 
-    return invoice;
+      return invoice;
+    });
   }
 
   /**

--- a/test/transactional-writes.e2e-spec.ts
+++ b/test/transactional-writes.e2e-spec.ts
@@ -1,0 +1,473 @@
+import { INestApplication } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { CACHE_MANAGER } from '@nestjs/cache-manager';
+import { DataSource } from 'typeorm';
+import { getDatabaseConfig } from '../src/config/database.config';
+
+import { Cohort } from '../src/cohorts/entities/cohort.entity';
+import { CohortMember } from '../src/cohorts/entities/cohort-member.entity';
+import { CohortThread } from '../src/cohorts/entities/cohort-thread.entity';
+import { CohortComment } from '../src/cohorts/entities/cohort-comment.entity';
+import { CohortAssignment } from '../src/cohorts/entities/cohort-assignment.entity';
+
+import { UnsubscribeToken } from '../src/email-unsubscribe/entities/unsubscribe-token.entity';
+import { EmailSubscription } from '../src/email-marketing/entities/email-subscription.entity';
+
+import { Tenant } from '../src/tenancy/entities/tenant.entity';
+import { TenantConfig } from '../src/tenancy/entities/tenant-config.entity';
+import { TenantBilling } from '../src/tenancy/entities/tenant-billing.entity';
+import { TenantCustomization } from '../src/tenancy/entities/tenant-customization.entity';
+
+import { Achievement } from '../src/achievements/entities/achievement.entity';
+import { AchievementProgress } from '../src/achievements/entities/achievement-progress.entity';
+import { UserAchievement } from '../src/achievements/entities/user-achievement.entity';
+import { AchievementStatistics } from '../src/achievements/entities/achievement-statistics.entity';
+
+import { Notification } from '../src/notifications/entities/notification.entity';
+import { User } from '../src/users/entities/user.entity';
+import { Role } from '../src/rbac/entities/role.entity';
+import { Permission } from '../src/rbac/entities/permission.entity';
+import { Course } from '../src/courses/entities/course.entity';
+import { CourseModule } from '../src/courses/entities/course-module.entity';
+import { CourseReview } from '../src/courses/entities/course-review.entity';
+import { CourseVersion } from '../src/courses/entities/course-version.entity';
+import { Lesson } from '../src/courses/entities/lesson.entity';
+import { Enrollment } from '../src/courses/entities/enrollment.entity';
+
+import { CohortsService } from '../src/cohorts/cohorts.service';
+import { EmailUnsubscribeService } from '../src/email-unsubscribe/email-unsubscribe.service';
+import { TenantAdminService } from '../src/tenancy/admin/tenant-admin.service';
+import { AchievementsService } from '../src/achievements/achievements.service';
+import { NotificationsService } from '../src/notifications/notifications.service';
+import { PreferencesService } from '../src/notifications/preferences/preferences.service';
+import { NotificationTemplateService } from '../src/notifications/templates/notification-template.service';
+
+/**
+ * Transactional writes (issue #1344).
+ *
+ * Every listed multi-write operation must commit or roll back atomically. Each
+ * rollback test installs a PostgreSQL trigger that makes a LATER write in the
+ * sequence fail, then asserts the earlier write was rolled back with it.
+ */
+describe('Transactional writes (#1344)', () => {
+  let app: INestApplication;
+  let dataSource: DataSource;
+  let cohortsService: CohortsService;
+  let unsubscribeService: EmailUnsubscribeService;
+  let tenantAdminService: TenantAdminService;
+  let achievementsService: AchievementsService;
+  let notificationsService: NotificationsService;
+
+  const userId = '00000000-0000-4000-8000-000000000001';
+  const tenantId = '00000000-0000-4000-8000-000000000003';
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [
+        TypeOrmModule.forRoot({
+          ...getDatabaseConfig(),
+          entities: [
+            Cohort,
+            CohortMember,
+            CohortThread,
+            CohortComment,
+            CohortAssignment,
+            UnsubscribeToken,
+            EmailSubscription,
+            Tenant,
+            TenantConfig,
+            TenantBilling,
+            TenantCustomization,
+            Achievement,
+            AchievementProgress,
+            UserAchievement,
+            AchievementStatistics,
+            Notification,
+            User,
+            Role,
+            Permission,
+            Course,
+            CourseModule,
+            CourseReview,
+            CourseVersion,
+            Lesson,
+            Enrollment,
+          ],
+          synchronize: false,
+        }),
+        TypeOrmModule.forFeature([
+          Cohort,
+          CohortMember,
+          CohortThread,
+          CohortComment,
+          CohortAssignment,
+          UnsubscribeToken,
+          EmailSubscription,
+          Tenant,
+          TenantConfig,
+          TenantBilling,
+          TenantCustomization,
+          Achievement,
+          AchievementProgress,
+          UserAchievement,
+          AchievementStatistics,
+          Notification,
+          User,
+          Role,
+          Permission,
+          Course,
+          CourseModule,
+          CourseReview,
+          CourseVersion,
+          Lesson,
+          Enrollment,
+        ]),
+      ],
+      providers: [
+        CohortsService,
+        EmailUnsubscribeService,
+        TenantAdminService,
+        AchievementsService,
+        NotificationsService,
+        {
+          provide: CACHE_MANAGER,
+          useValue: { get: jest.fn(), set: jest.fn(), del: jest.fn() },
+        },
+        {
+          provide: PreferencesService,
+          useValue: {
+            getPreferences: jest.fn().mockResolvedValue({
+              globalUnsubscribe: false,
+              inAppEnabled: true,
+              emailEnabled: true,
+              pushEnabled: true,
+              smsEnabled: true,
+            }),
+          },
+        },
+        { provide: NotificationTemplateService, useValue: {} },
+      ],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    await app.init();
+
+    dataSource = app.get(DataSource);
+    cohortsService = app.get(CohortsService);
+    unsubscribeService = app.get(EmailUnsubscribeService);
+    tenantAdminService = app.get(TenantAdminService);
+    achievementsService = app.get(AchievementsService);
+    notificationsService = app.get(NotificationsService);
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  beforeEach(async () => {
+    await dataSource.query('DELETE FROM cohort_members');
+    await dataSource.query('DELETE FROM cohorts');
+    await dataSource.query('DELETE FROM email_subscriptions');
+    await dataSource.query('DELETE FROM unsubscribe_tokens');
+    await dataSource.query('DELETE FROM user_achievements');
+    await dataSource.query('DELETE FROM achievement_progress');
+    await dataSource.query('DELETE FROM achievements');
+    await dataSource.query('DELETE FROM notifications');
+    await dataSource.query('DELETE FROM tenant_billing');
+    await dataSource.query('DELETE FROM tenants');
+    await dataSource.query('DELETE FROM users');
+  });
+
+  /** Installs a trigger that fails the write to `table`, then always removes it. */
+  async function withFailTrigger(
+    table: string,
+    event: 'INSERT' | 'UPDATE',
+    body: () => Promise<void>,
+    condition?: string,
+  ) {
+    const name = `test_force_fail_${table.replace(/[^a-z0-9_]/gi, '')}`;
+    const trigger = `trg_${name}`;
+
+    await dataSource.query(`
+      CREATE OR REPLACE FUNCTION ${name}() RETURNS trigger AS $$
+      BEGIN
+        ${condition ?? `RAISE EXCEPTION 'forced write failure for test (${table})';`}
+        RETURN NEW;
+      END;
+      $$ LANGUAGE plpgsql
+    `);
+    await dataSource.query(
+      `CREATE TRIGGER ${trigger} BEFORE ${event} ON ${table} FOR EACH ROW EXECUTE FUNCTION ${name}();`,
+    );
+    try {
+      await body();
+    } finally {
+      await dataSource.query(`DROP TRIGGER IF EXISTS ${trigger} ON ${table}`);
+      await dataSource.query(`DROP FUNCTION IF EXISTS ${name}();`);
+    }
+  }
+
+  describe('cohorts.createCohort', () => {
+    it('rolls back the cohort when the owner membership write fails', async () => {
+      await withFailTrigger('cohort_members', 'INSERT', async () => {
+        await expect(
+          cohortsService.createCohort({ name: 'Ops', description: 'd' }, userId),
+        ).rejects.toThrow('forced write failure');
+      });
+
+      const rows = await dataSource.query(
+        'SELECT COUNT(*)::int AS count FROM cohorts WHERE "ownerId" = $1',
+        [userId],
+      );
+      expect(rows[0].count).toBe(0);
+    });
+
+    it('commits the cohort together with its owner membership', async () => {
+      const cohort = await cohortsService.createCohort({ name: 'Ops', description: 'd' }, userId);
+
+      const cohortRows = await dataSource.query(
+        'SELECT COUNT(*)::int AS count FROM cohorts WHERE id = $1',
+        [cohort.id],
+      );
+      const memberRows = await dataSource.query(
+        'SELECT COUNT(*)::int AS count FROM cohort_members WHERE "cohortId" = $1 AND "userId" = $2 AND role = $3',
+        [cohort.id, userId, 'owner'],
+      );
+      expect(cohortRows[0].count).toBe(1);
+      expect(memberRows[0].count).toBe(1);
+    });
+  });
+
+  describe('email-unsubscribe.unsubscribe', () => {
+    const token = 'test-unsubscribe-token';
+
+    const seedToken = async () => {
+      await dataSource.query(
+        `INSERT INTO unsubscribe_tokens (id, token, email, used, "expiresAt")
+         VALUES (gen_random_uuid(), $1, $2, false, now() + interval '1 day')`,
+        [token, 'user@example.com'],
+      );
+    };
+
+    it('rolls back token consumption when the subscription write fails', async () => {
+      await seedToken();
+
+      await withFailTrigger('email_subscriptions', 'INSERT', async () => {
+        await expect(unsubscribeService.unsubscribe({ token })).rejects.toThrow(
+          'forced write failure',
+        );
+      });
+
+      const rows = await dataSource.query(
+        'SELECT used::boolean AS used FROM unsubscribe_tokens WHERE token = $1',
+        [token],
+      );
+      expect(rows[0].used).toBe(false);
+    });
+
+    it('consumes the token and unsubscribes the address together', async () => {
+      await seedToken();
+
+      await unsubscribeService.unsubscribe({ token });
+
+      const tokenRows = await dataSource.query(
+        'SELECT used::boolean AS used FROM unsubscribe_tokens WHERE token = $1',
+        [token],
+      );
+      const subRows = await dataSource.query(
+        `SELECT "isSubscribed"::boolean AS subscribed FROM email_subscriptions
+         WHERE email = $1`,
+        ['user@example.com'],
+      );
+      expect(tokenRows[0].used).toBe(true);
+      expect(subRows).toHaveLength(1);
+      expect(subRows[0].subscribed).toBe(false);
+    });
+  });
+
+  describe('achievements.unlockAchievement', () => {
+    const achievementId = '00000000-0000-4000-8000-000000000002';
+
+    const seedUser = async () => {
+      await dataSource.query(
+        `INSERT INTO users (id, version, email, "firstName", "lastName")
+         VALUES ($1, 1, 'tx-achievements@example.com', 'Tx', 'Test')`,
+        [userId],
+      );
+    };
+
+    const seedAchievement = async () => {
+      await dataSource.query(
+        `INSERT INTO achievements (id, version, name, description, "iconUrl", type, difficulty, "pointsReward", "experienceReward", "isActive", "unlockedBy")
+         VALUES ($1, 1, 'First Step', 'desc', 'icon.png', 'milestone', 'easy', 100, 50, true, 0)`,
+        [achievementId],
+      );
+    };
+
+    const seedProgress = async () => {
+      await dataSource.query(
+        `INSERT INTO achievement_progress (id, version, "userId", "achievementId", "currentProgress", "targetProgress", "percentageComplete", "isUnlocked")
+         VALUES (gen_random_uuid(), 1, $1, $2, 1, 1, 100, false)`,
+        [userId, achievementId],
+      );
+    };
+
+    it('rolls back the unlock row when the progress update fails', async () => {
+      await seedUser();
+      await seedAchievement();
+      await seedProgress();
+
+      await withFailTrigger('achievement_progress', 'UPDATE', async () => {
+        await expect(achievementsService.unlockAchievement(userId, achievementId)).rejects.toThrow(
+          'forced write failure',
+        );
+      });
+
+      const unlocks = await dataSource.query(
+        'SELECT COUNT(*)::int AS count FROM user_achievements WHERE "userId" = $1',
+        [userId],
+      );
+      const achievement = await dataSource.query(
+        'SELECT "unlockedBy"::int AS n FROM achievements WHERE id = $1',
+        [achievementId],
+      );
+      const progress = await dataSource.query(
+        'SELECT "isUnlocked"::boolean AS unlocked FROM achievement_progress WHERE "userId" = $1 AND "achievementId" = $2',
+        [userId, achievementId],
+      );
+      expect(unlocks[0].count).toBe(0);
+      expect(achievement[0].n).toBe(0);
+      expect(progress[0].unlocked).toBe(false);
+    });
+
+    it('commits the unlock, progress flag and counter together', async () => {
+      await seedUser();
+      await seedAchievement();
+      await seedProgress();
+
+      await achievementsService.unlockAchievement(userId, achievementId);
+
+      const unlocks = await dataSource.query(
+        'SELECT COUNT(*)::int AS count FROM user_achievements WHERE "userId" = $1',
+        [userId],
+      );
+      const achievement = await dataSource.query(
+        'SELECT "unlockedBy"::int AS n FROM achievements WHERE id = $1',
+        [achievementId],
+      );
+      const progress = await dataSource.query(
+        'SELECT "isUnlocked"::boolean AS unlocked FROM achievement_progress WHERE "userId" = $1 AND "achievementId" = $2',
+        [userId, achievementId],
+      );
+      expect(unlocks[0].count).toBe(1);
+      expect(achievement[0].n).toBe(1);
+      expect(progress[0].unlocked).toBe(true);
+    });
+  });
+
+  describe('notifications.send', () => {
+    const seedUser = async () => {
+      await dataSource.query(
+        `INSERT INTO users (id, version, email, "firstName", "lastName")
+         VALUES ($1, 1, 'tx-test@example.com', 'Tx', 'Test')`,
+        [userId],
+      );
+    };
+
+    it('rolls back every dispatch when a later channel write fails', async () => {
+      await seedUser();
+
+      await withFailTrigger(
+        'notifications',
+        'INSERT',
+        async () => {
+          await expect(
+            notificationsService.send({
+              userId,
+              title: 'Hello',
+              content: 'World',
+            }),
+          ).rejects.toThrow('forced write failure');
+        },
+        `IF (SELECT count(*) FROM notifications WHERE "userId" = NEW."userId") >= 1 THEN
+            RAISE EXCEPTION 'forced write failure for test (notifications)';
+         END IF;`,
+      );
+
+      const rows = await dataSource.query(
+        'SELECT COUNT(*)::int AS count FROM notifications WHERE "userId" = $1',
+        [userId],
+      );
+      expect(rows[0].count).toBe(0);
+    });
+
+    it('persists the base notification and every enabled channel', async () => {
+      await seedUser();
+
+      await notificationsService.send({ userId, title: 'Hello', content: 'World' });
+
+      const rows = await dataSource.query(
+        'SELECT COUNT(*)::int AS count FROM notifications WHERE "userId" = $1',
+        [userId],
+      );
+      // base (in-app default) + in_app + email + push + sms
+      expect(rows[0].count).toBe(5);
+    });
+  });
+
+  describe('tenant-admin.resetTenantData', () => {
+    const seedTenant = async () => {
+      await dataSource.query(
+        `INSERT INTO tenants (id, version, slug, name, status, plan, "userLimit", "currentUserCount", "storageLimit", "currentStorageUsage")
+         VALUES ($1, 1, 'tx-tenant', 'Tx Tenant', 'active', 'free', 100, 5, 1000, 42)`,
+        [tenantId],
+      );
+      await dataSource.query(
+        `INSERT INTO tenant_billing (id, version, "tenantId", "billingCycle", "monthlyFee", "currentBalance", "totalPaid", "usageMetrics")
+         VALUES (gen_random_uuid(), 1, $1, 'monthly', 0, 12.5, 50, '{"activeUsers":5,"storageUsed":42}')`,
+        [tenantId],
+      );
+    };
+
+    it('rolls back the tenant counters when the billing write fails', async () => {
+      await seedTenant();
+
+      await withFailTrigger('tenant_billing', 'UPDATE', async () => {
+        await expect(tenantAdminService.resetTenantData(tenantId)).rejects.toThrow(
+          'forced write failure',
+        );
+      });
+
+      const tenant = await dataSource.query(
+        'SELECT "currentUserCount"::int AS users, "currentStorageUsage"::int AS storage FROM tenants WHERE id = $1',
+        [tenantId],
+      );
+      const billing = await dataSource.query(
+        'SELECT "usageMetrics"::text AS metrics FROM tenant_billing WHERE "tenantId" = $1',
+        [tenantId],
+      );
+      expect(tenant[0].users).toBe(5);
+      expect(tenant[0].storage).toBe(42);
+      expect(JSON.parse(billing[0].metrics).activeUsers).toBe(5);
+    });
+
+    it('resets the tenant counters and billing usage together', async () => {
+      await seedTenant();
+
+      await tenantAdminService.resetTenantData(tenantId);
+
+      const tenant = await dataSource.query(
+        'SELECT "currentUserCount"::int AS users, "currentStorageUsage"::int AS storage FROM tenants WHERE id = $1',
+        [tenantId],
+      );
+      const billing = await dataSource.query(
+        'SELECT "usageMetrics"::text AS metrics FROM tenant_billing WHERE "tenantId" = $1',
+        [tenantId],
+      );
+      expect(tenant[0].users).toBe(0);
+      expect(tenant[0].storage).toBe(0);
+      expect(JSON.parse(billing[0].metrics)).toEqual({});
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Wraps every listed multi-step write operation in `dataSource.transaction` so the writes commit or roll back together — no partially-applied state (issue #1344).

- **cohorts**: `createCohort` — cohort + owner membership (the issue's headline example)
- **achievements**: `unlockAchievement` (unlock row + progress flag + `unlockedBy` counter), `updateProgress` (progress save + unlock), `batchUnlockAchievements`
- **incident management**: auto-remediation actions + incident update commit together; notifications moved to after commit
- **tenant billing**: `recordPayment` / `generateInvoice` history + balance mutations
- **email unsubscribe**: token consumption + subscription state
- **ab-testing**: multi-variant traffic allocation updates
- **notifications**: `send` / `sendTemplated` base row + all channel dispatches (also sets the `content_hash` column the table requires)
- **tenant admin**: `resetTenantData` tenant counters + billing usage reset

Each uses the established transactional pattern from `courses`/`enrollments` (`manager.getRepository(...)` inside `dataSource.transaction`).

## Tests

New `test/transactional-writes.e2e-spec.ts` (10 tests) installs PostgreSQL triggers that force a later write in each sequence to fail and asserts the earlier writes roll back — plus happy paths asserting atomic commit.

All repo CI checks pass locally: lint, typecheck, build, migrations check/run/drift-check, and the e2e suites.

Closes #1344