### PR TITLE
test(user-preferences): guard currency column against entity drift

### DIFF
--- a/src/user-preferences/entities/user-preference.entity.spec.ts
+++ b/src/user-preferences/entities/user-preference.entity.spec.ts
@@ -1,0 +1,29 @@
+import { getMetadataArgsStorage } from 'typeorm';
+import { UserPreference } from './user-preference.entity';
+
+describe('UserPreference entity - schema drift (#1206)', () => {
+  const columns = getMetadataArgsStorage().filterColumns(UserPreference);
+  const columnByProperty = (property: string) =>
+    columns.find((column) => column.propertyName === property);
+
+  it('declares a currency column matching the AddTimezoneLocalePreferences migration', () => {
+    const currencyColumn = columnByProperty('currency');
+
+    expect(currencyColumn).toBeDefined();
+    expect(currencyColumn?.options.type).toBe('varchar');
+    expect(currencyColumn?.options.default).toBe('USD');
+    expect(currencyColumn?.options.nullable).toBe(true);
+  });
+
+  it('still declares the locale and timezone columns added by the same migration', () => {
+    expect(columnByProperty('locale')).toBeDefined();
+    expect(columnByProperty('timezone')).toBeDefined();
+  });
+
+  it('reads a currency value assigned on the entity instance', () => {
+    const preference = new UserPreference();
+    preference.currency = 'NGN';
+
+    expect(preference.currency).toBe('NGN');
+  });
+});

--- a/src/user-preferences/user-preferences.service.spec.ts
+++ b/src/user-preferences/user-preferences.service.spec.ts
@@ -1,0 +1,62 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { UserPreference } from './entities/user-preference.entity';
+import { UserPreferencesService } from './user-preferences.service';
+
+describe('UserPreferencesService - currency (#1206)', () => {
+  let service: UserPreferencesService;
+  const repository = {
+    findOne: jest.fn(),
+    create: jest.fn((dto) => dto),
+    save: jest.fn((prefs) => Promise.resolve(prefs)),
+    remove: jest.fn((prefs) => Promise.resolve(prefs)),
+  };
+
+  beforeEach(async () => {
+    repository.findOne.mockReset();
+    repository.create.mockReset();
+    repository.save.mockReset();
+    repository.remove.mockReset();
+    repository.create.mockImplementation((dto: any) => dto);
+    repository.save.mockImplementation((prefs: any) => Promise.resolve(prefs));
+    repository.remove.mockImplementation((prefs: any) => Promise.resolve(prefs));
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        UserPreferencesService,
+        {
+          provide: getRepositoryToken(UserPreference),
+          useValue: repository,
+        },
+      ],
+    }).compile();
+
+    service = module.get(UserPreferencesService);
+  });
+
+  it('returns the currency column when reading an existing preference row', async () => {
+    repository.findOne.mockResolvedValueOnce({ userId: 'user-1', currency: 'NGN' });
+
+    const prefs = await service.getPreferences('user-1');
+
+    expect(prefs.currency).toBe('NGN');
+  });
+
+  it('persists an updated currency value', async () => {
+    repository.findOne.mockResolvedValueOnce({ userId: 'user-1', currency: 'USD' });
+
+    const updated = await service.updatePreferences('user-1', { currency: 'EUR' } as any);
+
+    expect(repository.save).toHaveBeenCalledWith(expect.objectContaining({ currency: 'EUR' }));
+    expect(updated.currency).toBe('EUR');
+  });
+
+  it('recreates default preferences with currency undefined so the entity default of USD applies', async () => {
+    repository.findOne.mockResolvedValueOnce({ userId: 'user-1', currency: 'GBP' });
+
+    await service.resetPreferences('user-1');
+
+    expect(repository.remove).toHaveBeenCalled();
+    expect(repository.create).toHaveBeenCalledWith({ userId: 'user-1' });
+  });
+});


### PR DESCRIPTION
Closes #1206

## Summary

`UserPreference` already declares the `currency` column that migration `1710000000000-AddTimezoneLocalePreferences.ts` adds to `user_preferences` (`type: 'varchar', default: 'USD', nullable: true`), matching the migration's `currency varchar DEFAULT 'USD'`. That alignment landed in `79145811` ("fix(migrations): reconcile entity/migration drift and enforce strict schema check"), so the column is already readable through the entity and the drift check no longer wants to drop it.

What was missing was regression coverage: nothing in the test suite would catch `currency` being silently dropped from the entity again in a future change. This PR closes that gap.

## Changes

### New files
- `src/user-preferences/entities/user-preference.entity.spec.ts` — verifies, via TypeORM's `getMetadataArgsStorage()`, that `UserPreference` declares a `currency` column with `type: 'varchar'`, `default: 'USD'`, `nullable: true` (matching the migration), plus sanity checks for the sibling `locale`/`timezone` columns and that the property itself reads/writes correctly on an instance.
- `src/user-preferences/user-preferences.service.spec.ts` — unit tests (mocked repository, following the existing `preferences.service.spec.ts` pattern) proving `currency` round-trips through `UserPreferencesService#getPreferences`, `#updatePreferences`, and `#resetPreferences`.

### Modified files
None — the entity already declares `currency`; no production code changed.

## Implementation details

- The entity metadata assertion reads TypeORM's internal `MetadataArgsStorage` directly rather than spinning up a real database connection, so the test is fast and has no infra dependency, while still failing loudly if the `@Column` decorator for `currency` is ever removed or its options (`type`/`default`/`nullable`) drift from what the migration produces.
- The service tests mirror the mocking style already used in `src/notifications/preferences/preferences.service.spec.ts` (a plain jest-mocked `Repository`, injected via `getRepositoryToken`) to stay consistent with existing conventions in the codebase.

## Tests added

- `UserPreference entity - schema drift (#1206)`
  - declares a currency column matching the `AddTimezoneLocalePreferences` migration
  - still declares the locale and timezone columns added by the same migration
  - reads a currency value assigned on the entity instance
- `UserPreferencesService - currency (#1206)`
  - returns the currency column when reading an existing preference row
  - persists an updated currency value
  - recreates default preferences with currency undefined so the entity default of USD applies

## How to test

```bash
pnpm install
npx jest src/user-preferences
```

All 6 new tests pass; no other test files were touched.