### PR TITLE
test: add coverage for currency and retention services

### DIFF
--- a/src/currency/services/currency-detection.service.spec.ts
+++ b/src/currency/services/currency-detection.service.spec.ts
@@ -1,0 +1,27 @@
+import { ConfigService } from '@nestjs/config';
+import { CurrencyDetectionService } from './currency-detection.service';
+
+describe('CurrencyDetectionService', () => {
+  const service = new CurrencyDetectionService({} as ConfigService);
+
+  it('detects currency from country code and country name', () => {
+    expect(service.detectCurrency({ countryCode: 'CA' })).toBe('CAD');
+    expect(service.detectCurrency({ country: 'United Kingdom' })).toBe('GBP');
+  });
+
+  it('falls back to timezone and USD', () => {
+    expect(service.detectCurrency({ timezone: 'Asia/Tokyo' })).toBe('JPY');
+    expect(service.detectCurrency({})).toBe('USD');
+  });
+
+  it('returns USD for IP-based detection in the current implementation', async () => {
+    await expect(service.detectCurrencyFromIP('203.0.113.10')).resolves.toBe('USD');
+  });
+
+  it('exposes a copy of supported countries', () => {
+    const countries = service.getSupportedCountries();
+    expect(countries).toHaveProperty('US', 'USD');
+    countries.US = 'XXX';
+    expect(service.getSupportedCountries().US).toBe('USD');
+  });
+});

--- a/src/currency/services/currency.service.spec.ts
+++ b/src/currency/services/currency.service.spec.ts
@@ -1,0 +1,69 @@
+import { ConfigService } from '@nestjs/config';
+import { CurrencyService } from './currency.service';
+import { ExchangeRateService } from './exchange-rate.service';
+
+describe('CurrencyService', () => {
+  const exchangeRateService = {
+    getExchangeRate: jest.fn().mockResolvedValue(0.9),
+  } as unknown as ExchangeRateService;
+
+  const configService = { get: jest.fn() } as unknown as ConfigService;
+  let service: CurrencyService;
+
+  beforeEach(() => {
+    service = new CurrencyService(exchangeRateService, configService);
+    jest.restoreAllMocks();
+  });
+
+  it('returns the same amount when currencies match', async () => {
+    await expect(service.convertCurrency(10, 'USD', 'USD')).resolves.toBe(10);
+    expect(exchangeRateService.getExchangeRate).not.toHaveBeenCalled();
+  });
+
+  it('converts to another currency using the exchange rate service', async () => {
+    await expect(service.convertCurrency(10, 'USD', 'EUR')).resolves.toBe(9);
+    expect(exchangeRateService.getExchangeRate).toHaveBeenCalledWith('USD', 'EUR');
+  });
+
+  it('converts to multiple currencies', async () => {
+    const spy = jest.spyOn(service, 'convertCurrency').mockImplementation(async (_a, _f, to) => {
+      return to === 'EUR' ? 9 : 8;
+    });
+
+    await expect(service.convertToMultipleCurrencies(10, 'USD', ['EUR', 'GBP'])).resolves.toEqual({
+      EUR: 9,
+      GBP: 8,
+    });
+    expect(spy).toHaveBeenCalledTimes(2);
+  });
+
+  it('formats prices and falls back when Intl formatting fails', () => {
+    expect(service.formatPrice(10, 'USD')).toContain('$');
+
+    const original = Intl.NumberFormat;
+    (Intl as any).NumberFormat = jest.fn(() => {
+      throw new Error('boom');
+    });
+
+    expect(service.formatPrice(10, 'USD')).toBe('USD 10.00');
+    (Intl as any).NumberFormat = original;
+  });
+
+  it('returns currency details', () => {
+    expect(service.getCurrencyDetails('eur')).toEqual({
+      code: 'EUR',
+      symbol: '€',
+      name: 'Euro',
+    });
+  });
+
+  it('rounds zero-decimal currencies correctly', () => {
+    expect(service.roundAmount(10.55, 'JPY')).toBe(11);
+  });
+
+  it('validates currency codes and returns the default currency', () => {
+    expect(service.isValidCurrencyCode('USD')).toBe(true);
+    expect(service.isValidCurrencyCode('US')).toBe(false);
+    expect(service.getDefaultCurrency()).toBe('USD');
+  });
+});

--- a/src/data-retention/data-retention.service.spec.ts
+++ b/src/data-retention/data-retention.service.spec.ts
@@ -1,0 +1,95 @@
+import { ConfigService } from '@nestjs/config';
+import { DataSource } from 'typeorm';
+import { DataRetentionService } from './data-retention.service';
+import { ArchivedData } from './entities/archived-data.entity';
+import { AuditLog } from '../audit-log/audit-log.entity';
+import { Notification } from '../notifications/entities/notification.entity';
+
+describe('DataRetentionService', () => {
+  const archiveRepo = {
+    save: jest.fn().mockResolvedValue(undefined),
+  };
+
+  const makeRepo = () => ({
+    find: jest.fn(),
+    delete: jest.fn().mockResolvedValue({ affected: 1 }),
+  });
+
+  const makeConfig = (overrides: Record<string, any> = {}) =>
+    ({
+      get: jest.fn((key: string, defaultValue: any) => {
+        const defaults: Record<string, any> = {
+          'retention.softDeleteRetentionDays': 30,
+          'retention.auditLogRetentionDays': 90,
+          'retention.notificationRetentionDays': 30,
+          'retention.batchSize': 1000,
+          'retention.enableArchiving': true,
+        };
+        return key in overrides ? overrides[key] : defaults[key] ?? defaultValue;
+      }),
+    }) as unknown as ConfigService;
+
+  const makeDataSource = (softRepo: any, auditRepo: any, notificationRepo: any) =>
+    ({
+      getRepository: jest.fn((entity: any) => {
+        if (entity === ArchivedSource) return softRepo;
+        if (entity === AuditLog) return auditRepo;
+        if (entity === Notification) return notificationRepo;
+        return null;
+      }),
+      getMetadata: jest.fn(() => ({ tableName: 'archived_source' })),
+    }) as unknown as DataSource;
+
+  class ArchivedSource {
+    id = 'arch-1';
+    deletedAt = new Date('2026-01-01T00:00:00Z');
+  }
+
+  it('archives and deletes old soft-deleted records', async () => {
+    const softRepo = makeRepo();
+    softRepo.find.mockResolvedValue([Object.assign(new ArchivedSource(), { id: 'arch-1' })]);
+    const auditRepo = makeRepo();
+    const notificationRepo = makeRepo();
+    const dataSource = makeDataSource(softRepo, auditRepo, notificationRepo);
+    const service = new DataRetentionService(dataSource, makeConfig(), archiveRepo as any);
+
+    const removed = await service.purgeSoftDeleted(ArchivedSource, 'ArchivedSource');
+
+    expect(removed).toBe(1);
+    expect(archiveRepo.save).toHaveBeenCalledWith(
+      expect.arrayContaining([
+        expect.objectContaining({ entityType: 'ArchivedSource', originalId: 'arch-1' }),
+      ]),
+    );
+    expect(softRepo.delete).toHaveBeenCalledWith(['arch-1']);
+  });
+
+  it('returns zero when no audit logs are eligible', async () => {
+    const softRepo = makeRepo();
+    const auditRepo = makeRepo();
+    auditRepo.find.mockResolvedValue([]);
+    const notificationRepo = makeRepo();
+    const service = new DataRetentionService(
+      makeDataSource(softRepo, auditRepo, notificationRepo),
+      makeConfig({ 'retention.enableArchiving': false }),
+      archiveRepo as any,
+    );
+
+    await expect(service.purgeAuditLogs()).resolves.toBe(0);
+  });
+
+  it('purges notifications without archiving when archiving is disabled', async () => {
+    const softRepo = makeRepo();
+    const auditRepo = makeRepo();
+    const notificationRepo = makeRepo();
+    notificationRepo.find.mockResolvedValue([{ id: 'notif-1' }]);
+    const service = new DataRetentionService(
+      makeDataSource(softRepo, auditRepo, notificationRepo),
+      makeConfig({ 'retention.enableArchiving': false }),
+      archiveRepo as any,
+    );
+
+    await expect(service.purgeNotifications()).resolves.toBe(1);
+    expect(notificationRepo.delete).toHaveBeenCalledWith(['notif-1']);
+  });
+});

--- a/src/data-retention/data-retention.service.spec.ts
+++ b/src/data-retention/data-retention.service.spec.ts
@@ -25,7 +25,7 @@ describe('DataRetentionService', () => {
           'retention.batchSize': 1000,
           'retention.enableArchiving': true,
         };
-        return key in overrides ? overrides[key] : defaults[key] ?? defaultValue;
+        return key in overrides ? overrides[key] : (defaults[key] ?? defaultValue);
       }),
     }) as unknown as ConfigService;
 

--- a/src/database/health/db-connection-health.service.spec.ts
+++ b/src/database/health/db-connection-health.service.spec.ts
@@ -1,0 +1,60 @@
+import { DbConnectionHealthService } from './db-connection-health.service';
+import { DataSource } from 'typeorm';
+
+describe('DbConnectionHealthService', () => {
+  const makeDataSource = () =>
+    ({
+      query: jest.fn(),
+      destroy: jest.fn().mockResolvedValue(undefined),
+      initialize: jest.fn().mockResolvedValue(undefined),
+      driver: { master: { pool: { totalCount: 2, idleCount: 1, waitingCount: 0 } } },
+    }) as unknown as DataSource;
+
+  beforeEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('runs a scheduled check on module init and registers the interval', async () => {
+    const service = new DbConnectionHealthService(makeDataSource());
+    const runCheck = jest.spyOn(service as any, 'runCheck').mockResolvedValue(undefined);
+    const setIntervalSpy = jest.spyOn(global, 'setInterval').mockReturnValue(123 as any);
+
+    service.onModuleInit();
+
+    expect(setIntervalSpy).toHaveBeenCalled();
+    expect(runCheck).toHaveBeenCalled();
+  });
+
+  it('clears the interval on module destroy', () => {
+    const service = new DbConnectionHealthService(makeDataSource());
+    (service as any).intervalRef = 456;
+    const clearIntervalSpy = jest.spyOn(global, 'clearInterval');
+
+    service.onModuleDestroy();
+
+    expect(clearIntervalSpy).toHaveBeenCalledWith(456);
+  });
+
+  it('returns a healthy result and caches it when the probe succeeds', async () => {
+    const dataSource = makeDataSource();
+    dataSource.query = jest.fn().mockResolvedValueOnce([]);
+    const service = new DbConnectionHealthService(dataSource);
+
+    const result = await service.check();
+
+    expect(result.status).toBe('healthy');
+    expect(service.getLastResult()).toEqual(result);
+  });
+
+  it('returns an unhealthy result when the probe fails', async () => {
+    const dataSource = makeDataSource();
+    dataSource.query = jest.fn().mockRejectedValueOnce(new Error('db down'));
+    const service = new DbConnectionHealthService(dataSource);
+
+    const result = await service.check();
+
+    expect(result.status).toBe('unhealthy');
+    expect(result.message).toContain('db down');
+    expect(service.getLastResult()).toEqual(result);
+  });
+});


### PR DESCRIPTION
Adds focused unit coverage for DB health, data retention, and currency helpers.

Closes #1289
Closes #1288
Closes #1287
Closes #1286