### PR TITLE
fix(search): enforce pagination bounds on search list endpoints

### DIFF
--- a/src/search/dto/pagination.dto.ts
+++ b/src/search/dto/pagination.dto.ts
@@ -1,0 +1,20 @@
+import { Type } from 'class-transformer';
+import { IsInt, IsOptional, Max, Min } from 'class-validator';
+import { ApiPropertyOptional } from '@nestjs/swagger';
+
+export class PaginationDto {
+  @ApiPropertyOptional({ description: 'The page number', default: 1, minimum: 1 })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  page?: number = 1;
+
+  @ApiPropertyOptional({ description: 'The maximum number of results (max 100)', default: 20, minimum: 1, maximum: 100 })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  limit?: number = 20;
+}

--- a/src/search/search.controller.ts
+++ b/src/search/search.controller.ts
@@ -3,6 +3,7 @@ import { ApiOperation, ApiQuery, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { Throttle } from '@nestjs/throttler';
 import { THROTTLE } from '../common/constants/throttle.constants';
 import { SearchService } from './search.service';
+import { PaginationDto } from './dto/pagination.dto';
 
 @ApiTags('Search')
 @Throttle({ default: THROTTLE.SEARCH })
@@ -29,8 +30,8 @@ export class SearchController {
     example: '{"category":"programming","level":"beginner"}',
   })
   @ApiQuery({ name: 'sort', required: false, example: 'relevance' })
-  @ApiQuery({ name: 'page', required: false, example: 1 })
-  @ApiQuery({ name: 'limit', required: false, example: 20 })
+  @ApiQuery({ name: 'page', required: false, description: 'The page number. Default is 1.', example: 1, type: Number })
+  @ApiQuery({ name: 'limit', required: false, description: 'The maximum number of results. Default is 20. Max is 100.', example: 20, type: Number })
   @ApiResponse({
     status: 200,
     description: 'Search results',
@@ -49,10 +50,9 @@ export class SearchController {
   @ApiResponse({ status: 503, description: 'Search is temporarily unavailable' })
   async search(
     @Query('q') query: string,
+    @Query() paginationDto: PaginationDto,
     @Query('filters') filters?: string,
     @Query('sort') sort?: string,
-    @Query('page') page?: string,
-    @Query('limit') limit?: string,
   ): Promise<any> {
     let parsedFilters: Record<string, any> = {};
     if (filters) {
@@ -63,8 +63,8 @@ export class SearchController {
       }
     }
 
-    const pageNum = page ? parseInt(page, 10) : 1;
-    const limitNum = limit ? parseInt(limit, 10) : 20;
+    const pageNum = paginationDto.page ?? 1;
+    const limitNum = paginationDto.limit ?? 20;
 
     return this.searchService.search(query, parsedFilters, sort, pageNum, limitNum);
   }


### PR DESCRIPTION
closes #1309
### **Overview**
This PR enforces validation and bounding for pagination parameters in the `search` endpoint, preventing clients from requesting an unbounded number of rows (which poses a memory, DoS, and performance risk).

### **Changes Made**
*   **Created `PaginationDto`**: Added a new DTO in `src/search/dto/pagination.dto.ts` using `class-validator` to enforce pagination constraints and type conversion.
*   **Enforced Constraints**:
    *   `page`: Minimum is 1. Default is 1.
    *   `limit`: Minimum is 1. Maximum is clamped at 100. Default is 20.
    *   Invalid values (negative, zero, non-numeric strings, or limits over 100) are automatically rejected with a `400 Bad Request` through NestJS's `ValidationPipe` combined with `@IsInt()`, `@Min()`, `@Max()`, and `@Type(() => Number)`.
*   **Updated Controller**: Replaced raw string pagination parsing in `src/search/search.controller.ts` with the new validated `PaginationDto`.
*   **Swagger Documentation**: Updated `@ApiQuery` to properly reflect and document the maximum page size (100) alongside default limits.

### **Testing/Acceptance Criteria Verified**
- Requesting an oversized limit (e.g., `limit=200`) is rejected with a `400 Bad Request`.
- Passing invalid negative or non-numeric limits/pages fails with a `400 Bad Request`.
- Requests missing `limit` or `page` succeed by automatically applying the `1` (page) and `20` (limit) defaults.