### PR TITLE
fix: resolve duplicate migration timestamps causing ambiguous ordering

### DIFF
--- a/src/migrations/1783000000006-clear-legacy-bcrypt-refresh-tokens.ts
+++ b/src/migrations/1783000000006-clear-legacy-bcrypt-refresh-tokens.ts
@@ -18,8 +18,17 @@ import { MigrationInterface, QueryRunner } from 'typeorm';
  *
  * This migration is **not reversible**. Bcrypt hashes cannot be converted back
  * to plaintext or re-hashed with HMAC-SHA-256. The `down()` method is a no-op.
+ *
+ * ## Timestamp note (issue #1196)
+ *
+ * Originally shared the timestamp `1783000000003` with
+ * `add-course-full-text-search`, making the relative order of the two
+ * migrations dependent on file-load order. Renumbered to `1783000000006` (the
+ * next free slot after `1783000000005-add-user-createdat-index`) so this
+ * data-updating migration deterministically runs after the DDL migrations in
+ * the `1783000000xxx` block rather than racing one of them.
  */
-export class ClearLegacyBcryptRefreshTokens1783000000003 implements MigrationInterface {
+export class ClearLegacyBcryptRefreshTokens1783000000006 implements MigrationInterface {
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(`
       UPDATE users

--- a/src/migrations/1790000000001-fix-invoice-number-sequence.ts
+++ b/src/migrations/1790000000001-fix-invoice-number-sequence.ts
@@ -47,8 +47,15 @@ import { MigrationInterface, QueryRunner } from 'typeorm';
  *     -- Should show monotonically increasing sequence values
  *  3. SELECT currval('invoice_number_seq');
  *     -- Shows current sequence position for debugging
+ *
+ * ## Timestamp note (issue #1196)
+ *
+ * Originally shared the timestamp `1790000000000` with
+ * `add-paused-subscription-status`, making the relative order of the two
+ * migrations dependent on file-load order. Renumbered to `1790000000001` for
+ * deterministic ordering.
  */
-export class FixInvoiceNumberSequence1790000000000 implements MigrationInterface {
+export class FixInvoiceNumberSequence1790000000001 implements MigrationInterface {
   public async up(queryRunner: QueryRunner): Promise<void> {
     // Use the queryRunner handed to us by the migration runner. Migrations run
     // inside a single shared transaction (TypeORM's default "all" mode), so a

--- a/src/migrations/1796000000001-reconcile-schema-drift.ts
+++ b/src/migrations/1796000000001-reconcile-schema-drift.ts
@@ -1,7 +1,7 @@
 import { MigrationInterface, QueryRunner } from 'typeorm';
 
-export class ReconcileSchemaDrift1796000000000 implements MigrationInterface {
-  name = 'ReconcileSchemaDrift1796000000000';
+export class ReconcileSchemaDrift1796000000001 implements MigrationInterface {
+  name = 'ReconcileSchemaDrift1796000000001';
 
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(

--- a/src/migrations/migration-timestamps.spec.ts
+++ b/src/migrations/migration-timestamps.spec.ts
@@ -1,0 +1,138 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+/**
+ * Issue #1196 — Duplicate migration timestamps caused ambiguous ordering.
+ *
+ * TypeORM orders migrations by their numeric timestamp prefix. Two files
+ * sharing a timestamp make their relative order depend on filesystem
+ * load order, which is not guaranteed to be stable across platforms/CI
+ * runners. This spec guards against that class of bug for every migration
+ * under `src/migrations`, and pins down the specific renumbering done for
+ * #1196.
+ */
+describe('src/migrations timestamps', () => {
+  const migrationsDir = __dirname;
+
+  // Mirrors the `migrations` glob in src/config/datasource.ts
+  // (`src/migrations/[0-9]*`): a migration file's basename starts with a digit.
+  const migrationFiles = fs
+    .readdirSync(migrationsDir)
+    .filter((name) => /^[0-9].*\.ts$/.test(name) && !name.endsWith('.spec.ts'));
+
+  interface ParsedMigration {
+    file: string;
+    timestamp: string;
+    className: string;
+  }
+
+  function parseMigration(file: string): ParsedMigration {
+    const match = file.match(/^(\d+)-.*\.ts$/);
+    if (!match) {
+      throw new Error(`Migration file "${file}" does not start with a numeric timestamp`);
+    }
+    const timestamp = match[1];
+
+    const content = fs.readFileSync(path.join(migrationsDir, file), 'utf8');
+    const classMatch = content.match(/export class (\w+) implements MigrationInterface/);
+    if (!classMatch) {
+      throw new Error(`Could not find an exported MigrationInterface class in "${file}"`);
+    }
+
+    return { file, timestamp, className: classMatch[1] };
+  }
+
+  const migrations = migrationFiles.map(parseMigration);
+
+  it('finds at least the migrations under test', () => {
+    expect(migrations.length).toBeGreaterThan(0);
+  });
+
+  it('has no two migration files sharing the same timestamp', () => {
+    const seen = new Map<string, string[]>();
+    for (const { file, timestamp } of migrations) {
+      const existing = seen.get(timestamp) ?? [];
+      existing.push(file);
+      seen.set(timestamp, existing);
+    }
+
+    const duplicates = [...seen.entries()].filter(([, files]) => files.length > 1);
+
+    expect(duplicates).toEqual([]);
+  });
+
+  it('names every migration class with its own file timestamp as a suffix (TypeORM derives the recorded migration name from the class)', () => {
+    const mismatched = migrations.filter(
+      ({ timestamp, className }) => !className.endsWith(timestamp),
+    );
+
+    expect(mismatched).toEqual([]);
+  });
+
+  it('gives every migration class an explicit `name` field (when present) that matches the class name', () => {
+    for (const { file, className } of migrations) {
+      const content = fs.readFileSync(path.join(migrationsDir, file), 'utf8');
+      const nameFieldMatch = content.match(/^\s*name\s*=\s*'([^']+)'/m);
+      if (nameFieldMatch) {
+        expect(nameFieldMatch[1]).toBe(className);
+      }
+    }
+  });
+
+  describe('issue #1196 regression: previously-duplicated timestamp pairs', () => {
+    it('add-course-full-text-search and clear-legacy-bcrypt-refresh-tokens no longer share 1783000000003', () => {
+      expect(
+        fs.existsSync(path.join(migrationsDir, '1783000000003-add-course-full-text-search.ts')),
+      ).toBe(true);
+      expect(
+        fs.existsSync(
+          path.join(migrationsDir, '1783000000006-clear-legacy-bcrypt-refresh-tokens.ts'),
+        ),
+      ).toBe(true);
+      expect(
+        fs.existsSync(
+          path.join(migrationsDir, '1783000000003-clear-legacy-bcrypt-refresh-tokens.ts'),
+        ),
+      ).toBe(false);
+
+      // The clear-legacy-bcrypt migration performs a data UPDATE and must not
+      // race, or be interleaved with, the DDL-only full-text-search migration.
+      const fullTextSearch = migrations.find((m) =>
+        m.file.endsWith('add-course-full-text-search.ts'),
+      );
+      const clearLegacyBcrypt = migrations.find((m) =>
+        m.file.endsWith('clear-legacy-bcrypt-refresh-tokens.ts'),
+      );
+
+      expect(fullTextSearch).toBeDefined();
+      expect(clearLegacyBcrypt).toBeDefined();
+      expect(Number(clearLegacyBcrypt!.timestamp)).toBeGreaterThan(
+        Number(fullTextSearch!.timestamp),
+      );
+    });
+
+    it('add-paused-subscription-status and fix-invoice-number-sequence no longer share 1790000000000', () => {
+      expect(
+        fs.existsSync(path.join(migrationsDir, '1790000000000-add-paused-subscription-status.ts')),
+      ).toBe(true);
+      expect(
+        fs.existsSync(path.join(migrationsDir, '1790000000001-fix-invoice-number-sequence.ts')),
+      ).toBe(true);
+      expect(
+        fs.existsSync(path.join(migrationsDir, '1790000000000-fix-invoice-number-sequence.ts')),
+      ).toBe(false);
+    });
+
+    it('add-invoice-tax-columns and reconcile-schema-drift no longer share 1796000000000', () => {
+      expect(
+        fs.existsSync(path.join(migrationsDir, '1796000000000-add-invoice-tax-columns.ts')),
+      ).toBe(true);
+      expect(
+        fs.existsSync(path.join(migrationsDir, '1796000000001-reconcile-schema-drift.ts')),
+      ).toBe(true);
+      expect(
+        fs.existsSync(path.join(migrationsDir, '1796000000000-reconcile-schema-drift.ts')),
+      ).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
Closes #1196

## Problem

Three pairs of migration files under `src/migrations/` shared identical numeric timestamps. TypeORM orders migrations by that timestamp, so within each pair the relative run order was undefined — it depended on filesystem load order rather than an explicit, deterministic sequence:

- `1783000000003-add-course-full-text-search.ts` and `1783000000003-clear-legacy-bcrypt-refresh-tokens.ts`
- `1790000000000-add-paused-subscription-status.ts` and `1790000000000-fix-invoice-number-sequence.ts`
- `1796000000000-add-invoice-tax-columns.ts` and `1796000000000-reconcile-schema-drift.ts` (found while implementing the fix — not called out in the original issue, but the same bug)

For the first pair specifically, `clear-legacy-bcrypt-refresh-tokens` performs a data `UPDATE` on `users`, so it must not race or interleave with the DDL-only `add-course-full-text-search` migration (or the other DDL migrations at `1783000000004`/`1783000000005`).

## Fix

Renumbered one migration in each pair to the next unused timestamp, and renamed its class to match (TypeORM derives the migration's recorded name from the class name, so the two must stay in sync):

| File | Old timestamp | New timestamp | Class |
|---|---|---|---|
| `clear-legacy-bcrypt-refresh-tokens.ts` | `1783000000003` | `1783000000006` | `ClearLegacyBcryptRefreshTokens1783000000006` |
| `fix-invoice-number-sequence.ts` | `1790000000000` | `1790000000001` | `FixInvoiceNumberSequence1790000000001` |
| `reconcile-schema-drift.ts` | `1796000000000` | `1796000000001` | `ReconcileSchemaDrift1796000000001` (also updates the explicit `name` field) |

`clear-legacy-bcrypt-refresh-tokens` was bumped to `1783000000006` (rather than `1783000000004`, which collides with the existing `add-forum-indexes` migration) so it deterministically runs *after* the full `1783000000003`–`1783000000005` DDL block instead of being sandwiched between DDL migrations.

The other file in each pair (`add-course-full-text-search`, `add-paused-subscription-status`, `add-invoice-tax-columns`) is unchanged.

No other files reference the old class names or timestamps (`add-course-full-text-search` is mentioned in `src/search/search.service.ts`, but that file kept its original timestamp, so the reference is still correct).

## Files changed

**Renamed (content + class name updated):**
- `src/migrations/1783000000003-clear-legacy-bcrypt-refresh-tokens.ts` → `src/migrations/1783000000006-clear-legacy-bcrypt-refresh-tokens.ts`
- `src/migrations/1790000000000-fix-invoice-number-sequence.ts` → `src/migrations/1790000000001-fix-invoice-number-sequence.ts`
- `src/migrations/1796000000000-reconcile-schema-drift.ts` → `src/migrations/1796000000001-reconcile-schema-drift.ts`

**New:**
- `src/migrations/migration-timestamps.spec.ts` — test file (see below)

## Tests added

`src/migrations/migration-timestamps.spec.ts`, following the existing filesystem-scanning spec pattern used elsewhere in the repo (e.g. `src/monitoring/prometheus-rules.spec.ts`):

- Scans every file in `src/migrations/` matching the digit-prefix convention TypeORM's `migrations` glob uses (`src/migrations/[0-9]*`).
- Asserts no two migration files share the same numeric timestamp (the general regression guard for this class of bug).
- Asserts every migration class name is suffixed with its own file's timestamp.
- Asserts that where a migration sets an explicit `name` field, it matches the class name.
- Regression-pins the three specific renumbered pairs: asserts the old duplicate-timestamp filenames no longer exist and the new ones do, and specifically asserts `clear-legacy-bcrypt-refresh-tokens`'s timestamp is greater than `add-course-full-text-search`'s (the ordering that matters per the issue).

## How to test

```bash
npx jest src/migrations/migration-timestamps.spec.ts
node scripts/validate-migrations.js   # existing CI migration check, confirms it still passes
```

Both pass locally. Also verified:
- `grep`'d the repo for the old class names/timestamps to confirm nothing else references them.
- `git mv` was used so the renames are tracked as renames, not delete+add.
- No new TypeScript errors introduced (`npx tsc --noEmit` shows the same pre-existing, unrelated errors in `test/*.e2e-spec.ts` on this branch as on `main`).