### PR TITLE
Add unit tests for audit-export, mfa, sensitive-operations, adaptive-ttl services

### DIFF
--- a/src/audit-log/services/audit-export.service.spec.ts
+++ b/src/audit-log/services/audit-export.service.spec.ts
@@ -1,0 +1,139 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { AuditExportService } from './audit-export.service';
+import { AuditQueryService } from './audit-query.service';
+
+describe('AuditExportService', () => {
+  let service: AuditExportService;
+  let queryService: { search: jest.Mock };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AuditExportService,
+        { provide: AuditQueryService, useValue: { search: jest.fn() } },
+      ],
+    }).compile();
+
+    service = module.get<AuditExportService>(AuditExportService);
+    queryService = module.get(AuditQueryService);
+  });
+
+  describe('exportToJson', () => {
+    it('queries with the given filters and returns pretty-printed JSON', async () => {
+      const logs = [{ id: '1', action: 'LOGIN' }];
+      queryService.search.mockResolvedValue({ data: logs, total: 1 });
+
+      const result = await service.exportToJson({ userId: 'u1' } as any);
+
+      expect(queryService.search).toHaveBeenCalledWith({ userId: 'u1' }, 1, 10000);
+      expect(JSON.parse(result)).toEqual(logs);
+      expect(result).toContain('\n'); // pretty-printed, not minified
+    });
+
+    it('returns an empty array literal when there are no matching logs', async () => {
+      queryService.search.mockResolvedValue({ data: [], total: 0 });
+
+      const result = await service.exportToJson({} as any);
+
+      expect(result).toBe('[]');
+    });
+
+    it('propagates a query failure', async () => {
+      const error = new Error('query failed');
+      queryService.search.mockRejectedValue(error);
+
+      await expect(service.exportToJson({} as any)).rejects.toThrow(error);
+    });
+  });
+
+  describe('exportToCsv', () => {
+    it('emits a header row followed by one row per log', async () => {
+      const timestamp = new Date('2026-01-01T00:00:00.000Z');
+      queryService.search.mockResolvedValue({
+        data: [
+          {
+            timestamp,
+            userId: 'u1',
+            userEmail: 'u1@example.com',
+            action: 'LOGIN',
+            category: 'auth',
+            severity: 'info',
+            entityType: 'user',
+            entityId: 'u1',
+            description: 'User logged in',
+            ipAddress: '127.0.0.1',
+            userAgent: 'jest',
+            apiEndpoint: '/login',
+            httpMethod: 'POST',
+            statusCode: 200,
+          },
+        ],
+      });
+
+      const result = await service.exportToCsv({} as any);
+      const lines = result.split('\n');
+
+      expect(lines[0]).toBe(
+        'timestamp,userId,userEmail,action,category,severity,entityType,entityId,description,ipAddress,userAgent,apiEndpoint,httpMethod,statusCode',
+      );
+      expect(lines[1]).toBe(
+        `${timestamp.toISOString()},u1,u1@example.com,LOGIN,auth,info,user,u1,User logged in,127.0.0.1,jest,/login,POST,200`,
+      );
+    });
+
+    it('substitutes empty strings for missing optional fields', async () => {
+      queryService.search.mockResolvedValue({
+        data: [
+          {
+            timestamp: new Date('2026-01-01T00:00:00.000Z'),
+            action: 'LOGIN',
+            category: 'auth',
+            severity: 'info',
+          },
+        ],
+      });
+
+      const result = await service.exportToCsv({} as any);
+      const dataLine = result.split('\n')[1];
+
+      // userId, userEmail, entityType, entityId, description, ipAddress,
+      // userAgent, apiEndpoint, httpMethod, statusCode all fall back to ''.
+      expect(dataLine).toBe(
+        `${new Date('2026-01-01T00:00:00.000Z').toISOString()},,,LOGIN,auth,info,,,,,,,,`,
+      );
+    });
+
+    it('quotes and escapes fields containing commas, quotes, or newlines', async () => {
+      queryService.search.mockResolvedValue({
+        data: [
+          {
+            timestamp: new Date('2026-01-01T00:00:00.000Z'),
+            action: 'LOGIN',
+            category: 'auth',
+            severity: 'info',
+            description: 'Said "hello", then\nleft',
+          },
+        ],
+      });
+
+      const result = await service.exportToCsv({} as any);
+      expect(result).toContain('"Said ""hello"", then\nleft"');
+    });
+
+    it('returns just the header row when there are no matching logs', async () => {
+      queryService.search.mockResolvedValue({ data: [] });
+
+      const result = await service.exportToCsv({} as any);
+
+      expect(result.split('\n')).toHaveLength(1);
+      expect(result).toContain('timestamp,userId');
+    });
+
+    it('propagates a query failure', async () => {
+      const error = new Error('query failed');
+      queryService.search.mockRejectedValue(error);
+
+      await expect(service.exportToCsv({} as any)).rejects.toThrow(error);
+    });
+  });
+});

--- a/src/audit-log/services/sensitive-operations.service.spec.ts
+++ b/src/audit-log/services/sensitive-operations.service.spec.ts
@@ -1,0 +1,243 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { SensitiveOperationsService } from './sensitive-operations.service';
+import { AuditLogService } from '../audit-log.service';
+import { AuditAction, AuditCategory, AuditSeverity } from '../enums/audit-action.enum';
+
+describe('SensitiveOperationsService', () => {
+  let service: SensitiveOperationsService;
+  let auditLogService: { log: jest.Mock };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        SensitiveOperationsService,
+        { provide: AuditLogService, useValue: { log: jest.fn().mockResolvedValue(undefined) } },
+      ],
+    }).compile();
+
+    service = module.get<SensitiveOperationsService>(SensitiveOperationsService);
+    auditLogService = module.get(AuditLogService);
+  });
+
+  describe('logSensitiveOperation', () => {
+    const baseOperation = {
+      userId: 'u1',
+      userEmail: 'u1@example.com',
+      action: AuditAction.USER_DELETED,
+      entityType: 'User',
+      entityId: 'u2',
+      description: 'deleted',
+      ipAddress: '127.0.0.1',
+      userAgent: 'jest',
+    };
+
+    it('logs with WARNING severity, a resolved category, and the sensitive-operation flag', async () => {
+      await service.logSensitiveOperation(baseOperation);
+
+      expect(auditLogService.log).toHaveBeenCalledWith(
+        expect.objectContaining({
+          userId: 'u1',
+          action: AuditAction.USER_DELETED,
+          category: AuditCategory.AUTHORIZATION,
+          severity: AuditSeverity.WARNING,
+          metadata: expect.objectContaining({ isSensitiveOperation: true }),
+        }),
+      );
+    });
+
+    it('falls back to the SYSTEM category for an action with no explicit mapping', async () => {
+      await service.logSensitiveOperation({
+        ...baseOperation,
+        action: 'UNMAPPED_ACTION' as AuditAction,
+      });
+
+      expect(auditLogService.log).toHaveBeenCalledWith(
+        expect.objectContaining({ category: AuditCategory.SYSTEM }),
+      );
+    });
+
+    it('logs the error and rethrows when the underlying audit log write fails', async () => {
+      const error = new Error('write failed');
+      auditLogService.log.mockRejectedValue(error);
+
+      await expect(service.logSensitiveOperation(baseOperation)).rejects.toThrow(error);
+    });
+  });
+
+  describe('logUserDeletion', () => {
+    it('delegates to logSensitiveOperation with a USER_DELETED entry', async () => {
+      await service.logUserDeletion('u1', 'admin@x.com', 'u2', 'victim@x.com', '1.2.3.4', 'ua');
+
+      expect(auditLogService.log).toHaveBeenCalledWith(
+        expect.objectContaining({
+          action: AuditAction.USER_DELETED,
+          entityType: 'User',
+          entityId: 'u2',
+          description: expect.stringContaining('victim@x.com'),
+        }),
+      );
+    });
+  });
+
+  describe('logRoleChange', () => {
+    it('records the old and new role in oldValues/newValues', async () => {
+      await service.logRoleChange(
+        'u1',
+        'admin@x.com',
+        'u2',
+        'target@x.com',
+        'student',
+        'instructor',
+        '1.2.3.4',
+        'ua',
+      );
+
+      expect(auditLogService.log).toHaveBeenCalledWith(
+        expect.objectContaining({
+          action: AuditAction.USER_ROLE_CHANGED,
+          oldValues: { role: 'student' },
+          newValues: { role: 'instructor' },
+        }),
+      );
+    });
+  });
+
+  describe('logPasswordChange', () => {
+    it('logs a PASSWORD_CHANGE entry scoped to the user themselves', async () => {
+      await service.logPasswordChange('u1', 'u1@example.com', '1.2.3.4', 'ua');
+
+      expect(auditLogService.log).toHaveBeenCalledWith(
+        expect.objectContaining({
+          action: AuditAction.PASSWORD_CHANGE,
+          entityId: 'u1',
+        }),
+      );
+    });
+  });
+
+  describe('logConfigChange', () => {
+    it('logs directly with CRITICAL severity and the old/new config values', async () => {
+      await service.logConfigChange(
+        'u1',
+        'admin@x.com',
+        'feature.flag',
+        false,
+        true,
+        '1.2.3.4',
+        'ua',
+      );
+
+      expect(auditLogService.log).toHaveBeenCalledWith(
+        expect.objectContaining({
+          action: AuditAction.CONFIG_CHANGED,
+          category: AuditCategory.SYSTEM,
+          severity: AuditSeverity.CRITICAL,
+          oldValues: { value: false },
+          newValues: { value: true },
+        }),
+      );
+    });
+
+    it('propagates a failure from the underlying audit log write', async () => {
+      const error = new Error('write failed');
+      auditLogService.log.mockRejectedValue(error);
+
+      await expect(
+        service.logConfigChange('u1', 'a@x.com', 'k', 1, 2, '1.2.3.4', 'ua'),
+      ).rejects.toThrow(error);
+    });
+  });
+
+  describe('logDataExport', () => {
+    it('describes the export and includes record count/format in metadata', async () => {
+      await service.logDataExport('u1', 'u1@x.com', 'User', 42, 'csv', '1.2.3.4', 'ua');
+
+      expect(auditLogService.log).toHaveBeenCalledWith(
+        expect.objectContaining({
+          action: AuditAction.DATA_EXPORTED,
+          description: expect.stringContaining('42'),
+          metadata: expect.objectContaining({ recordCount: 42, exportFormat: 'csv' }),
+        }),
+      );
+    });
+  });
+
+  describe('logBackupOperation', () => {
+    it('maps CREATE to BACKUP_CREATED', async () => {
+      await service.logBackupOperation('u1', 'a@x.com', 'CREATE', 'backup-1', '1.2.3.4', 'ua');
+
+      expect(auditLogService.log).toHaveBeenCalledWith(
+        expect.objectContaining({ action: AuditAction.BACKUP_CREATED, entityId: 'backup-1' }),
+      );
+    });
+
+    it('maps RESTORE to BACKUP_RESTORED', async () => {
+      await service.logBackupOperation('u1', 'a@x.com', 'RESTORE', 'backup-1', '1.2.3.4', 'ua');
+
+      expect(auditLogService.log).toHaveBeenCalledWith(
+        expect.objectContaining({ action: AuditAction.BACKUP_RESTORED }),
+      );
+    });
+  });
+
+  describe('logPermissionDenied', () => {
+    it('logs with SECURITY category and WARNING severity', async () => {
+      await service.logPermissionDenied('u1', 'u1@x.com', 'Course', 'delete', '1.2.3.4', 'ua');
+
+      expect(auditLogService.log).toHaveBeenCalledWith(
+        expect.objectContaining({
+          action: AuditAction.PERMISSION_DENIED,
+          category: AuditCategory.SECURITY,
+          severity: AuditSeverity.WARNING,
+        }),
+      );
+    });
+
+    it('converts a null userId/userEmail to undefined for anonymous attempts', async () => {
+      await service.logPermissionDenied(null, null, 'Course', 'delete', '1.2.3.4', 'ua');
+
+      expect(auditLogService.log).toHaveBeenCalledWith(
+        expect.objectContaining({ userId: undefined, userEmail: undefined }),
+      );
+    });
+  });
+
+  describe('logSuspiciousActivity', () => {
+    it('logs with SECURITY category and CRITICAL severity, merging extra metadata', async () => {
+      await service.logSuspiciousActivity(
+        'u1',
+        'u1@x.com',
+        'brute-force',
+        'multiple failed logins',
+        '1.2.3.4',
+        'ua',
+        undefined,
+        { attempts: 5 },
+      );
+
+      expect(auditLogService.log).toHaveBeenCalledWith(
+        expect.objectContaining({
+          action: AuditAction.SUSPICIOUS_ACTIVITY,
+          category: AuditCategory.SECURITY,
+          severity: AuditSeverity.CRITICAL,
+          metadata: expect.objectContaining({ activityType: 'brute-force', attempts: 5 }),
+        }),
+      );
+    });
+
+    it('supports an anonymous actor', async () => {
+      await service.logSuspiciousActivity(
+        null,
+        null,
+        'scraping',
+        'unusual request pattern',
+        '1.2.3.4',
+        'ua',
+      );
+
+      expect(auditLogService.log).toHaveBeenCalledWith(
+        expect.objectContaining({ userId: undefined, userEmail: undefined }),
+      );
+    });
+  });
+});

--- a/src/auth/mfa/mfa.service.spec.ts
+++ b/src/auth/mfa/mfa.service.spec.ts
@@ -1,0 +1,220 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { BadRequestException } from '@nestjs/common';
+import * as otplib from 'otplib';
+import * as qrcode from 'qrcode';
+import * as bcrypt from 'bcrypt';
+import { MfaService } from './mfa.service';
+import { User } from '../../users/entities/user.entity';
+import { EncryptionService } from '../../security/encryption/encryption.service';
+
+jest.mock('otplib', () => ({
+  generateSecret: jest.fn(),
+  generateURI: jest.fn(),
+  verifySync: jest.fn(),
+}));
+
+jest.mock('qrcode', () => ({
+  toDataURL: jest.fn(),
+}));
+
+jest.mock('bcrypt', () => ({
+  genSalt: jest.fn(),
+  hash: jest.fn(),
+  compare: jest.fn(),
+}));
+
+describe('MfaService', () => {
+  let service: MfaService;
+  let userRepository: jest.Mocked<Repository<User>>;
+  let encryptionService: { encrypt: jest.Mock; decrypt: jest.Mock };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        MfaService,
+        {
+          provide: getRepositoryToken(User),
+          useValue: { save: jest.fn((u) => Promise.resolve(u)) },
+        },
+        {
+          provide: EncryptionService,
+          useValue: { encrypt: jest.fn(), decrypt: jest.fn() },
+        },
+      ],
+    }).compile();
+
+    service = module.get<MfaService>(MfaService);
+    userRepository = module.get(getRepositoryToken(User));
+    encryptionService = module.get(EncryptionService);
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  function makeUser(overrides: Partial<User> = {}): User {
+    return {
+      email: 'user@example.com',
+      isMfaEnabled: false,
+      totpSecret: null,
+      mfaRecoveryCodes: [],
+      ...overrides,
+    } as User;
+  }
+
+  describe('generateTotpSecret', () => {
+    it('encrypts the secret, hashes recovery codes, saves the user, and returns a QR code + plaintext codes', async () => {
+      (otplib.generateSecret as jest.Mock).mockReturnValue('SECRET123');
+      (otplib.generateURI as jest.Mock).mockReturnValue('otpauth://totp/x');
+      encryptionService.encrypt.mockReturnValue({ iv: 'iv', content: 'enc' });
+      (qrcode.toDataURL as jest.Mock).mockResolvedValue('data:image/png;base64,xyz');
+      (bcrypt.genSalt as jest.Mock).mockResolvedValue('salt');
+      (bcrypt.hash as jest.Mock).mockImplementation((code: string) =>
+        Promise.resolve(`hashed:${code}`),
+      );
+
+      const user = makeUser();
+      const result = await service.generateTotpSecret(user);
+
+      expect(otplib.generateURI).toHaveBeenCalledWith({
+        issuer: 'TeachLink',
+        label: user.email,
+        secret: 'SECRET123',
+      });
+      expect(encryptionService.encrypt).toHaveBeenCalledWith('SECRET123');
+      expect(user.totpSecret).toBe(JSON.stringify({ iv: 'iv', content: 'enc' }));
+      expect(user.mfaRecoveryCodes).toHaveLength(5);
+      expect(user.mfaRecoveryCodes.every((c) => c.startsWith('hashed:'))).toBe(true);
+      expect(userRepository.save).toHaveBeenCalledWith(user);
+      expect(result.qrCodeDataUrl).toBe('data:image/png;base64,xyz');
+      expect(result.recoveryCodes).toHaveLength(5);
+      // Returned codes are the plaintext originals, not the hashed values persisted on the user.
+      expect(result.recoveryCodes.every((c) => !c.startsWith('hashed:'))).toBe(true);
+    });
+
+    it('propagates a repository save failure', async () => {
+      (otplib.generateSecret as jest.Mock).mockReturnValue('SECRET123');
+      (otplib.generateURI as jest.Mock).mockReturnValue('otpauth://totp/x');
+      encryptionService.encrypt.mockReturnValue({ iv: 'iv', content: 'enc' });
+      (bcrypt.genSalt as jest.Mock).mockResolvedValue('salt');
+      (bcrypt.hash as jest.Mock).mockResolvedValue('hashed');
+      const error = new Error('db unavailable');
+      userRepository.save.mockRejectedValue(error);
+
+      await expect(service.generateTotpSecret(makeUser())).rejects.toThrow(error);
+    });
+  });
+
+  describe('verifySetup', () => {
+    it('throws BadRequestException when MFA setup was never initiated', async () => {
+      const user = makeUser({ totpSecret: null });
+
+      await expect(service.verifySetup(user, '123456')).rejects.toThrow(BadRequestException);
+    });
+
+    it('enables MFA and saves when the TOTP code is valid', async () => {
+      const user = makeUser({ totpSecret: JSON.stringify({ iv: 'iv', content: 'enc' }) });
+      encryptionService.decrypt.mockReturnValue('SECRET123');
+      (otplib.verifySync as jest.Mock).mockReturnValue({ valid: true });
+
+      const result = await service.verifySetup(user, '123456');
+
+      expect(otplib.verifySync).toHaveBeenCalledWith({ token: '123456', secret: 'SECRET123' });
+      expect(user.isMfaEnabled).toBe(true);
+      expect(userRepository.save).toHaveBeenCalledWith(user);
+      expect(result).toEqual({ success: true });
+    });
+
+    it('throws BadRequestException for an invalid TOTP code and does not enable MFA', async () => {
+      const user = makeUser({ totpSecret: JSON.stringify({ iv: 'iv', content: 'enc' }) });
+      encryptionService.decrypt.mockReturnValue('SECRET123');
+      (otplib.verifySync as jest.Mock).mockReturnValue({ valid: false });
+
+      await expect(service.verifySetup(user, 'bad')).rejects.toThrow(BadRequestException);
+      expect(user.isMfaEnabled).toBe(false);
+      expect(userRepository.save).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('verifyCode', () => {
+    it('returns false when MFA is not enabled', async () => {
+      const user = makeUser({ isMfaEnabled: false, totpSecret: 'x' });
+      await expect(service.verifyCode(user, '123456')).resolves.toBe(false);
+    });
+
+    it('returns false when there is no TOTP secret', async () => {
+      const user = makeUser({ isMfaEnabled: true, totpSecret: null });
+      await expect(service.verifyCode(user, '123456')).resolves.toBe(false);
+    });
+
+    it('returns true for a valid TOTP code', async () => {
+      const user = makeUser({
+        isMfaEnabled: true,
+        totpSecret: JSON.stringify({ iv: 'iv', content: 'enc' }),
+      });
+      encryptionService.decrypt.mockReturnValue('SECRET123');
+      (otplib.verifySync as jest.Mock).mockReturnValue({ valid: true });
+
+      await expect(service.verifyCode(user, '123456')).resolves.toBe(true);
+    });
+
+    it('falls back to a matching recovery code, consumes it, and saves', async () => {
+      const user = makeUser({
+        isMfaEnabled: true,
+        totpSecret: JSON.stringify({ iv: 'iv', content: 'enc' }),
+        mfaRecoveryCodes: ['hashed-a', 'hashed-b'],
+      });
+      encryptionService.decrypt.mockReturnValue('SECRET123');
+      (otplib.verifySync as jest.Mock).mockReturnValue({ valid: false });
+      (bcrypt.compare as jest.Mock).mockImplementation((code: string, hash: string) =>
+        Promise.resolve(hash === 'hashed-b'),
+      );
+
+      const result = await service.verifyCode(user, 'recovery-code');
+
+      expect(result).toBe(true);
+      expect(user.mfaRecoveryCodes).toEqual(['hashed-a']);
+      expect(userRepository.save).toHaveBeenCalledWith(user);
+    });
+
+    it('returns false when neither TOTP nor any recovery code match', async () => {
+      const user = makeUser({
+        isMfaEnabled: true,
+        totpSecret: JSON.stringify({ iv: 'iv', content: 'enc' }),
+        mfaRecoveryCodes: ['hashed-a'],
+      });
+      encryptionService.decrypt.mockReturnValue('SECRET123');
+      (otplib.verifySync as jest.Mock).mockReturnValue({ valid: false });
+      (bcrypt.compare as jest.Mock).mockResolvedValue(false);
+
+      await expect(service.verifyCode(user, 'nope')).resolves.toBe(false);
+      expect(userRepository.save).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('disableMfa', () => {
+    it('clears MFA state and saves when the code is valid', async () => {
+      const user = makeUser({
+        isMfaEnabled: true,
+        totpSecret: JSON.stringify({ iv: 'iv', content: 'enc' }),
+        mfaRecoveryCodes: ['hashed-a'],
+      });
+      encryptionService.decrypt.mockReturnValue('SECRET123');
+      (otplib.verifySync as jest.Mock).mockReturnValue({ valid: true });
+
+      const result = await service.disableMfa(user, '123456');
+
+      expect(user.isMfaEnabled).toBe(false);
+      expect(user.totpSecret).toBeNull();
+      expect(user.mfaRecoveryCodes).toEqual([]);
+      expect(result).toEqual({ success: true });
+    });
+
+    it('throws BadRequestException and leaves state untouched for an invalid code', async () => {
+      const user = makeUser({ isMfaEnabled: true, totpSecret: null });
+
+      await expect(service.disableMfa(user, 'bad')).rejects.toThrow(BadRequestException);
+      expect(user.isMfaEnabled).toBe(true);
+    });
+  });
+});

--- a/src/caching/adaptive-ttl.service.spec.ts
+++ b/src/caching/adaptive-ttl.service.spec.ts
@@ -1,0 +1,294 @@
+import { EventEmitter2 } from '@nestjs/event-emitter';
+import { AdaptiveTTLService, AdaptiveTTLRule } from './adaptive-ttl.service';
+
+jest.mock('../config/cache.config', () => ({
+  getSharedRedisClient: jest.fn(() => mockRedis),
+}));
+
+const rule: AdaptiveTTLRule = {
+  keyPattern: 'cache:course:*',
+  minTtl: 180,
+  maxTtl: 1800,
+  hitRateThreshold: 0.6,
+  accessFrequencyThreshold: 5,
+  adjustmentFactor: 1.3,
+  enabled: true,
+};
+
+let mockRedis: {
+  get: jest.Mock;
+  set: jest.Mock;
+  incr: jest.Mock;
+  zadd: jest.Mock;
+  zremrangebyrank: jest.Mock;
+  zrevrange: jest.Mock;
+  zrangebyscore: jest.Mock;
+  zremrangebyscore: jest.Mock;
+};
+
+describe('AdaptiveTTLService', () => {
+  let service: AdaptiveTTLService;
+  let eventEmitter: { emit: jest.Mock };
+  let configService: { get: jest.Mock };
+
+  beforeEach(() => {
+    mockRedis = {
+      get: jest.fn().mockResolvedValue(JSON.stringify([rule])),
+      set: jest.fn().mockResolvedValue('OK'),
+      incr: jest.fn().mockResolvedValue(1),
+      zadd: jest.fn().mockResolvedValue(1),
+      zremrangebyrank: jest.fn().mockResolvedValue(0),
+      zrevrange: jest.fn().mockResolvedValue([]),
+      zrangebyscore: jest.fn().mockResolvedValue([]),
+      zremrangebyscore: jest.fn().mockResolvedValue(0),
+    };
+    eventEmitter = { emit: jest.fn() };
+    configService = { get: jest.fn() };
+
+    service = new AdaptiveTTLService(
+      configService as never,
+      eventEmitter as unknown as EventEmitter2,
+    );
+  });
+
+  describe('getAdaptiveTTL', () => {
+    it('returns the default TTL when no rule matches the key', async () => {
+      mockRedis.get.mockResolvedValue(JSON.stringify([rule]));
+
+      const ttl = await service.getAdaptiveTTL('cache:unmatched:1', 100);
+
+      expect(ttl).toBe(100);
+    });
+
+    it('returns the default TTL when the matching rule is disabled', async () => {
+      mockRedis.get.mockResolvedValue(JSON.stringify([{ ...rule, enabled: false }]));
+
+      const ttl = await service.getAdaptiveTTL('cache:course:1', 100);
+
+      expect(ttl).toBe(100);
+    });
+
+    it('clamps the default TTL to the rule bounds when no metrics are supplied', async () => {
+      const ttl = await service.getAdaptiveTTL('cache:course:1', 10);
+      expect(ttl).toBe(rule.minTtl);
+    });
+
+    it('increases TTL and records the adjustment for high hit rate and frequency', async () => {
+      const ttl = await service.getAdaptiveTTL('cache:course:1', 500, 0.9, 10);
+
+      expect(ttl).toBe(Math.round(500 * rule.adjustmentFactor));
+      expect(mockRedis.zadd).toHaveBeenCalled();
+      expect(eventEmitter.emit).toHaveBeenCalledWith(
+        'cache.ttl.adjusted',
+        expect.objectContaining({ key: 'cache:course:1', reason: expect.any(String) }),
+      );
+    });
+
+    it('decreases TTL for a low hit rate', async () => {
+      const ttl = await service.getAdaptiveTTL('cache:course:1', 500, 0.1, 10);
+      expect(ttl).toBeLessThan(500);
+      expect(ttl).toBeGreaterThanOrEqual(rule.minTtl);
+    });
+
+    it('treats corrupt rule data as a miss and returns the default TTL', async () => {
+      mockRedis.get.mockResolvedValue('not-json');
+
+      const ttl = await service.getAdaptiveTTL('cache:course:1', 250);
+
+      expect(ttl).toBe(250);
+      expect(mockRedis.incr).toHaveBeenCalledWith('cache:metrics:deserialization_failures_total');
+    });
+  });
+
+  describe('getRecentAdjustments', () => {
+    it('parses stored adjustment records', async () => {
+      const record = {
+        key: 'k',
+        oldTtl: 1,
+        newTtl: 2,
+        reason: 'r',
+        hitRate: 1,
+        accessFrequency: 1,
+        timestamp: new Date().toISOString(),
+      };
+      mockRedis.zrevrange.mockResolvedValue([JSON.stringify(record)]);
+
+      const result = await service.getRecentAdjustments(10);
+
+      expect(result).toEqual([record]);
+      expect(mockRedis.zrevrange).toHaveBeenCalledWith(expect.any(String), 0, 9);
+    });
+
+    it('skips corrupt entries rather than throwing', async () => {
+      mockRedis.zrevrange.mockResolvedValue(['not-json']);
+
+      const result = await service.getRecentAdjustments();
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('getAdjustmentStats', () => {
+    it('aggregates increased/decreased counts and the average ratio', async () => {
+      mockRedis.zrangebyscore.mockResolvedValue([
+        JSON.stringify({ key: 'a', oldTtl: 100, newTtl: 200 }),
+        JSON.stringify({ key: 'a', oldTtl: 100, newTtl: 50 }),
+      ]);
+
+      const stats = await service.getAdjustmentStats(24);
+
+      expect(stats.totalAdjustments).toBe(2);
+      expect(stats.increasedTtl).toBe(1);
+      expect(stats.decreasedTtl).toBe(1);
+      expect(stats.topAdjustedKeys).toEqual(['a']);
+    });
+
+    it('returns a neutral average (1) when there are no adjustments in range', async () => {
+      mockRedis.zrangebyscore.mockResolvedValue([]);
+
+      const stats = await service.getAdjustmentStats();
+
+      expect(stats).toEqual({
+        totalAdjustments: 0,
+        increasedTtl: 0,
+        decreasedTtl: 0,
+        averageAdjustment: 1,
+        topAdjustedKeys: [],
+      });
+    });
+  });
+
+  describe('getRules', () => {
+    it('returns the parsed rules from Redis', async () => {
+      mockRedis.get.mockResolvedValue(JSON.stringify([rule]));
+      await expect(service.getRules()).resolves.toEqual([rule]);
+    });
+
+    it('falls back to the built-in defaults when Redis has no rules stored', async () => {
+      mockRedis.get.mockResolvedValue(null);
+      const rules = await service.getRules();
+      expect(rules.length).toBeGreaterThan(0);
+    });
+
+    it('falls back to the built-in defaults on corrupt data', async () => {
+      mockRedis.get.mockResolvedValue('not-json');
+      const rules = await service.getRules();
+      expect(rules.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('updateRules', () => {
+    it('persists the rules and emits an update event', async () => {
+      await service.updateRules([rule]);
+
+      expect(mockRedis.set).toHaveBeenCalledWith(expect.any(String), JSON.stringify([rule]));
+      expect(eventEmitter.emit).toHaveBeenCalledWith('cache.adaptive_ttl.rules_updated', [rule]);
+    });
+  });
+
+  describe('updateRule', () => {
+    it('appends a new rule when the pattern does not already exist', async () => {
+      mockRedis.get.mockResolvedValue(JSON.stringify([rule]));
+      const newRule = { ...rule, keyPattern: 'cache:new:*' };
+
+      await service.updateRule(newRule);
+
+      const persisted = JSON.parse(mockRedis.set.mock.calls[0][1]);
+      expect(persisted).toEqual(expect.arrayContaining([rule, newRule]));
+    });
+
+    it('replaces an existing rule with the same key pattern', async () => {
+      mockRedis.get.mockResolvedValue(JSON.stringify([rule]));
+      const updated = { ...rule, maxTtl: 9999 };
+
+      await service.updateRule(updated);
+
+      const persisted = JSON.parse(mockRedis.set.mock.calls[0][1]);
+      expect(persisted).toEqual([updated]);
+    });
+  });
+
+  describe('removeRule', () => {
+    it('removes a rule matching the given pattern', async () => {
+      mockRedis.get.mockResolvedValue(JSON.stringify([rule]));
+
+      await service.removeRule(rule.keyPattern);
+
+      expect(mockRedis.set).toHaveBeenCalledWith(expect.any(String), JSON.stringify([]));
+    });
+
+    it('is a no-op when no rule matches the pattern', async () => {
+      mockRedis.get.mockResolvedValue(JSON.stringify([rule]));
+
+      await service.removeRule('cache:does-not-exist:*');
+
+      expect(mockRedis.set).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('toggleRule', () => {
+    it('flips the enabled flag for a matching rule', async () => {
+      mockRedis.get.mockResolvedValue(JSON.stringify([rule]));
+
+      await service.toggleRule(rule.keyPattern, false);
+
+      const persisted = JSON.parse(mockRedis.set.mock.calls[0][1]);
+      expect(persisted[0].enabled).toBe(false);
+    });
+
+    it('is a no-op when no rule matches the pattern', async () => {
+      mockRedis.get.mockResolvedValue(JSON.stringify([rule]));
+
+      await service.toggleRule('cache:does-not-exist:*', false);
+
+      expect(mockRedis.set).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('cleanupOldAdjustments', () => {
+    it('logs when stale records were removed', async () => {
+      mockRedis.zremrangebyscore.mockResolvedValue(5);
+      await expect(service.cleanupOldAdjustments()).resolves.toBeUndefined();
+      expect(mockRedis.zremrangebyscore).toHaveBeenCalled();
+    });
+
+    it('is silent when nothing needed cleaning up', async () => {
+      mockRedis.zremrangebyscore.mockResolvedValue(0);
+      await expect(service.cleanupOldAdjustments()).resolves.toBeUndefined();
+    });
+  });
+
+  describe('handlePerformanceAnalysis', () => {
+    it('emits a recommendation when the adaptive TTL differs from the current TTL', async () => {
+      mockRedis.get.mockResolvedValue(JSON.stringify([rule]));
+
+      await service.handlePerformanceAnalysis({
+        key: 'cache:course:1',
+        hitRate: 0.9,
+        accessFrequency: 10,
+        currentTtl: 500,
+      });
+
+      expect(eventEmitter.emit).toHaveBeenCalledWith(
+        'cache.ttl.recommendation',
+        expect.objectContaining({ key: 'cache:course:1', currentTtl: 500 }),
+      );
+    });
+
+    it('does not emit a recommendation when the TTL would not change', async () => {
+      mockRedis.get.mockResolvedValue(JSON.stringify([{ ...rule, enabled: false }]));
+
+      await service.handlePerformanceAnalysis({
+        key: 'cache:course:1',
+        hitRate: 0.9,
+        accessFrequency: 10,
+        currentTtl: 500,
+      });
+
+      expect(eventEmitter.emit).not.toHaveBeenCalledWith(
+        'cache.ttl.recommendation',
+        expect.anything(),
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Closes four issues, each asking for unit test coverage on a previously-untested service:

- Closes #1265 — `AuditExportService`: `exportToJson`/`exportToCsv` (pretty-printed JSON, header + row shape, missing-optional-field fallback to `''`, CSV escaping of commas/quotes/newlines, empty-result and query-failure cases).
- Closes #1268 — `MfaService`: `generateTotpSecret` (encrypts the secret, hashes recovery codes, saves, returns the QR code + plaintext codes), `verifySetup` (missing-setup and invalid-code rejections), `verifyCode` (TOTP path, recovery-code fallback + consumption, no-match path), `disableMfa` (valid/invalid code).
- Closes #1267 — `SensitiveOperationsService`: `logSensitiveOperation` (category resolution incl. unmapped-action fallback, error propagation) plus each of the eight domain-specific wrappers (user deletion, role change, password change, config change, data export, backup create/restore, permission denied, suspicious activity), including the anonymous-actor (`null` userId/userEmail) paths.
- Closes #1269 — `AdaptiveTTLService`: `getAdaptiveTTL` (no match, disabled rule, no-metrics clamping, increase/decrease paths, corrupt-rule-data fallback), `getRecentAdjustments`/`getAdjustmentStats` (parsing + skipping corrupt records, empty-range average), `getRules`/`updateRules`/`updateRule`/`removeRule`/`toggleRule` (add vs. replace, no-op when nothing matches), `cleanupOldAdjustments`, and the `cache.performance.analyzed` event handler.

No production code was touched — this is test-only, per each issue's scope.

## Test plan

- [x] `npx jest` on all four new spec files — 59 passed, 0 failed
- [x] `npm run typecheck` (`tsconfig.build.json`) — clean
- [x] `eslint` on the new files — clean