### PR TITLE
test+feat: unit tests for audit-log/reporting/grading services + notification-preferences indexes

### DIFF
--- a/src/assessment/grading/grading.service.spec.ts
+++ b/src/assessment/grading/grading.service.spec.ts
@@ -1,0 +1,268 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { DataSource } from 'typeorm';
+import { GradingService } from './grading.service';
+import { SubmissionGrade, SubmissionGradeStatus } from './entities/submission-grade.entity';
+import { CriterionGrade } from './entities/criterion-grade.entity';
+import { AssessmentAttempt } from '../entities/assessment-attempt.entity';
+import { RubricsService } from './rubrics.service';
+import { FeedbackTemplatesService } from './feedback-templates.service';
+import { AssessmentStatus } from '../enums/assessment-status.enum';
+
+// ── Fixtures ────────────────────────────────────────────────────────────────
+
+const criterionId = 'c1';
+const levelId = 'l1';
+
+const mockLevel = { id: levelId, criterionId, points: 8, label: 'Good' };
+const mockCriterion = {
+  id: criterionId,
+  title: 'Writing',
+  maxPoints: 10,
+  defaultLevelId: levelId,
+  levels: [mockLevel],
+};
+const mockRubric = {
+  id: 'r1',
+  name: 'Essay',
+  autoGradeEnabled: true,
+  criteria: [mockCriterion],
+};
+const mockAttempt = {
+  id: 'a1',
+  score: 0,
+  status: AssessmentStatus.SUBMITTED,
+  submittedAt: null,
+};
+const mockGrade = {
+  id: 'g1',
+  attemptId: 'a1',
+  status: SubmissionGradeStatus.GRADED,
+  totalScore: 8,
+  maxScore: 10,
+  percentage: 80,
+  criterionGrades: [],
+  rubric: mockRubric,
+};
+
+// ── Mock helpers ─────────────────────────────────────────────────────────────
+
+const makeGradeRepo = () => ({
+  findOne: jest.fn(),
+  create: jest.fn().mockImplementation((v) => v),
+  save: jest.fn().mockImplementation(async (v) => v),
+});
+
+const makeCriterionGradeRepo = () => ({
+  create: jest.fn().mockImplementation((v) => v),
+  save: jest.fn().mockImplementation(async (v) => v),
+  delete: jest.fn().mockResolvedValue(undefined),
+});
+
+const makeAttemptRepo = () => ({
+  findOne: jest.fn(),
+  save: jest.fn().mockImplementation(async (v) => v),
+});
+
+const makeDataSource = (
+  gradeRepo: ReturnType<typeof makeGradeRepo>,
+  cgRepo: ReturnType<typeof makeCriterionGradeRepo>,
+  attemptRepo: ReturnType<typeof makeAttemptRepo>,
+) => ({
+  transaction: jest.fn().mockImplementation(async (cb: (manager: any) => Promise<any>) => {
+    const manager = {
+      getRepository: jest.fn().mockImplementation((entity: any) => {
+        if (entity === SubmissionGrade) return gradeRepo;
+        if (entity === CriterionGrade) return cgRepo;
+        if (entity === AssessmentAttempt) return attemptRepo;
+        return {};
+      }),
+    };
+    return cb(manager);
+  }),
+});
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('GradingService', () => {
+  let service: GradingService;
+  let gradeRepo: ReturnType<typeof makeGradeRepo>;
+  let criterionGradeRepo: ReturnType<typeof makeCriterionGradeRepo>;
+  let attemptRepo: ReturnType<typeof makeAttemptRepo>;
+  let rubricsService: { findOne: jest.Mock };
+  let feedbackTemplatesService: {
+    findOne: jest.Mock;
+    findDefault: jest.Mock;
+    render: jest.Mock;
+  };
+
+  beforeEach(async () => {
+    gradeRepo = makeGradeRepo();
+    criterionGradeRepo = makeCriterionGradeRepo();
+    attemptRepo = makeAttemptRepo();
+
+    rubricsService = { findOne: jest.fn().mockResolvedValue(mockRubric) };
+    feedbackTemplatesService = {
+      findOne: jest.fn(),
+      findDefault: jest.fn().mockResolvedValue(null),
+      render: jest.fn().mockReturnValue('Good job'),
+    };
+
+    // The outer-scope repos are used by findByAttempt; transaction uses inner repos.
+    gradeRepo.findOne
+      .mockResolvedValueOnce(null) // inside transaction: no existing grade
+      .mockResolvedValueOnce({ ...mockGrade }); // final hydrated load
+
+    attemptRepo.findOne.mockResolvedValue({ ...mockAttempt });
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        GradingService,
+        { provide: getRepositoryToken(SubmissionGrade), useValue: gradeRepo },
+        { provide: getRepositoryToken(CriterionGrade), useValue: criterionGradeRepo },
+        { provide: getRepositoryToken(AssessmentAttempt), useValue: attemptRepo },
+        { provide: RubricsService, useValue: rubricsService },
+        { provide: FeedbackTemplatesService, useValue: feedbackTemplatesService },
+        {
+          provide: DataSource,
+          useValue: makeDataSource(gradeRepo, criterionGradeRepo, attemptRepo),
+        },
+      ],
+    }).compile();
+
+    service = module.get<GradingService>(GradingService);
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  // ── gradeSubmission ────────────────────────────────────────────────────────
+
+  describe('gradeSubmission', () => {
+    it('throws BadRequestException when score count mismatches rubric criteria', async () => {
+      const dto = { rubricId: 'r1', attemptId: 'a1', scores: [] };
+      await expect(service.gradeSubmission(dto)).rejects.toThrow(BadRequestException);
+    });
+
+    it('throws BadRequestException for unknown criterionId', async () => {
+      const dto = {
+        rubricId: 'r1',
+        attemptId: 'a1',
+        scores: [{ criterionId: 'unknown', points: 5 }],
+      };
+      await expect(service.gradeSubmission(dto)).rejects.toThrow(BadRequestException);
+    });
+
+    it('throws BadRequestException when the same criterion is scored twice', async () => {
+      const twoScoreSameRubric = {
+        ...mockRubric,
+        criteria: [
+          { ...mockCriterion, id: 'c1' },
+          { ...mockCriterion, id: 'c2' },
+        ],
+      };
+      rubricsService.findOne.mockResolvedValue(twoScoreSameRubric);
+
+      const dto = {
+        rubricId: 'r1',
+        attemptId: 'a1',
+        scores: [
+          { criterionId: 'c1', points: 5 },
+          { criterionId: 'c1', points: 3 }, // duplicate
+        ],
+      };
+      await expect(service.gradeSubmission(dto)).rejects.toThrow(BadRequestException);
+    });
+
+    it('throws BadRequestException when criterion score has neither levelId nor points', async () => {
+      const dto = {
+        rubricId: 'r1',
+        attemptId: 'a1',
+        scores: [{ criterionId }],
+      };
+      await expect(service.gradeSubmission(dto)).rejects.toThrow(BadRequestException);
+    });
+
+    it('caps points at criterion maxPoints', async () => {
+      const dto = {
+        rubricId: 'r1',
+        attemptId: 'a1',
+        scores: [{ criterionId, points: 999 }],
+      };
+      await service.gradeSubmission(dto);
+      // grade should be saved with totalScore = 10 (capped)
+      const savedGrade = gradeRepo.save.mock.calls[0][0];
+      expect(savedGrade.totalScore).toBe(10);
+    });
+
+    it('resolves points from levelId when provided', async () => {
+      const dto = {
+        rubricId: 'r1',
+        attemptId: 'a1',
+        scores: [{ criterionId, levelId }],
+      };
+      await service.gradeSubmission(dto);
+      const savedGrade = gradeRepo.save.mock.calls[0][0];
+      expect(savedGrade.totalScore).toBe(8);
+    });
+
+    it('throws NotFoundException for missing attempt', async () => {
+      attemptRepo.findOne.mockResolvedValue(null);
+      const dto = {
+        rubricId: 'r1',
+        attemptId: 'missing',
+        scores: [{ criterionId, points: 5 }],
+      };
+      await expect(service.gradeSubmission(dto)).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  // ── autoGradeSubmission ────────────────────────────────────────────────────
+
+  describe('autoGradeSubmission', () => {
+    it('throws BadRequestException when rubric is not auto-grade enabled', async () => {
+      rubricsService.findOne.mockResolvedValue({ ...mockRubric, autoGradeEnabled: false });
+      await expect(
+        service.autoGradeSubmission({ rubricId: 'r1', attemptId: 'a1' }),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('throws BadRequestException when a criterion has no defaultLevelId', async () => {
+      rubricsService.findOne.mockResolvedValue({
+        ...mockRubric,
+        criteria: [{ ...mockCriterion, defaultLevelId: null }],
+      });
+      await expect(
+        service.autoGradeSubmission({ rubricId: 'r1', attemptId: 'a1' }),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('auto-grades using default level points', async () => {
+      await service.autoGradeSubmission({ rubricId: 'r1', attemptId: 'a1' });
+      const savedGrade = gradeRepo.save.mock.calls[0][0];
+      expect(savedGrade.totalScore).toBe(8);
+      expect(savedGrade.status).toBe(SubmissionGradeStatus.AUTO_GRADED);
+    });
+  });
+
+  // ── findByAttempt ──────────────────────────────────────────────────────────
+
+  describe('findByAttempt', () => {
+    it('returns the grade for an attempt', async () => {
+      gradeRepo.findOne.mockReset();
+      gradeRepo.findOne.mockResolvedValue(mockGrade);
+      const result = await service.findByAttempt('a1');
+      expect(result).toBe(mockGrade);
+    });
+
+    it('throws NotFoundException when no grade exists for the attempt', async () => {
+      gradeRepo.findOne.mockReset();
+      gradeRepo.findOne.mockResolvedValue(null);
+      await expect(service.findByAttempt('missing')).rejects.toThrow(NotFoundException);
+    });
+  });
+});

--- a/src/audit-log/audit-log.service.spec.ts
+++ b/src/audit-log/audit-log.service.spec.ts
@@ -1,0 +1,327 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { AuditLogService } from './audit-log.service';
+import { AuditLoggerService } from './services/audit-logger.service';
+import { AuditQueryService } from './services/audit-query.service';
+import { AuditReportingService } from './services/audit-reporting.service';
+import { AuditExportService } from './services/audit-export.service';
+import { AuditAction, AuditSeverity, AuditCategory } from './enums/audit-action.enum';
+import { AuditLog, HttpMethod } from './audit-log.entity';
+import { IAuditLogSearchResult, IAuditReport } from './interfaces/audit-log.interfaces';
+
+const mockLog = { id: 'log-1', action: AuditAction.LOGIN } as AuditLog;
+
+const mockLoggerService = {
+  log: jest.fn().mockResolvedValue(mockLog),
+  logAuth: jest.fn().mockResolvedValue(mockLog),
+  logDataChange: jest.fn().mockResolvedValue(mockLog),
+  logApiAccess: jest.fn().mockResolvedValue(mockLog),
+  logSecurityEvent: jest.fn().mockResolvedValue(mockLog),
+  applyRetentionPolicy: jest.fn().mockResolvedValue(42),
+};
+
+const mockQueryService = {
+  search: jest.fn(),
+  findAll: jest.fn().mockResolvedValue([mockLog]),
+  findByUser: jest.fn().mockResolvedValue([mockLog]),
+  findByAction: jest.fn().mockResolvedValue([mockLog]),
+  findByEntity: jest.fn().mockResolvedValue([mockLog]),
+  findByIpAddress: jest.fn().mockResolvedValue([mockLog]),
+  findByDateRange: jest.fn().mockResolvedValue([mockLog]),
+};
+
+const mockReportingService = {
+  generateReport: jest.fn(),
+  getStatistics: jest.fn(),
+};
+
+const mockExportService = {
+  exportToJson: jest.fn().mockResolvedValue('[]'),
+  exportToCsv: jest.fn().mockResolvedValue(''),
+};
+
+describe('AuditLogService', () => {
+  let service: AuditLogService;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AuditLogService,
+        { provide: AuditLoggerService, useValue: mockLoggerService },
+        { provide: AuditQueryService, useValue: mockQueryService },
+        { provide: AuditReportingService, useValue: mockReportingService },
+        { provide: AuditExportService, useValue: mockExportService },
+      ],
+    }).compile();
+
+    service = module.get<AuditLogService>(AuditLogService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  // ── Write ──────────────────────────────────────────────────────────────────
+
+  describe('log', () => {
+    it('delegates to loggerService.log and returns result', async () => {
+      const entry = {
+        action: AuditAction.USER_CREATED,
+        category: AuditCategory.DATA_MODIFICATION,
+      };
+      const result = await service.log(entry);
+      expect(mockLoggerService.log).toHaveBeenCalledWith(entry);
+      expect(result).toBe(mockLog);
+    });
+  });
+
+  describe('logAuth', () => {
+    it('passes all options to loggerService.logAuth', async () => {
+      await service.logAuth({
+        action: AuditAction.LOGIN,
+        userId: 'u1',
+        userEmail: 'u@x.com',
+        ipAddress: '1.2.3.4',
+        userAgent: 'jest',
+      });
+      expect(mockLoggerService.logAuth).toHaveBeenCalledWith(
+        AuditAction.LOGIN,
+        'u1',
+        'u@x.com',
+        '1.2.3.4',
+        'jest',
+        undefined,
+        AuditSeverity.INFO,
+      );
+    });
+
+    it('uses provided severity instead of default INFO', async () => {
+      await service.logAuth({
+        action: AuditAction.LOGIN_FAILED,
+        userId: null,
+        userEmail: null,
+        ipAddress: '1.2.3.4',
+        userAgent: 'jest',
+        severity: AuditSeverity.WARNING,
+      });
+      expect(mockLoggerService.logAuth).toHaveBeenCalledWith(
+        AuditAction.LOGIN_FAILED,
+        null,
+        null,
+        '1.2.3.4',
+        'jest',
+        undefined,
+        AuditSeverity.WARNING,
+      );
+    });
+  });
+
+  describe('logDataChange', () => {
+    it('passes all options to loggerService.logDataChange', async () => {
+      await service.logDataChange({
+        action: AuditAction.USER_UPDATED,
+        userId: 'u1',
+        userEmail: 'u@x.com',
+        entityType: 'User',
+        entityId: 'e1',
+        oldValues: { name: 'old' },
+        newValues: { name: 'new' },
+      });
+      expect(mockLoggerService.logDataChange).toHaveBeenCalledWith(
+        AuditAction.USER_UPDATED,
+        'u1',
+        'u@x.com',
+        'User',
+        'e1',
+        { name: 'old' },
+        { name: 'new' },
+        undefined,
+        undefined,
+      );
+    });
+  });
+
+  describe('logApiAccess', () => {
+    it('passes all options to loggerService.logApiAccess', async () => {
+      await service.logApiAccess({
+        userId: 'u1',
+        userEmail: 'u@x.com',
+        apiEndpoint: '/v1/users',
+        httpMethod: HttpMethod.GET,
+        statusCode: 200,
+        responseTimeMs: 50,
+        ipAddress: '1.2.3.4',
+        userAgent: 'jest',
+      });
+      expect(mockLoggerService.logApiAccess).toHaveBeenCalledWith(
+        'u1',
+        'u@x.com',
+        '/v1/users',
+        HttpMethod.GET,
+        200,
+        50,
+        '1.2.3.4',
+        'jest',
+        undefined,
+      );
+    });
+  });
+
+  describe('logSecurityEvent', () => {
+    it('passes all options to loggerService.logSecurityEvent', async () => {
+      await service.logSecurityEvent({
+        action: AuditAction.SUSPICIOUS_ACTIVITY,
+        userId: null,
+        userEmail: null,
+        ipAddress: '1.2.3.4',
+        userAgent: 'jest',
+        description: 'brute force',
+      });
+      expect(mockLoggerService.logSecurityEvent).toHaveBeenCalledWith(
+        AuditAction.SUSPICIOUS_ACTIVITY,
+        null,
+        null,
+        '1.2.3.4',
+        'jest',
+        'brute force',
+        undefined,
+      );
+    });
+  });
+
+  // ── Query ──────────────────────────────────────────────────────────────────
+
+  describe('search', () => {
+    it('delegates to queryService.search with defaults', async () => {
+      const result: IAuditLogSearchResult = {
+        data: [],
+        total: 0,
+        page: 1,
+        limit: 50,
+        totalPages: 0,
+        hasNextPage: false,
+        hasPrevPage: false,
+      };
+      mockQueryService.search.mockResolvedValue(result);
+      const filters = { userId: 'u1' };
+      const out = await service.search(filters);
+      expect(mockQueryService.search).toHaveBeenCalledWith(filters, 1, 50, undefined, undefined);
+      expect(out).toBe(result);
+    });
+  });
+
+  describe('findAll', () => {
+    it('delegates to queryService.findAll', async () => {
+      const out = await service.findAll(10);
+      expect(mockQueryService.findAll).toHaveBeenCalledWith(10);
+      expect(out).toEqual([mockLog]);
+    });
+  });
+
+  describe('findByUser', () => {
+    it('delegates to queryService.findByUser', async () => {
+      await service.findByUser('u1', 5);
+      expect(mockQueryService.findByUser).toHaveBeenCalledWith('u1', 5);
+    });
+  });
+
+  describe('findByAction', () => {
+    it('delegates to queryService.findByAction', async () => {
+      await service.findByAction(AuditAction.LOGIN);
+      expect(mockQueryService.findByAction).toHaveBeenCalledWith(AuditAction.LOGIN, 100);
+    });
+  });
+
+  describe('findByEntity', () => {
+    it('delegates to queryService.findByEntity', async () => {
+      await service.findByEntity('User', 'e1');
+      expect(mockQueryService.findByEntity).toHaveBeenCalledWith('User', 'e1', 100);
+    });
+  });
+
+  describe('findByIpAddress', () => {
+    it('delegates to queryService.findByIpAddress', async () => {
+      await service.findByIpAddress('1.2.3.4');
+      expect(mockQueryService.findByIpAddress).toHaveBeenCalledWith('1.2.3.4', 100);
+    });
+  });
+
+  describe('findByDateRange', () => {
+    it('delegates to queryService.findByDateRange', async () => {
+      const start = new Date('2024-01-01');
+      const end = new Date('2024-01-31');
+      await service.findByDateRange(start, end);
+      expect(mockQueryService.findByDateRange).toHaveBeenCalledWith(start, end, 1000);
+    });
+  });
+
+  // ── Reporting ──────────────────────────────────────────────────────────────
+
+  describe('generateReport', () => {
+    it('delegates to reportingService.generateReport', async () => {
+      const report: IAuditReport = {
+        period: { start: new Date(), end: new Date() },
+        totalEvents: 0,
+        eventsByCategory: {},
+        eventsByAction: {},
+        eventsBySeverity: {},
+        topUsers: [],
+        topEndpoints: [],
+        failedActions: [],
+      };
+      mockReportingService.generateReport.mockResolvedValue(report);
+      const start = new Date('2024-01-01');
+      const end = new Date('2024-01-31');
+      const out = await service.generateReport(start, end);
+      expect(mockReportingService.generateReport).toHaveBeenCalledWith(start, end);
+      expect(out).toBe(report);
+    });
+  });
+
+  describe('getStatistics', () => {
+    it('delegates to reportingService.getStatistics', async () => {
+      const stats = {
+        totalLogs: 100,
+        logsToday: 5,
+        logsThisWeek: 20,
+        logsThisMonth: 80,
+        criticalEvents: 1,
+        errorEvents: 3,
+      };
+      mockReportingService.getStatistics.mockResolvedValue(stats);
+      const out = await service.getStatistics();
+      expect(mockReportingService.getStatistics).toHaveBeenCalled();
+      expect(out).toBe(stats);
+    });
+  });
+
+  // ── Maintenance ────────────────────────────────────────────────────────────
+
+  describe('applyRetentionPolicy', () => {
+    it('delegates to loggerService.applyRetentionPolicy and returns count', async () => {
+      const out = await service.applyRetentionPolicy();
+      expect(mockLoggerService.applyRetentionPolicy).toHaveBeenCalled();
+      expect(out).toBe(42);
+    });
+  });
+
+  // ── Export ─────────────────────────────────────────────────────────────────
+
+  describe('exportToJson', () => {
+    it('delegates to exportService.exportToJson', async () => {
+      const filters = { userId: 'u1' };
+      const out = await service.exportToJson(filters);
+      expect(mockExportService.exportToJson).toHaveBeenCalledWith(filters);
+      expect(out).toBe('[]');
+    });
+  });
+
+  describe('exportToCsv', () => {
+    it('delegates to exportService.exportToCsv', async () => {
+      const filters = { userId: 'u1' };
+      await service.exportToCsv(filters);
+      expect(mockExportService.exportToCsv).toHaveBeenCalledWith(filters);
+    });
+  });
+});

--- a/src/audit-log/services/audit-reporting.service.spec.ts
+++ b/src/audit-log/services/audit-reporting.service.spec.ts
@@ -1,0 +1,183 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { AuditReportingService } from './audit-reporting.service';
+import { AuditLog } from '../audit-log.entity';
+import { AuditSeverity } from '../enums/audit-action.enum';
+
+const makeQb = (overrides: Record<string, jest.Mock> = {}) => ({
+  where: jest.fn().mockReturnThis(),
+  andWhere: jest.fn().mockReturnThis(),
+  select: jest.fn().mockReturnThis(),
+  addSelect: jest.fn().mockReturnThis(),
+  groupBy: jest.fn().mockReturnThis(),
+  addGroupBy: jest.fn().mockReturnThis(),
+  orderBy: jest.fn().mockReturnThis(),
+  limit: jest.fn().mockReturnThis(),
+  getCount: jest.fn().mockResolvedValue(0),
+  getRawMany: jest.fn().mockResolvedValue([]),
+  ...overrides,
+});
+
+describe('AuditReportingService', () => {
+  let service: AuditReportingService;
+  let mockRepo: {
+    createQueryBuilder: jest.Mock;
+    count: jest.Mock;
+  };
+
+  beforeEach(async () => {
+    mockRepo = {
+      createQueryBuilder: jest.fn(),
+      count: jest.fn().mockResolvedValue(0),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AuditReportingService,
+        { provide: getRepositoryToken(AuditLog), useValue: mockRepo },
+      ],
+    }).compile();
+
+    service = module.get<AuditReportingService>(AuditReportingService);
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  // ── generateReport ─────────────────────────────────────────────────────────
+
+  describe('generateReport', () => {
+    it('returns a report with correct period and zero totals when repo returns nothing', async () => {
+      mockRepo.createQueryBuilder.mockReturnValue(makeQb());
+
+      const start = new Date('2024-01-01');
+      const end = new Date('2024-01-31');
+      const report = await service.generateReport(start, end);
+
+      expect(report.period.start).toBe(start);
+      expect(report.period.end).toBe(end);
+      expect(report.totalEvents).toBe(0);
+      expect(report.eventsByCategory).toEqual({});
+      expect(report.eventsByAction).toEqual({});
+      expect(report.eventsBySeverity).toEqual({});
+      expect(report.topUsers).toEqual([]);
+      expect(report.topEndpoints).toEqual([]);
+      expect(report.failedActions).toEqual([]);
+    });
+
+    it('aggregates category, action and severity stats correctly', async () => {
+      let callCount = 0;
+      mockRepo.createQueryBuilder.mockImplementation(() => {
+        callCount++;
+        if (callCount === 1) {
+          // total count query
+          return makeQb({ getCount: jest.fn().mockResolvedValue(3) });
+        }
+        if (callCount === 2) {
+          // category stats
+          return makeQb({
+            getRawMany: jest.fn().mockResolvedValue([{ category: 'AUTHENTICATION', count: '2' }]),
+          });
+        }
+        if (callCount === 3) {
+          // action stats
+          return makeQb({
+            getRawMany: jest.fn().mockResolvedValue([{ action: 'LOGIN', count: '1' }]),
+          });
+        }
+        if (callCount === 4) {
+          // severity stats
+          return makeQb({
+            getRawMany: jest.fn().mockResolvedValue([{ severity: 'INFO', count: '3' }]),
+          });
+        }
+        // top users, top endpoints, failed actions
+        return makeQb();
+      });
+
+      const report = await service.generateReport(new Date(), new Date());
+
+      expect(report.totalEvents).toBe(3);
+      expect(report.eventsByCategory).toEqual({ AUTHENTICATION: 2 });
+      expect(report.eventsByAction).toEqual({ LOGIN: 1 });
+      expect(report.eventsBySeverity).toEqual({ INFO: 3 });
+    });
+
+    it('maps top users with integer counts', async () => {
+      let callCount = 0;
+      mockRepo.createQueryBuilder.mockImplementation(() => {
+        callCount++;
+        if (callCount === 5) {
+          // top users query (5th query builder call)
+          return makeQb({
+            getRawMany: jest
+              .fn()
+              .mockResolvedValue([{ userId: 'u1', userEmail: 'u@x.com', count: '10' }]),
+          });
+        }
+        return makeQb();
+      });
+
+      const report = await service.generateReport(new Date(), new Date());
+      expect(report.topUsers[0]).toEqual({ userId: 'u1', userEmail: 'u@x.com', count: 10 });
+    });
+
+    it('uses "Unknown" as fallback when userEmail is null', async () => {
+      let callCount = 0;
+      mockRepo.createQueryBuilder.mockImplementation(() => {
+        callCount++;
+        if (callCount === 5) {
+          return makeQb({
+            getRawMany: jest
+              .fn()
+              .mockResolvedValue([{ userId: 'u2', userEmail: null, count: '1' }]),
+          });
+        }
+        return makeQb();
+      });
+
+      const report = await service.generateReport(new Date(), new Date());
+      expect(report.topUsers[0].userEmail).toBe('Unknown');
+    });
+  });
+
+  // ── getStatistics ──────────────────────────────────────────────────────────
+
+  describe('getStatistics', () => {
+    it('returns all counters from parallel count queries', async () => {
+      mockRepo.count
+        .mockResolvedValueOnce(500) // totalLogs
+        .mockResolvedValueOnce(10) // logsToday
+        .mockResolvedValueOnce(50) // logsThisWeek
+        .mockResolvedValueOnce(200) // logsThisMonth
+        .mockResolvedValueOnce(3) // criticalEvents
+        .mockResolvedValueOnce(7); // errorEvents
+
+      const stats = await service.getStatistics();
+
+      expect(stats).toEqual({
+        totalLogs: 500,
+        logsToday: 10,
+        logsThisWeek: 50,
+        logsThisMonth: 200,
+        criticalEvents: 3,
+        errorEvents: 7,
+      });
+    });
+
+    it('calls count with CRITICAL severity for criticalEvents', async () => {
+      mockRepo.count.mockResolvedValue(0);
+
+      await service.getStatistics();
+
+      const calls = mockRepo.count.mock.calls;
+      // 5th call (index 4) should filter by CRITICAL
+      expect(calls[4][0]).toMatchObject({ where: { severity: AuditSeverity.CRITICAL } });
+      // 6th call (index 5) should filter by ERROR
+      expect(calls[5][0]).toMatchObject({ where: { severity: AuditSeverity.ERROR } });
+    });
+  });
+});

--- a/src/migrations/1800000000000-add-notification-preferences-indexes.ts
+++ b/src/migrations/1800000000000-add-notification-preferences-indexes.ts
@@ -1,0 +1,24 @@
+import { MigrationInterface, QueryRunner, TableIndex } from 'typeorm';
+
+export class AddNotificationPreferencesIndexes1800000000000 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.createIndices('notification_preferences', [
+      new TableIndex({
+        name: 'IDX_notification_preferences_user_id',
+        columnNames: ['userId'],
+      }),
+      new TableIndex({
+        name: 'IDX_notification_preferences_global_unsub',
+        columnNames: ['globalUnsubscribe'],
+      }),
+    ]);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropIndex(
+      'notification_preferences',
+      'IDX_notification_preferences_global_unsub',
+    );
+    await queryRunner.dropIndex('notification_preferences', 'IDX_notification_preferences_user_id');
+  }
+}

--- a/src/notifications/entities/notification-preferences.entity.ts
+++ b/src/notifications/entities/notification-preferences.entity.ts
@@ -7,6 +7,7 @@ import {
   CreateDateColumn,
   UpdateDateColumn,
   VersionColumn,
+  Index,
 } from 'typeorm';
 import { User } from '../../users/entities/user.entity';
 
@@ -22,6 +23,7 @@ export class NotificationPreferences {
   version: number;
 
   @Column()
+  @Index('IDX_notification_preferences_user_id')
   userId: string;
 
   @OneToOne(() => User, { onDelete: 'CASCADE' })
@@ -48,6 +50,7 @@ export class NotificationPreferences {
   eventFrequency: Record<string, 'instant' | 'daily' | 'weekly' | 'never'>;
 
   @Column({ default: false })
+  @Index('IDX_notification_preferences_global_unsub')
   globalUnsubscribe: boolean;
 
   @Column({ type: 'varchar', default: '09:00' })


### PR DESCRIPTION
## Summary

Resolves four assigned issues in a single PR.

### Changes

- **#1264** — `src/audit-log/audit-log.service.spec.ts`: unit tests covering all public methods of the `AuditLogService` facade (log, logAuth, logDataChange, logApiAccess, logSecurityEvent, search, findAll, findByUser, findByAction, findByEntity, findByIpAddress, findByDateRange, generateReport, getStatistics, applyRetentionPolicy, exportToJson, exportToCsv)
- **#1266** — `src/audit-log/services/audit-reporting.service.spec.ts`: unit tests for `AuditReportingService` covering `generateReport` (zero totals, aggregations, top-users mapping, Unknown email fallback) and `getStatistics` (parallel counts, correct severity filters)
- **#1261** — `src/assessment/grading/grading.service.spec.ts`: unit tests for `GradingService` covering `gradeSubmission` (score mismatch, unknown criterion, duplicate criterion, missing level/points, point capping, levelId resolution, missing attempt) and `autoGradeSubmission` (not enabled, missing default level, happy path) and `findByAttempt` (found, not found)
- **#1248** — `@Index` decorators added to `notification-preferences.entity.ts` (`userId`, `globalUnsubscribe`) plus migration `1800000000000-add-notification-preferences-indexes.ts` to create the indexes on existing databases

### CI
- Lint: 0 errors ✅
- TypeScript typecheck: clean ✅
- Build: passes ✅
- migrations:check: all 33 files pass ✅

Closes #1264
Closes #1266
Closes #1261
Closes #1248