### PR TITLE
Add unit tests for graceful-shutdown service + Add unit tests for request-router service

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -168,7 +168,7 @@
         "prettier": "^3.0.0",
         "source-map-support": "^0.5.21",
         "supertest": "^7.0.0",
-        "ts-jest": "^29.1.0",
+        "ts-jest": "^29.4.12",
         "ts-loader": "^9.5.7",
         "ts-node": "^10.9.1",
         "tsconfig-paths": "^4.2.0",
@@ -24433,9 +24433,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/semver": {
-      "version": "7.8.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
-      "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -25961,9 +25961,9 @@
       }
     },
     "node_modules/ts-jest": {
-      "version": "29.4.11",
-      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.11.tgz",
-      "integrity": "sha512-IrFl7l9AuB/qrNw5quqvAv/hmKMb8dhWOH4jQOGo0Oq8tCeo1O86/iTFG1FaRimgUkF13l4PcepO8ATFT6Ns4g==",
+      "version": "29.4.12",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.12.tgz",
+      "integrity": "sha512-Ov6ClY53Fflh6BGAnY2DlTq1hYDrTycz2PVTXBWFW2CU+9zrEqAp9fWdGXl42EXO5RLSFAcAZ2JFKbP+zBTFfw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -25973,7 +25973,7 @@
         "json5": "^2.2.3",
         "lodash.memoize": "^4.1.2",
         "make-error": "^1.3.6",
-        "semver": "^7.8.0",
+        "semver": "^7.8.5",
         "type-fest": "^4.41.0",
         "yargs-parser": "^21.1.1"
       },

--- a/package.json
+++ b/package.json
@@ -233,7 +233,7 @@
     "prettier": "^3.0.0",
     "source-map-support": "^0.5.21",
     "supertest": "^7.0.0",
-    "ts-jest": "^29.1.0",
+    "ts-jest": "^29.4.12",
     "ts-loader": "^9.5.7",
     "ts-node": "^10.9.1",
     "tsconfig-paths": "^4.2.0",

--- a/src/common/request-router.service.spec.ts
+++ b/src/common/request-router.service.spec.ts
@@ -1,0 +1,113 @@
+import { RequestRouterService, RouteTarget } from './request-router.service';
+
+describe('RequestRouterService', () => {
+  let service: RequestRouterService;
+
+  beforeEach(() => {
+    service = new RequestRouterService();
+  });
+
+  describe('selectTarget', () => {
+    it('returns the only target when a single target is provided', () => {
+      const targets: RouteTarget[] = [{ host: 'a.example.com', weight: 1 }];
+
+      const result = service.selectTarget(targets);
+
+      expect(result).toEqual(targets[0]);
+    });
+
+    it('throws when an empty array is provided', () => {
+      expect(() => service.selectTarget([])).toThrow('No targets available');
+    });
+
+    it('always selects the sole target when all weight is on one entry', () => {
+      const targets: RouteTarget[] = [
+        { host: 'a.example.com', weight: 100 },
+        { host: 'b.example.com', weight: 0 },
+      ];
+
+      // Mock Math.random to return 0.5 — should hit the first target (weight 100).
+      jest.spyOn(Math, 'random').mockReturnValue(0.5);
+
+      const result = service.selectTarget(targets);
+
+      expect(result.host).toBe('a.example.com');
+    });
+
+    it('selects the second target when random falls into its weight range', () => {
+      const targets: RouteTarget[] = [
+        { host: 'a.example.com', weight: 1 },
+        { host: 'b.example.com', weight: 99 },
+      ];
+
+      // random=0.99 → after subtracting first weight (1) → 0.89 * 100 = 89 → hits second target
+      jest.spyOn(Math, 'random').mockReturnValue(0.99);
+
+      const result = service.selectTarget(targets);
+
+      expect(result.host).toBe('b.example.com');
+    });
+
+    it('selects the first target when random is zero', () => {
+      const targets: RouteTarget[] = [
+        { host: 'a.example.com', weight: 10 },
+        { host: 'b.example.com', weight: 10 },
+      ];
+
+      jest.spyOn(Math, 'random').mockReturnValue(0);
+
+      const result = service.selectTarget(targets);
+
+      expect(result.host).toBe('a.example.com');
+    });
+
+    it('returns the last target as a fallback when random equals total weight', () => {
+      const targets: RouteTarget[] = [
+        { host: 'a.example.com', weight: 5 },
+        { host: 'b.example.com', weight: 5 },
+      ];
+
+      // random=1 → totalWeight=10, random*totalWeight=10 → loop subtracts 5 then 5 → falls through to fallback
+      jest.spyOn(Math, 'random').mockReturnValue(1);
+
+      const result = service.selectTarget(targets);
+
+      // With random=1, random * totalWeight = 10. After subtracting both weights (5+5=10),
+      // random becomes 0, which satisfies `random <= 0` on the second iteration.
+      expect(result.host).toBe('b.example.com');
+    });
+
+    it('handles targets with fractional weights', () => {
+      const targets: RouteTarget[] = [
+        { host: 'a.example.com', weight: 0.3 },
+        { host: 'b.example.com', weight: 0.7 },
+      ];
+
+      // random=0.4, totalWeight=1.0, so randomValue=0.4. First target (0.3) subtracts to 0.1>0,
+      // second target (0.7) subtracts to -0.6<=0 → selects second target.
+      jest.spyOn(Math, 'random').mockReturnValue(0.4);
+
+      const result = service.selectTarget(targets);
+
+      expect(result).toEqual(targets[1]);
+    });
+
+    it('covers the fallback branch when floating-point precision skips the <= 0 check', () => {
+      // With weights (0.1, 0.2), Math.random() = 0.9999999999999999 produces a value
+      // so close to totalWeight that float subtraction leaves a tiny positive remainder
+      // after the last iteration, falling through to the fallback return.
+      const targets: RouteTarget[] = [
+        { host: 'a.example.com', weight: 0.1 },
+        { host: 'b.example.com', weight: 0.2 },
+      ];
+
+      jest.spyOn(Math, 'random').mockReturnValue(0.9999999999999999);
+
+      const result = service.selectTarget(targets);
+
+      // The fallback always returns the last element, so regardless of whether
+      // the loop or the fallback handles it, the result is the last target.
+      expect(result.host).toBe('b.example.com');
+    });
+  });
+});

--- a/src/common/services/graceful-shutdown.service.spec.ts
+++ b/src/common/services/graceful-shutdown.service.spec.ts
@@ -1,0 +1,281 @@
+import { GracefulShutdownService, ShutdownPhase } from './graceful-shutdown.service';
+import { ShutdownStateService } from './shutdown-state.service';
+import { DataSource } from 'typeorm';
+
+describe('GracefulShutdownService', () => {
+  let service: GracefulShutdownService;
+  let shutdownState: ShutdownStateService;
+  let dataSource: DataSource;
+
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    // Disable the global force-exit timeout so tests don't call process.exit
+    process.env.FORCE_EXIT_ON_TIMEOUT = 'false';
+
+    shutdownState = { markShuttingDown: jest.fn() } as unknown as ShutdownStateService;
+    dataSource = {} as DataSource;
+
+    service = new GracefulShutdownService(shutdownState, dataSource);
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+    jest.restoreAllMocks();
+  });
+
+  // ── registerShutdownPhase ────────────────────────────────────────────────
+
+  describe('registerShutdownPhase', () => {
+    it('increments the registered phase count', () => {
+      expect(service.getShutdownStatus().registeredPhases).toBe(0);
+
+      service.registerShutdownPhase({ name: 'phase-1', timeout: 1000, execute: jest.fn() });
+
+      expect(service.getShutdownStatus().registeredPhases).toBe(1);
+    });
+
+    it('allows registering multiple phases', () => {
+      service.registerShutdownPhase({ name: 'a', timeout: 1000, execute: jest.fn() });
+      service.registerShutdownPhase({ name: 'b', timeout: 2000, execute: jest.fn() });
+
+      expect(service.getShutdownStatus().registeredPhases).toBe(2);
+    });
+  });
+
+  // ── isShutdownInProgress ─────────────────────────────────────────────────
+
+  describe('isShutdownInProgress', () => {
+    it('returns false before shutdown starts', () => {
+      expect(service.isShutdownInProgress()).toBe(false);
+    });
+
+    it('returns true after shutdown starts', async () => {
+      let resolvePhase!: () => void;
+      service.registerShutdownPhase({
+        name: 'blocking',
+        timeout: 5000,
+        execute: () => new Promise<void>((r) => { resolvePhase = r; }),
+      });
+
+      const shutdownPromise = service.shutdown();
+      // Give microtasks a chance to run
+      await new Promise((r) => setTimeout(r, 0));
+
+      expect(service.isShutdownInProgress()).toBe(true);
+
+      resolvePhase();
+      await shutdownPromise;
+    });
+  });
+
+  // ── getShutdownStatus ────────────────────────────────────────────────────
+
+  describe('getShutdownStatus', () => {
+    it('returns initial status before shutdown', () => {
+      const status = service.getShutdownStatus();
+
+      expect(status).toEqual({
+        isShuttingDown: false,
+        registeredPhases: 0,
+        globalTimeout: 30000,
+      });
+    });
+
+    it('reads globalTimeout from environment variable', () => {
+      process.env.SHUTDOWN_TIMEOUT_MS = '10000';
+      const fresh = new GracefulShutdownService(shutdownState, dataSource);
+
+      expect(fresh.getShutdownStatus().globalTimeout).toBe(10000);
+    });
+
+    it('defaults globalTimeout to 30000 when env var is unset', () => {
+      delete process.env.SHUTDOWN_TIMEOUT_MS;
+      const fresh = new GracefulShutdownService(shutdownState, dataSource);
+
+      expect(fresh.getShutdownStatus().globalTimeout).toBe(30000);
+    });
+
+    it('returns NaN when SHUTDOWN_TIMEOUT_MS is non-numeric', () => {
+      process.env.SHUTDOWN_TIMEOUT_MS = 'not-a-number';
+      const fresh = new GracefulShutdownService(shutdownState, dataSource);
+
+      // parseInt('not-a-number', 10) is NaN — the service does not guard against this
+      expect(fresh.getShutdownStatus().globalTimeout).toBeNaN();
+    });
+  });
+
+  // ── shutdown ─────────────────────────────────────────────────────────────
+
+  describe('shutdown', () => {
+    it('marks the state service as shutting down', async () => {
+      service.registerShutdownPhase({ name: 'p', timeout: 1000, execute: jest.fn() });
+
+      await service.shutdown('SIGTERM');
+
+      expect(shutdownState.markShuttingDown).toHaveBeenCalledTimes(1);
+    });
+
+    it('executes a single registered phase', async () => {
+      const execute = jest.fn().mockResolvedValue(undefined);
+      service.registerShutdownPhase({ name: 'cleanup', timeout: 5000, execute });
+
+      await service.shutdown();
+
+      expect(execute).toHaveBeenCalledTimes(1);
+    });
+
+    it('executes phases in order of ascending timeout', async () => {
+      const order: string[] = [];
+      const make = (name: string, timeout: number): ShutdownPhase => ({
+        name,
+        timeout,
+        execute: jest.fn().mockImplementation(async () => { order.push(name); }),
+      });
+
+      // Register in reverse priority order
+      service.registerShutdownPhase(make('slow', 5000));
+      service.registerShutdownPhase(make('fast', 100));
+      service.registerShutdownPhase(make('mid', 1000));
+
+      await service.shutdown();
+
+      expect(order).toEqual(['fast', 'mid', 'slow']);
+    });
+
+    it('resolves without error when no phases are registered', async () => {
+      await expect(service.shutdown()).resolves.toBeUndefined();
+    });
+
+    it('continues executing remaining phases after a phase throws', async () => {
+      const afterExecute = jest.fn().mockResolvedValue(undefined);
+
+      service.registerShutdownPhase({
+        name: 'failing',
+        timeout: 5000,
+        execute: jest.fn().mockRejectedValue(new Error('boom')),
+      });
+      service.registerShutdownPhase({
+        name: 'after-failure',
+        timeout: 5000,
+        execute: afterExecute,
+      });
+
+      await service.shutdown();
+
+      expect(afterExecute).toHaveBeenCalledTimes(1);
+    });
+
+    it('continues executing remaining phases after a phase times out', async () => {
+      const afterExecute = jest.fn().mockResolvedValue(undefined);
+
+      service.registerShutdownPhase({
+        name: 'slow',
+        timeout: 1, // 1 ms timeout — will race against a 5s delay
+        execute: () => new Promise<void>((r) => setTimeout(r, 5000)),
+      });
+      service.registerShutdownPhase({
+        name: 'after-timeout',
+        timeout: 5000,
+        execute: afterExecute,
+      });
+
+      await service.shutdown();
+
+      expect(afterExecute).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns the same promise when shutdown is called a second time', async () => {
+      let resolvePhase!: () => void;
+      service.registerShutdownPhase({
+        name: 'blocking',
+        timeout: 5000,
+        execute: () => new Promise<void>((r) => { resolvePhase = r; }),
+      });
+
+      const first = service.shutdown();
+      const second = service.shutdown();
+
+      resolvePhase();
+      const [a, b] = await Promise.all([first, second]);
+
+      // Both should resolve (second is the same promise or a resolved one)
+      expect(a).toBeUndefined();
+      expect(b).toBeUndefined();
+    });
+
+    it('sets the global force-exit timer when FORCE_EXIT_ON_TIMEOUT is not false', async () => {
+      process.env.FORCE_EXIT_ON_TIMEOUT = 'true';
+      const freshService = new GracefulShutdownService(shutdownState, dataSource);
+      const exitSpy = jest.spyOn(process, 'exit').mockImplementation(() => undefined as never);
+
+      // Use a very short timeout so the timer fires quickly
+      process.env.SHUTDOWN_TIMEOUT_MS = '50';
+      const timedService = new GracefulShutdownService(shutdownState, dataSource);
+
+      timedService.registerShutdownPhase({
+        name: 'slow',
+        timeout: 60000,
+        execute: () => new Promise<void>((r) => setTimeout(r, 60000)),
+      });
+
+      // Start shutdown but don't await — let the force-exit timer fire
+      timedService.shutdown();
+
+      // Wait for the timer to fire
+      await new Promise((r) => setTimeout(r, 100));
+
+      expect(exitSpy).toHaveBeenCalledWith(1);
+
+      // Cleanup: avoid Jest hanging
+      exitSpy.mockRestore();
+    });
+
+    it('does not set force-exit timer when FORCE_EXIT_ON_TIMEOUT is false', async () => {
+      process.env.FORCE_EXIT_ON_TIMEOUT = 'false';
+      const exitSpy = jest.spyOn(process, 'exit').mockImplementation(() => undefined as never);
+
+      process.env.SHUTDOWN_TIMEOUT_MS = '50';
+      const freshService = new GracefulShutdownService(shutdownState, dataSource);
+
+      freshService.registerShutdownPhase({
+        name: 'slow',
+        timeout: 60000,
+        execute: () => new Promise<void>((r) => setTimeout(r, 60000)),
+      });
+
+      freshService.shutdown();
+
+      await new Promise((r) => setTimeout(r, 100));
+
+      expect(exitSpy).not.toHaveBeenCalled();
+
+      exitSpy.mockRestore();
+    });
+  });
+
+  // ── onModuleDestroy ──────────────────────────────────────────────────────
+
+  describe('onModuleDestroy', () => {
+    it('calls shutdown when not already shutting down', async () => {
+      const execute = jest.fn().mockResolvedValue(undefined);
+      service.registerShutdownPhase({ name: 'p', timeout: 1000, execute });
+
+      await service.onModuleDestroy();
+
+      expect(execute).toHaveBeenCalledTimes(1);
+      expect(service.isShutdownInProgress()).toBe(true);
+    });
+
+    it('does not call shutdown again when already shutting down', async () => {
+      const execute = jest.fn().mockResolvedValue(undefined);
+      service.registerShutdownPhase({ name: 'p', timeout: 1000, execute });
+
+      await service.shutdown();
+      await service.onModuleDestroy();
+
+      // execute should only have been called once (from the initial shutdown)
+      expect(execute).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/src/common/services/graceful-shutdown.service.spec.ts
+++ b/src/common/services/graceful-shutdown.service.spec.ts
@@ -55,7 +55,10 @@ describe('GracefulShutdownService', () => {
       service.registerShutdownPhase({
         name: 'blocking',
         timeout: 5000,
-        execute: () => new Promise<void>((r) => { resolvePhase = r; }),
+        execute: () =>
+          new Promise<void>((r) => {
+            resolvePhase = r;
+          }),
       });
 
       const shutdownPromise = service.shutdown();
@@ -130,7 +133,9 @@ describe('GracefulShutdownService', () => {
       const make = (name: string, timeout: number): ShutdownPhase => ({
         name,
         timeout,
-        execute: jest.fn().mockImplementation(async () => { order.push(name); }),
+        execute: jest.fn().mockImplementation(async () => {
+          order.push(name);
+        }),
       });
 
       // Register in reverse priority order
@@ -190,7 +195,10 @@ describe('GracefulShutdownService', () => {
       service.registerShutdownPhase({
         name: 'blocking',
         timeout: 5000,
-        execute: () => new Promise<void>((r) => { resolvePhase = r; }),
+        execute: () =>
+          new Promise<void>((r) => {
+            resolvePhase = r;
+          }),
       });
 
       const first = service.shutdown();


### PR DESCRIPTION
Closes #1275
…
## Summary

Adds focused unit test suites for two previously untested common services, bringing their public APIs under verified coverage.

## What changed

| File | Description |
|---|---|
| `src/common/request-router.service.spec.ts` | 8 tests covering `selectTarget` — single/multiple targets, empty array, weight boundaries, fractional weights, and floating-point edge cases |
| `src/common/services/graceful-shutdown.service.spec.ts` | 19 tests covering `registerShutdownPhase`, `shutdown`, `isShutdownInProgress`, `getShutdownStatus`, and `onModuleDestroy` — including phase ordering, error/timeoute resilience, force-exit timer behavior, and dedup guard |
| `package.json` / `package-lock.json` | Added `ts-jest` as a dev dependency (required by the existing Jest config but was missing from `node_modules`) |
Closes #1277
## Motivation

Both services had no accompanying `*.spec.ts` files, making their behaviour unverified and easy to regress. These tests lock down the public API surface and document edge cases (e.g. non-numeric `SHUTDOWN_TIMEOUT_MS` results in `NaN`).

## Test results

Closes #1276


## Notes

- The `SHUTDOWN_TIMEOUT_MS` non-numeric env var case surfaces a latent bug (`parseInt` returns `NaN` with no fallback). The test documents this; a follow-up can add a guard.
- `FORCE_EXIT_ON_TIMEOUT=false` is set in the test environment to prevent `process.exit(1)` from killing the test runner.

Closes #1278