### PR TITLE
perf(achievements): add lookup indexes

### DIFF
--- a/src/achievements/entities/achievement.entity.ts
+++ b/src/achievements/entities/achievement.entity.ts
@@ -1,5 +1,6 @@
 import {
   Entity,
+  Index,
   PrimaryGeneratedColumn,
   Column,
   CreateDateColumn,
@@ -31,6 +32,18 @@ export enum AchievementDifficulty {
  * Achievements are goals that users can unlock by meeting specific criteria.
  */
 @Entity('achievements')
+@Index('IDX_achievements_active_hidden_difficulty_createdAt', [
+  'isActive',
+  'isHidden',
+  'difficulty',
+  'createdAt',
+])
+@Index('IDX_achievements_type_active_hidden_difficulty', [
+  'type',
+  'isActive',
+  'isHidden',
+  'difficulty',
+])
 export class Achievement {
   @PrimaryGeneratedColumn('uuid')
   id: string;

--- a/src/migrations/1801000000000-add-achievement-indexes.ts
+++ b/src/migrations/1801000000000-add-achievement-indexes.ts
@@ -1,0 +1,21 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddAchievementIndexes1801000000000 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      'CREATE INDEX IF NOT EXISTS "IDX_achievements_active_hidden_difficulty_createdAt" ON "achievements" ("isActive", "isHidden", "difficulty", "createdAt")',
+    );
+    await queryRunner.query(
+      'CREATE INDEX IF NOT EXISTS "IDX_achievements_type_active_hidden_difficulty" ON "achievements" ("type", "isActive", "isHidden", "difficulty")',
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      'DROP INDEX IF EXISTS "IDX_achievements_type_active_hidden_difficulty"',
+    );
+    await queryRunner.query(
+      'DROP INDEX IF EXISTS "IDX_achievements_active_hidden_difficulty_createdAt"',
+    );
+  }
+}


### PR DESCRIPTION
## Summary

- Add composite indexes for the active, visible achievement list ordered by difficulty and creation date.
- Add a composite index for active, visible achievements filtered by type and ordered by difficulty.
- Add a reversible TypeORM migration so existing databases receive the indexes.

## Why

These indexes cover the achievement definition lookup paths used by `AchievementsService` without duplicating the primary-key index that already serves ID lookups.

## Verification

- [x] `npm run migrations:check`
- [x] Confirmed the entity decorators and migration create the same named indexes.
- [x] `git diff --check`
- [ ] Full typecheck and Jest suite (blocked locally because the upstream lockfile is out of sync with `package.json`).
- [ ] Live migration run (no PostgreSQL server is available in this environment).

Closes #1226
