### PR TITLE
feat: add database indexes to automation-action entity (#1232)

### DIFF
--- a/src/email-marketing/entities/automation-action.entity.ts
+++ b/src/email-marketing/entities/automation-action.entity.ts
@@ -6,6 +6,7 @@ import {
   JoinColumn,
   DeleteDateColumn,
   VersionColumn,
+  Index,
 } from 'typeorm';
 import { ApiProperty } from '@nestjs/swagger';
 import { AutomationWorkflow } from './automation-workflow.entity';
@@ -15,6 +16,8 @@ import { ActionType } from '../enums/action-type.enum';
  * Represents the automation Action entity.
  */
 @Entity('automation_actions')
+@Index('IDX_automation_actions_workflowId_order', ['workflowId', 'order'])
+@Index('IDX_automation_actions_workflowId_type', ['workflowId', 'type'])
 export class AutomationAction {
   @ApiProperty()
   @PrimaryGeneratedColumn('uuid')
@@ -24,6 +27,7 @@ export class AutomationAction {
   version: number;
 
   @ApiProperty()
+  @Index('IDX_automation_actions_workflowId')
   @Column()
   workflowId: string;
 
@@ -32,6 +36,7 @@ export class AutomationAction {
   workflow: AutomationWorkflow;
 
   @ApiProperty({ enum: ActionType })
+  @Index('IDX_automation_actions_type')
   @Column({ type: 'enum', enum: ActionType })
   type: ActionType;
 
@@ -40,6 +45,7 @@ export class AutomationAction {
   config: Record<string, any>;
 
   @ApiProperty()
+  @Index('IDX_automation_actions_order')
   @Column({ default: 0 })
   order: number;
 
@@ -47,6 +53,7 @@ export class AutomationAction {
   @Column({ type: 'text', nullable: true })
   description?: string;
 
+  @Index('IDX_automation_actions_deletedAt')
   @DeleteDateColumn()
   deletedAt?: Date;
 }

--- a/src/migrations/1800000000001-add-automation-action-indexes.ts
+++ b/src/migrations/1800000000001-add-automation-action-indexes.ts
@@ -23,23 +23,11 @@ export class AddAutomationActionIndexes1800000000001 implements MigrationInterfa
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {
-    await queryRunner.query(
-      'DROP INDEX IF EXISTS "IDX_automation_actions_workflowId_type"',
-    );
-    await queryRunner.query(
-      'DROP INDEX IF EXISTS "IDX_automation_actions_workflowId_order"',
-    );
-    await queryRunner.query(
-      'DROP INDEX IF EXISTS "IDX_automation_actions_deletedAt"',
-    );
-    await queryRunner.query(
-      'DROP INDEX IF EXISTS "IDX_automation_actions_order"',
-    );
-    await queryRunner.query(
-      'DROP INDEX IF EXISTS "IDX_automation_actions_type"',
-    );
-    await queryRunner.query(
-      'DROP INDEX IF EXISTS "IDX_automation_actions_workflowId"',
-    );
+    await queryRunner.query('DROP INDEX IF EXISTS "IDX_automation_actions_workflowId_type"');
+    await queryRunner.query('DROP INDEX IF EXISTS "IDX_automation_actions_workflowId_order"');
+    await queryRunner.query('DROP INDEX IF EXISTS "IDX_automation_actions_deletedAt"');
+    await queryRunner.query('DROP INDEX IF EXISTS "IDX_automation_actions_order"');
+    await queryRunner.query('DROP INDEX IF EXISTS "IDX_automation_actions_type"');
+    await queryRunner.query('DROP INDEX IF EXISTS "IDX_automation_actions_workflowId"');
   }
 }

--- a/src/migrations/1800000000001-add-automation-action-indexes.ts
+++ b/src/migrations/1800000000001-add-automation-action-indexes.ts
@@ -1,0 +1,45 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddAutomationActionIndexes1800000000001 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      'CREATE INDEX IF NOT EXISTS "IDX_automation_actions_workflowId" ON "automation_actions" ("workflowId")',
+    );
+    await queryRunner.query(
+      'CREATE INDEX IF NOT EXISTS "IDX_automation_actions_type" ON "automation_actions" ("type")',
+    );
+    await queryRunner.query(
+      'CREATE INDEX IF NOT EXISTS "IDX_automation_actions_order" ON "automation_actions" ("order")',
+    );
+    await queryRunner.query(
+      'CREATE INDEX IF NOT EXISTS "IDX_automation_actions_deletedAt" ON "automation_actions" ("deletedAt")',
+    );
+    await queryRunner.query(
+      'CREATE INDEX IF NOT EXISTS "IDX_automation_actions_workflowId_order" ON "automation_actions" ("workflowId", "order")',
+    );
+    await queryRunner.query(
+      'CREATE INDEX IF NOT EXISTS "IDX_automation_actions_workflowId_type" ON "automation_actions" ("workflowId", "type")',
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      'DROP INDEX IF EXISTS "IDX_automation_actions_workflowId_type"',
+    );
+    await queryRunner.query(
+      'DROP INDEX IF EXISTS "IDX_automation_actions_workflowId_order"',
+    );
+    await queryRunner.query(
+      'DROP INDEX IF EXISTS "IDX_automation_actions_deletedAt"',
+    );
+    await queryRunner.query(
+      'DROP INDEX IF EXISTS "IDX_automation_actions_order"',
+    );
+    await queryRunner.query(
+      'DROP INDEX IF EXISTS "IDX_automation_actions_type"',
+    );
+    await queryRunner.query(
+      'DROP INDEX IF EXISTS "IDX_automation_actions_workflowId"',
+    );
+  }
+}


### PR DESCRIPTION
Add @Index decorators to AutomationAction entity for commonly queried columns:
- workflowId (single): speeds up foreign key lookups / CASCADE deletes
- type (single): speeds up filtering actions by type
- order (single): speeds up ORDER BY order queries
- deletedAt (single): speeds up soft-delete aware queries
- workflowId + order (composite): optimised ordered action fetch per workflow
- workflowId + type (composite): optimised type-filter per workflow

Add migration 1800000000001-add-automation-action-indexes.ts with idempotent CREATE INDEX IF NOT EXISTS / DROP INDEX IF EXISTS statements.

Closes #1232