### PR TITLE
Add AB test variant indexes

### DIFF
--- a/src/email-marketing/entities/ab-test-variant.entity.ts
+++ b/src/email-marketing/entities/ab-test-variant.entity.ts
@@ -4,6 +4,7 @@ import {
   Column,
   ManyToOne,
   JoinColumn,
+  Index,
   VersionColumn,
 } from 'typeorm';
 import { ApiProperty } from '@nestjs/swagger';
@@ -13,6 +14,7 @@ import { ABTest } from './ab-test.entity';
  * Represents the aBTest Variant entity.
  */
 @Entity('ab_test_variants')
+@Index('IDX_ab_test_variants_abTestId_weight', ['abTestId', 'weight'])
 export class ABTestVariant {
   @ApiProperty()
   @PrimaryGeneratedColumn('uuid')

--- a/src/migrations/1802000000000-add-ab-test-variant-indexes.ts
+++ b/src/migrations/1802000000000-add-ab-test-variant-indexes.ts
@@ -1,0 +1,17 @@
+import { MigrationInterface, QueryRunner, TableIndex } from 'typeorm';
+
+export class AddABTestVariantIndexes1802000000000 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.createIndex(
+      'ab_test_variants',
+      new TableIndex({
+        name: 'IDX_ab_test_variants_abTestId_weight',
+        columnNames: ['abTestId', 'weight'],
+      }),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropIndex('ab_test_variants', 'IDX_ab_test_variants_abTestId_weight');
+  }
+}


### PR DESCRIPTION
closes #1230

## Summary
- Add the missing composite index on the AB test variant foreign key and weight column.
- Add a migration to create the same index in existing databases.

## Notes
- No tests or compilation were run, per request.