### PR TITLE
feat(profile-completeness): add rate limiting to endpoints

### DIFF
--- a/src/profile-completeness/profile-completeness.controller.ts
+++ b/src/profile-completeness/profile-completeness.controller.ts
@@ -1,17 +1,22 @@
 import { Controller, Get, Param, UseGuards } from '@nestjs/common';
-import { ApiTags, ApiOperation, ApiBearerAuth } from '@nestjs/swagger';
+import { ApiTags, ApiOperation, ApiBearerAuth, ApiResponse } from '@nestjs/swagger';
+import { Throttle } from '@nestjs/throttler';
 import { ProfileCompletenessService } from './profile-completeness.service';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { CustomThrottleGuard } from '../common/guards/throttle.guard';
+import { THROTTLE } from '../common/constants/throttle.constants';
 
 @ApiTags('profile-completeness')
 @ApiBearerAuth()
-@UseGuards(JwtAuthGuard)
+@UseGuards(JwtAuthGuard, CustomThrottleGuard)
 @Controller('users/:userId/profile-completeness')
 export class ProfileCompletenessController {
   constructor(private readonly profileCompletenessService: ProfileCompletenessService) {}
 
   @Get()
+  @Throttle({ default: THROTTLE.MODERATE })
   @ApiOperation({ summary: 'Get profile completeness score and progress for a user' })
+  @ApiResponse({ status: 429, description: 'Too many requests — rate limit exceeded' })
   getScore(@Param('userId') userId: string) {
     return this.profileCompletenessService.getScore(userId);
   }

--- a/src/profile-completeness/profile-completeness.module.ts
+++ b/src/profile-completeness/profile-completeness.module.ts
@@ -1,11 +1,16 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
+import { ThrottlerModule } from '@nestjs/throttler';
 import { ProfileCompletenessController } from './profile-completeness.controller';
 import { ProfileCompletenessService } from './profile-completeness.service';
 import { User } from '../users/entities/user.entity';
+import { THROTTLE } from '../common/constants/throttle.constants';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([User])],
+  imports: [
+    TypeOrmModule.forFeature([User]),
+    ThrottlerModule.forRoot([{ ttl: THROTTLE.MODERATE.ttl, limit: THROTTLE.MODERATE.limit }]),
+  ],
   controllers: [ProfileCompletenessController],
   providers: [ProfileCompletenessService],
   exports: [ProfileCompletenessService],


### PR DESCRIPTION
closes #1330

## Summary

Apply rate limiting to profile-completeness endpoints to protect against brute-force and abuse (#1330).

## Changes

- Added `CustomThrottleGuard` to the `ProfileCompletenessController`
- Applied `@Throttle({ default: THROTTLE.MODERATE })` decorator (10 requests per hour)
- Registered `ThrottlerModule.forRoot()` in the module with configurable limits
- Added `@ApiResponse({ status: 429 })` documentation

## Acceptance Criteria

- Exceeding the limit returns HTTP 429 with a clear message
- Limits use the shared `THROTTLE` presets from `throttle.constants.ts` (not hardcoded)
- Normal usage is unaffected