### PR TITLE
fix: Add database indexes to the migration entity

### DIFF
--- a/src/migrations/1802000000000-add-migration-indexes.ts
+++ b/src/migrations/1802000000000-add-migration-indexes.ts
@@ -1,0 +1,28 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Issue #1241 — Add database indexes to the migration entity.
+ *
+ * The `migrations` table is TypeORM's internal bookkeeping table. It is
+ * queried by `name` (to check whether a migration has already been applied)
+ * and ordered by `timestamp` (to determine the next pending migration).
+ *
+ * Indexes added:
+ *  - IDX_migrations_name      — per-name lookup on every migration:run/revert
+ *  - IDX_migrations_timestamp — ordering by timestamp to find pending migrations
+ */
+export class AddMigrationIndexes1802000000000 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      'CREATE INDEX IF NOT EXISTS "IDX_migrations_name" ON "migrations" ("name")',
+    );
+    await queryRunner.query(
+      'CREATE INDEX IF NOT EXISTS "IDX_migrations_timestamp" ON "migrations" ("timestamp")',
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query('DROP INDEX IF EXISTS "IDX_migrations_timestamp"');
+    await queryRunner.query('DROP INDEX IF EXISTS "IDX_migrations_name"');
+  }
+}

--- a/src/migrations/entities/migration.entity.ts
+++ b/src/migrations/entities/migration.entity.ts
@@ -1,0 +1,28 @@
+import { Entity, Column, PrimaryGeneratedColumn, Index } from 'typeorm';
+
+/**
+ * TypeORM's internal `migrations` table.
+ *
+ * Tracks which migrations have been applied. TypeORM queries this table by
+ * `name` (to check whether a migration has already run) and orders by
+ * `timestamp` (to determine the order in which migrations are applied).
+ *
+ * Index strategy:
+ *   - `name`      — TypeORM looks up applied migrations by name on every
+ *                   `migration:run` / `migration:revert`.
+ *   - `timestamp` — migrations are ordered by timestamp to determine the
+ *                   next pending migration.
+ */
+@Entity('migrations')
+@Index('IDX_migrations_name', ['name'])
+@Index('IDX_migrations_timestamp', ['timestamp'])
+export class Migration {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column('bigint')
+  timestamp: number;
+
+  @Column()
+  name: string;
+}


### PR DESCRIPTION
## Summary
Added database indexes to the migration entity for issue #1241.

Changes:
1. **Created `src/migrations/entities/migration.entity.ts`** — a new entity representing TypeORM's internal `migrations` table (columns: `id`, `timestamp`, `name`). Added two `@Index` decorators:
   - `IDX_migrations_name` on `name` — TypeORM looks up applied migrations by name on every `migration:run`/`migration:revert`.
   - `IDX_migrations_timestamp` on `timestamp` — migrations are ordered by timestamp to determine the next pending migration.

2. **Created `src/migrations/1802000000000-add-migration-indexes.ts`** — a reviewable migration that creates both indexes with `CREATE INDEX IF NOT EXISTS` (idempotent) and drops them in `down()`. Uses the next available timestamp (`1802000000000`) above the current max (`1801000000000`), and the class name ends with the timestamp to satisfy the `migration-timestamps.spec.ts` requirements.

No duplicate/redundant indexes are introduced — the `migrations` table has no pre-existing indexes beyond the primary key on `id`.

## Changed files
- `src/migrations/1802000000000-add-migration-indexes.ts`
- `src/migrations/entities/migration.entity.ts`

## Test plan
1. Run `pnpm test src/migrations/migration-timestamps.spec.ts` — verifies the new migration file has a unique timestamp, a class name ending with the timestamp, and no duplicate timestamps.
2. Run `pnpm run migration:run` against a database — verifies the new migration applies cleanly and creates both indexes.
3. Optionally verify with `\d migrations` in psql that `IDX_migrations_name` and `IDX_migrations_timestamp` exist.

This PR was created as a draft by the issue solver bot. It will remain a
draft until repository CI passes.

Closes #1241
