### PR TITLE
feat: add database indexes to assessment_attempt for common query paths

### DIFF
--- a/src/assessment/entities/assessment-attempt.entity.ts
+++ b/src/assessment/entities/assessment-attempt.entity.ts
@@ -3,8 +3,10 @@ import {
   PrimaryGeneratedColumn,
   Column,
   ManyToOne,
+  JoinColumn,
   OneToMany,
   VersionColumn,
+  Index,
 } from 'typeorm';
 import { AssessmentStatus } from '../enums/assessment-status.enum';
 import { Answer } from './answer.entity';
@@ -14,6 +16,10 @@ import { Assessment } from './assessment.entity';
  * Represents the assessment Attempt entity.
  */
 @Entity()
+@Index('IDX_assessment_attempt_studentId', ['studentId'])
+@Index('IDX_assessment_attempt_assessmentId', ['assessmentId'])
+@Index('IDX_assessment_attempt_status', ['status'])
+@Index('IDX_assessment_attempt_studentId_assessmentId', ['studentId', 'assessmentId'])
 export class AssessmentAttempt {
   @PrimaryGeneratedColumn('uuid')
   id: string;
@@ -25,7 +31,11 @@ export class AssessmentAttempt {
   studentId: string;
 
   @ManyToOne(() => Assessment)
+  @JoinColumn({ name: 'assessmentId' })
   assessment: Assessment;
+
+  @Column({ name: 'assessmentId', type: 'uuid', nullable: true })
+  assessmentId: string | null;
 
   @Column({ type: 'enum', enum: AssessmentStatus })
   status: AssessmentStatus;

--- a/src/migrations/1802000000000-add-assessment-attempt-indexes.ts
+++ b/src/migrations/1802000000000-add-assessment-attempt-indexes.ts
@@ -1,0 +1,34 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Issue #1229 — assessment_attempt has no indexes beyond the primary key.
+ *
+ * Common query paths that need coverage:
+ *  - "list my attempts"  → WHERE "studentId" = $1
+ *  - "attempts for assessment" → WHERE "assessmentId" = $1 (FK column)
+ *  - "filter by status"  → WHERE status = $1
+ *  - "has student started this assessment?" → WHERE "studentId" = $1 AND "assessmentId" = $2
+ */
+export class AddAssessmentAttemptIndexes1802000000000 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      'CREATE INDEX IF NOT EXISTS "IDX_assessment_attempt_studentId" ON "assessment_attempt" ("studentId")',
+    );
+    await queryRunner.query(
+      'CREATE INDEX IF NOT EXISTS "IDX_assessment_attempt_assessmentId" ON "assessment_attempt" ("assessmentId")',
+    );
+    await queryRunner.query(
+      'CREATE INDEX IF NOT EXISTS "IDX_assessment_attempt_status" ON "assessment_attempt" ("status")',
+    );
+    await queryRunner.query(
+      'CREATE INDEX IF NOT EXISTS "IDX_assessment_attempt_studentId_assessmentId" ON "assessment_attempt" ("studentId", "assessmentId")',
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query('DROP INDEX IF EXISTS "IDX_assessment_attempt_studentId_assessmentId"');
+    await queryRunner.query('DROP INDEX IF EXISTS "IDX_assessment_attempt_status"');
+    await queryRunner.query('DROP INDEX IF EXISTS "IDX_assessment_attempt_assessmentId"');
+    await queryRunner.query('DROP INDEX IF EXISTS "IDX_assessment_attempt_studentId"');
+  }
+}


### PR DESCRIPTION
## Summary

Add indexes to `assessment_attempt` covering its common lookup and foreign-key columns (#1229).

Closes #1229

## Problem

`assessment_attempt` had no indexes beyond the primary key. Columns used for lookups (`studentId`, `assessmentId`, `status`) forced sequential scans as the table grows.

## Changes

**Entity** (`src/assessment/entities/assessment-attempt.entity.ts`):
- Added `@Index` decorators for `studentId`, `assessmentId`, `status`, and a composite `(studentId, assessmentId)`.

**Migration** (`src/migrations/1802000000000-add-assessment-attempt-indexes.ts`):
- Creates 4 indexes via `CREATE INDEX IF NOT EXISTS`.
- `down()` drops them in reverse order.

| Index | Columns | Covers |
|---|---|---|
| `IDX_assessment_attempt_studentId` | `(studentId)` | "List my attempts" |
| `IDX_assessment_attempt_assessmentId` | `(assessmentId)` | FK lookups, "attempts for assessment" |
| `IDX_assessment_attempt_status` | `(status)` | Status-filtered queries |
| `IDX_assessment_attempt_studentId_assessmentId` | `(studentId, assessmentId)` | Duplicate-attempt check |

## Verification

- `tsc --noEmit` passes
- ESLint passes
- `validate-migrations.js` passes (36 files)