### PR TITLE
## test: add unit tests for cache-analytics, cache-optimization, and transaction-helper services

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -484,8 +484,8 @@ importers:
         specifier: ^7.0.0
         version: 7.2.2
       ts-jest:
-        specifier: ^29.1.0
-        version: 29.4.11(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.42)(ts-node@10.9.2(@types/node@20.19.42)(typescript@5.9.3)))(typescript@5.9.3)
+        specifier: ^29.4.12
+        version: 29.4.12(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.42)(ts-node@10.9.2(@types/node@20.19.42)(typescript@5.9.3)))(typescript@5.9.3)
       ts-loader:
         specifier: ^9.5.7
         version: 9.6.0(typescript@5.9.3)(webpack@5.97.1)
@@ -6170,6 +6170,11 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  semver@7.8.5:
+    resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
   send@1.2.1:
     resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
     engines: {node: '>= 18'}
@@ -6637,8 +6642,8 @@ packages:
     peerDependencies:
       typescript: '>=4.8.4'
 
-  ts-jest@29.4.11:
-    resolution: {integrity: sha512-IrFl7l9AuB/qrNw5quqvAv/hmKMb8dhWOH4jQOGo0Oq8tCeo1O86/iTFG1FaRimgUkF13l4PcepO8ATFT6Ns4g==}
+  ts-jest@29.4.12:
+    resolution: {integrity: sha512-Ov6ClY53Fflh6BGAnY2DlTq1hYDrTycz2PVTXBWFW2CU+9zrEqAp9fWdGXl42EXO5RLSFAcAZ2JFKbP+zBTFfw==}
     engines: {node: ^14.15.0 || ^16.10.0 || ^18.0.0 || >=20.0.0}
     hasBin: true
     peerDependencies:
@@ -13836,6 +13841,8 @@ snapshots:
 
   semver@7.8.2: {}
 
+  semver@7.8.5: {}
+
   send@1.2.1:
     dependencies:
       debug: 4.4.3
@@ -14365,7 +14372,7 @@ snapshots:
     dependencies:
       typescript: 5.9.3
 
-  ts-jest@29.4.11(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.42)(ts-node@10.9.2(@types/node@20.19.42)(typescript@5.9.3)))(typescript@5.9.3):
+  ts-jest@29.4.12(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.42)(ts-node@10.9.2(@types/node@20.19.42)(typescript@5.9.3)))(typescript@5.9.3):
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
@@ -14374,7 +14381,7 @@ snapshots:
       json5: 2.2.3
       lodash.memoize: 4.1.2
       make-error: 1.3.6
-      semver: 7.8.2
+      semver: 7.8.5
       type-fest: 4.41.0
       typescript: 5.9.3
       yargs-parser: 21.1.1

--- a/src/caching/cache-analytics.service.spec.ts
+++ b/src/caching/cache-analytics.service.spec.ts
@@ -1,0 +1,729 @@
+import { EventEmitter2 } from '@nestjs/event-emitter';
+import { CacheAnalyticsService, CacheMetrics, TTLRecommendation } from './cache-analytics.service';
+
+jest.mock('../config/cache.config', () => ({
+  getSharedRedisClient: jest.fn(() => mockRedis),
+}));
+
+let mockRedis: {
+  hget: jest.Mock;
+  hset: jest.Mock;
+  hgetall: jest.Mock;
+  hdel: jest.Mock;
+  get: jest.Mock;
+  incr: jest.Mock;
+  incrby: jest.Mock;
+  info: jest.Mock;
+};
+
+const freshMetrics = (): CacheMetrics => ({
+  key: 'test-key',
+  hits: 0,
+  misses: 0,
+  hitRate: 0,
+  avgTtl: 0,
+  lastAccessed: new Date(),
+  accessFrequency: 0,
+  dataSize: 0,
+  costScore: 0,
+});
+
+function makeConfigService(overrides: Record<string, unknown> = {}) {
+  const defaults: Record<string, unknown> = {
+    CACHE_ADAPTIVE_TTL_ENABLED: true,
+    CACHE_MIN_SAMPLE_SIZE: 100,
+  };
+  return {
+    get: jest.fn((key: string, fallback?: unknown) => {
+      const val = { ...defaults, ...overrides }[key];
+      return val ?? fallback;
+    }),
+  };
+}
+
+describe('CacheAnalyticsService', () => {
+  let service: CacheAnalyticsService;
+  let eventEmitter: { emit: jest.Mock };
+  let configService: ReturnType<typeof makeConfigService>;
+
+  beforeEach(() => {
+    mockRedis = {
+      hget: jest.fn().mockResolvedValue(null),
+      hset: jest.fn().mockResolvedValue(1),
+      hgetall: jest.fn().mockResolvedValue({}),
+      hdel: jest.fn().mockResolvedValue(1),
+      get: jest.fn().mockResolvedValue(null),
+      incr: jest.fn().mockResolvedValue(1),
+      incrby: jest.fn().mockResolvedValue(1),
+      info: jest.fn().mockResolvedValue('used_memory:12345678'),
+    };
+
+    eventEmitter = { emit: jest.fn() };
+    configService = makeConfigService();
+    service = new CacheAnalyticsService(
+      configService as never,
+      eventEmitter as unknown as EventEmitter2,
+    );
+  });
+
+  afterEach(() => jest.restoreAllMocks());
+
+  // ─── recordHit ────────────────────────────────────────────────────────────
+
+  describe('recordHit', () => {
+    it('increments hit count and emits cache.hit event', async () => {
+      await service.recordHit('my-key');
+
+      expect(mockRedis.hset).toHaveBeenCalledWith(
+        'cache:analytics:metrics',
+        'my-key',
+        expect.any(String),
+      );
+      const stored = JSON.parse(mockRedis.hset.mock.calls[0][2]) as CacheMetrics;
+      expect(stored.hits).toBe(1);
+      expect(stored.misses).toBe(0);
+      expect(stored.hitRate).toBe(1);
+      expect(eventEmitter.emit).toHaveBeenCalledWith(
+        'cache.hit',
+        expect.objectContaining({ key: 'my-key' }),
+      );
+    });
+
+    it('updates avgTtl when a ttl is supplied', async () => {
+      await service.recordHit('my-key', 300);
+
+      const stored = JSON.parse(mockRedis.hset.mock.calls[0][2]) as CacheMetrics;
+      expect(stored.avgTtl).toBe(300);
+    });
+
+    it('computes a rolling avgTtl across multiple hits', async () => {
+      // Simulate existing metrics with 1 hit and avgTtl 200
+      mockRedis.hget.mockResolvedValueOnce(
+        JSON.stringify({ ...freshMetrics(), hits: 1, avgTtl: 200 }),
+      );
+
+      await service.recordHit('my-key', 400);
+
+      const stored = JSON.parse(mockRedis.hset.mock.calls[0][2]) as CacheMetrics;
+      expect(stored.hits).toBe(2);
+      // rolling avg: (200*1 + 400) / 2 = 300
+      expect(stored.avgTtl).toBe(300);
+    });
+
+    it('does not change avgTtl when no ttl is supplied', async () => {
+      mockRedis.hget.mockResolvedValueOnce(
+        JSON.stringify({ ...freshMetrics(), hits: 3, avgTtl: 100 }),
+      );
+
+      await service.recordHit('my-key');
+
+      const stored = JSON.parse(mockRedis.hset.mock.calls[0][2]) as CacheMetrics;
+      expect(stored.avgTtl).toBe(100);
+    });
+
+    it('starts from zero metrics when no prior data exists', async () => {
+      mockRedis.hget.mockResolvedValue(null);
+
+      await service.recordHit('new-key');
+
+      const stored = JSON.parse(mockRedis.hset.mock.calls[0][2]) as CacheMetrics;
+      expect(stored.hits).toBe(1);
+      expect(stored.misses).toBe(0);
+    });
+
+    it('treats corrupt existing metrics as a fresh start', async () => {
+      mockRedis.hget.mockResolvedValueOnce('not-json');
+
+      await service.recordHit('bad-key');
+
+      expect(mockRedis.incr).toHaveBeenCalledWith('cache:metrics:deserialization_failures_total');
+      const stored = JSON.parse(mockRedis.hset.mock.calls[0][2]) as CacheMetrics;
+      expect(stored.hits).toBe(1);
+    });
+
+    it('treats metrics with missing fields as corrupt', async () => {
+      mockRedis.hget.mockResolvedValueOnce(JSON.stringify({ key: 'x' }));
+
+      await service.recordHit('bad-key');
+
+      expect(mockRedis.incr).toHaveBeenCalledWith('cache:metrics:deserialization_failures_total');
+    });
+
+    it('silently ignores incr failure on corrupt metrics', async () => {
+      mockRedis.hget.mockResolvedValueOnce('not-json');
+      mockRedis.incr.mockRejectedValueOnce(new Error('redis down'));
+
+      await expect(service.recordHit('bad-key')).resolves.toBeUndefined();
+    });
+  });
+
+  // ─── recordMiss ───────────────────────────────────────────────────────────
+
+  describe('recordMiss', () => {
+    it('increments miss count and emits cache.miss event', async () => {
+      await service.recordMiss('my-key');
+
+      const stored = JSON.parse(mockRedis.hset.mock.calls[0][2]) as CacheMetrics;
+      expect(stored.misses).toBe(1);
+      expect(stored.hits).toBe(0);
+      expect(stored.hitRate).toBe(0);
+      expect(eventEmitter.emit).toHaveBeenCalledWith(
+        'cache.miss',
+        expect.objectContaining({ key: 'my-key' }),
+      );
+    });
+
+    it('accumulates misses on top of existing metrics', async () => {
+      mockRedis.hget.mockResolvedValueOnce(
+        JSON.stringify({ ...freshMetrics(), misses: 5, hits: 10 }),
+      );
+
+      await service.recordMiss('my-key');
+
+      const stored = JSON.parse(mockRedis.hset.mock.calls[0][2]) as CacheMetrics;
+      expect(stored.misses).toBe(6);
+      expect(stored.hitRate).toBeCloseTo(10 / 16);
+    });
+
+    it('starts from zero metrics when no prior data exists', async () => {
+      mockRedis.hget.mockResolvedValue(null);
+
+      await service.recordMiss('new-key');
+
+      const stored = JSON.parse(mockRedis.hset.mock.calls[0][2]) as CacheMetrics;
+      expect(stored.misses).toBe(1);
+    });
+
+    it('treats corrupt metrics as a fresh start', async () => {
+      mockRedis.hget.mockResolvedValueOnce('not-json');
+
+      await service.recordMiss('bad-key');
+
+      const stored = JSON.parse(mockRedis.hset.mock.calls[0][2]) as CacheMetrics;
+      expect(stored.misses).toBe(1);
+      expect(mockRedis.incr).toHaveBeenCalledWith('cache:metrics:deserialization_failures_total');
+    });
+  });
+
+  // ─── recordSet ────────────────────────────────────────────────────────────
+
+  describe('recordSet', () => {
+    it('sets avgTtl, dataSize, and emits cache.set event', async () => {
+      await service.recordSet('my-key', 600, 2048);
+
+      const stored = JSON.parse(mockRedis.hset.mock.calls[0][2]) as CacheMetrics;
+      expect(stored.avgTtl).toBe(600);
+      expect(stored.dataSize).toBe(2048);
+      expect(eventEmitter.emit).toHaveBeenCalledWith(
+        'cache.set',
+        expect.objectContaining({ key: 'my-key', ttl: 600, dataSize: 2048 }),
+      );
+    });
+
+    it('overwrites previous metrics on a new set', async () => {
+      mockRedis.hget.mockResolvedValueOnce(
+        JSON.stringify({ ...freshMetrics(), hits: 5, avgTtl: 100, dataSize: 1024 }),
+      );
+
+      await service.recordSet('my-key', 300, 4096);
+
+      const stored = JSON.parse(mockRedis.hset.mock.calls[0][2]) as CacheMetrics;
+      expect(stored.avgTtl).toBe(300);
+      expect(stored.dataSize).toBe(4096);
+      expect(stored.hits).toBe(5); // preserved
+    });
+  });
+
+  // ─── getRecommendedTTL ────────────────────────────────────────────────────
+
+  describe('getRecommendedTTL', () => {
+    it('returns the stored recommended TTL for a key', async () => {
+      mockRedis.hget.mockResolvedValueOnce('720');
+
+      const ttl = await service.getRecommendedTTL('my-key', 300);
+
+      expect(ttl).toBe(720);
+      expect(mockRedis.hget).toHaveBeenCalledWith('cache:analytics:config', 'ttl:my-key');
+    });
+
+    it('returns the default TTL when no recommendation exists', async () => {
+      mockRedis.hget.mockResolvedValueOnce(null);
+
+      const ttl = await service.getRecommendedTTL('my-key', 300);
+
+      expect(ttl).toBe(300);
+    });
+
+    it('returns the default TTL when the stored value is empty string', async () => {
+      mockRedis.hget.mockResolvedValueOnce('');
+
+      const ttl = await service.getRecommendedTTL('my-key', 120);
+
+      expect(ttl).toBe(120);
+    });
+  });
+
+  // ─── generateAnalyticsReport ──────────────────────────────────────────────
+
+  describe('generateAnalyticsReport', () => {
+    it('returns a report with zero keys and zero hit rate when no metrics exist', async () => {
+      mockRedis.hgetall.mockResolvedValue({});
+      mockRedis.info.mockResolvedValue('used_memory:0');
+      mockRedis.get.mockResolvedValue(null);
+
+      const report = await service.generateAnalyticsReport();
+
+      expect(report.totalKeys).toBe(0);
+      expect(report.overallHitRate).toBe(0);
+      expect(report.memoryUsage).toBe(0);
+      expect(report.topPerformers).toEqual([]);
+      expect(report.underPerformers).toEqual([]);
+      expect(report.ttlRecommendations).toEqual([]);
+      expect(report.generatedAt).toBeInstanceOf(Date);
+    });
+
+    it('calculates overall hit rate from multiple keys', async () => {
+      const m1: CacheMetrics = { ...freshMetrics(), key: 'a', hits: 80, misses: 20, costScore: 0.5 };
+      const m2: CacheMetrics = { ...freshMetrics(), key: 'b', hits: 10, misses: 90, costScore: 0.2 };
+      mockRedis.hgetall.mockResolvedValue({
+        a: JSON.stringify(m1),
+        b: JSON.stringify(m2),
+      });
+      mockRedis.info.mockResolvedValue('used_memory:5000');
+      mockRedis.get.mockResolvedValue('0');
+
+      const report = await service.generateAnalyticsReport();
+
+      expect(report.totalKeys).toBe(2);
+      // total hits=90, total misses=110 → 90/200 = 0.45
+      expect(report.overallHitRate).toBeCloseTo(0.45);
+      expect(report.memoryUsage).toBe(5000);
+    });
+
+    it('sorts topPerformers by costScore descending and underPerformers ascending', async () => {
+      const metrics: CacheMetrics[] = Array.from({ length: 15 }, (_, i) => ({
+        ...freshMetrics(),
+        key: `k${i}`,
+        costScore: i,
+      }));
+      mockRedis.hgetall.mockResolvedValue(
+        Object.fromEntries(metrics.map((m) => [m.key, JSON.stringify(m)])),
+      );
+      mockRedis.info.mockResolvedValue('used_memory:100');
+      mockRedis.get.mockResolvedValue('0');
+
+      const report = await service.generateAnalyticsReport();
+
+      expect(report.topPerformers).toHaveLength(10);
+      expect(report.topPerformers[0].key).toBe('k14'); // highest costScore
+      expect(report.underPerformers).toHaveLength(10);
+      // underPerformers are reversed (lowest first becomes first in array)
+      expect(report.underPerformers[0].key).toBe('k0');
+    });
+
+    it('skips corrupt metrics entries gracefully', async () => {
+      mockRedis.hgetall.mockResolvedValue({
+        good: JSON.stringify({ ...freshMetrics(), key: 'good', hits: 10, misses: 5, costScore: 0.5 }),
+        bad: 'not-json',
+        empty: JSON.stringify({ key: 'empty' }),
+      });
+      mockRedis.info.mockResolvedValue('used_memory:100');
+      mockRedis.get.mockResolvedValue('0');
+
+      const report = await service.generateAnalyticsReport();
+
+      expect(report.totalKeys).toBe(1); // only the good one
+      expect(mockRedis.incr).toHaveBeenCalledWith('cache:metrics:deserialization_failures_total');
+    });
+
+    it('returns 0 memory usage when redis.info fails', async () => {
+      mockRedis.hgetall.mockResolvedValue({});
+      mockRedis.info.mockRejectedValue(new Error('connection lost'));
+      mockRedis.get.mockResolvedValue('0');
+
+      const report = await service.generateAnalyticsReport();
+
+      expect(report.memoryUsage).toBe(0);
+    });
+
+    it('returns 0 memoryUsage when info string has no used_memory', async () => {
+      mockRedis.hgetall.mockResolvedValue({});
+      mockRedis.info.mockResolvedValue('redis_version:7.0');
+      mockRedis.get.mockResolvedValue('0');
+
+      const report = await service.generateAnalyticsReport();
+
+      expect(report.memoryUsage).toBe(0);
+    });
+
+    it('returns 0 for adaptiveTtlAdjustments when none stored', async () => {
+      mockRedis.hgetall.mockResolvedValue({});
+      mockRedis.info.mockResolvedValue('used_memory:0');
+      mockRedis.get.mockResolvedValue(null);
+
+      const report = await service.generateAnalyticsReport();
+
+      expect(report.adaptiveTtlAdjustments).toBe(0);
+    });
+
+    it('parses adaptiveTtlAdjustments from redis', async () => {
+      mockRedis.hgetall.mockResolvedValue({});
+      mockRedis.info.mockResolvedValue('used_memory:0');
+      mockRedis.get.mockResolvedValue('42');
+
+      const report = await service.generateAnalyticsReport();
+
+      expect(report.adaptiveTtlAdjustments).toBe(42);
+    });
+
+    it('generates TTL recommendations for keys with sufficient sample size', async () => {
+      const metrics: CacheMetrics = {
+        ...freshMetrics(),
+        key: 'popular',
+        hits: 200,
+        misses: 10,
+        hitRate: 200 / 210,
+        avgTtl: 300,
+        accessFrequency: 10,
+        dataSize: 1024,
+        costScore: 0.8,
+      };
+      mockRedis.hgetall.mockResolvedValue({ popular: JSON.stringify(metrics) });
+      mockRedis.info.mockResolvedValue('used_memory:500');
+      mockRedis.get.mockResolvedValue('0');
+
+      const report = await service.generateAnalyticsReport();
+
+      // hitRate > 0.8 && accessFrequency > 5 → recommends increase
+      expect(report.ttlRecommendations.length).toBeGreaterThanOrEqual(1);
+      const rec = report.ttlRecommendations.find((r) => r.key === 'popular')!;
+      expect(rec.recommendedTtl).toBeGreaterThan(300);
+    });
+
+    it('skips TTL recommendations for keys below minSampleSize', async () => {
+      const metrics: CacheMetrics = {
+        ...freshMetrics(),
+        key: 'rare',
+        hits: 5,
+        misses: 2,
+        hitRate: 5 / 7,
+        avgTtl: 300,
+        accessFrequency: 10,
+        dataSize: 1024,
+        costScore: 0.8,
+      };
+      mockRedis.hgetall.mockResolvedValue({ rare: JSON.stringify(metrics) });
+      mockRedis.info.mockResolvedValue('used_memory:500');
+      mockRedis.get.mockResolvedValue('0');
+
+      const report = await service.generateAnalyticsReport();
+
+      expect(report.ttlRecommendations).toEqual([]);
+    });
+  });
+
+  // ─── applyAdaptiveTTLAdjustments ──────────────────────────────────────────
+
+  describe('applyAdaptiveTTLAdjustments', () => {
+    it('skips adjustments when adaptiveTtl is disabled', async () => {
+      configService = makeConfigService({ CACHE_ADAPTIVE_TTL_ENABLED: false });
+      service = new CacheAnalyticsService(
+        configService as never,
+        eventEmitter as unknown as EventEmitter2,
+      );
+
+      await service.applyAdaptiveTTLAdjustments();
+
+      expect(mockRedis.hgetall).not.toHaveBeenCalled();
+      expect(mockRedis.incrby).not.toHaveBeenCalled();
+    });
+
+    it('applies high-confidence TTL adjustments and increments counter', async () => {
+      const metrics: CacheMetrics = {
+        ...freshMetrics(),
+        key: 'hot',
+        hits: 200,
+        misses: 10,
+        hitRate: 200 / 210,
+        avgTtl: 300,
+        accessFrequency: 10,
+        dataSize: 1024,
+        costScore: 0.8,
+      };
+      mockRedis.hgetall.mockResolvedValue({ hot: JSON.stringify(metrics) });
+      mockRedis.get.mockResolvedValue('0');
+
+      await service.applyAdaptiveTTLAdjustments();
+
+      // TTL adjustment written to config
+      expect(mockRedis.hset).toHaveBeenCalledWith(
+        'cache:analytics:config',
+        'ttl:hot',
+        expect.any(Number),
+      );
+      // Counter incremented
+      expect(mockRedis.incrby).toHaveBeenCalledWith('cache:analytics:ttl_adjustments', 1);
+      // Event emitted
+      expect(eventEmitter.emit).toHaveBeenCalledWith(
+        'cache.ttl.adjusted',
+        expect.objectContaining({ key: 'hot' }),
+      );
+    });
+
+    it('skips keys with insufficient sample size', async () => {
+      const metrics: CacheMetrics = {
+        ...freshMetrics(),
+        key: 'cold',
+        hits: 5,
+        misses: 2,
+        hitRate: 5 / 7,
+        avgTtl: 300,
+        accessFrequency: 10,
+        dataSize: 1024,
+        costScore: 0.8,
+      };
+      mockRedis.hgetall.mockResolvedValue({ cold: JSON.stringify(metrics) });
+      mockRedis.get.mockResolvedValue('0');
+
+      await service.applyAdaptiveTTLAdjustments();
+
+      expect(mockRedis.hset).not.toHaveBeenCalledWith(
+        'cache:analytics:config',
+        'ttl:cold',
+        expect.anything(),
+      );
+      expect(mockRedis.incrby).toHaveBeenCalledWith('cache:analytics:ttl_adjustments', 0);
+    });
+
+    it('skips low-confidence recommendations', async () => {
+      // Metrics that produce a recommendation with confidence ≤ 0.7
+      // low frequency (< 1) → confidence 0.7, not > 0.7, so it's skipped
+      const metrics: CacheMetrics = {
+        ...freshMetrics(),
+        key: 'lowconf',
+        hits: 150,
+        misses: 50,
+        hitRate: 0.75,
+        avgTtl: 300,
+        accessFrequency: 0.5,
+        dataSize: 1024,
+        costScore: 0.5,
+      };
+      mockRedis.hgetall.mockResolvedValue({ lowconf: JSON.stringify(metrics) });
+      mockRedis.get.mockResolvedValue('0');
+
+      await service.applyAdaptiveTTLAdjustments();
+
+      // No TTL adjustment should be written for this key
+      expect(mockRedis.hset).not.toHaveBeenCalled();
+      expect(mockRedis.incrby).toHaveBeenCalledWith('cache:analytics:ttl_adjustments', 0);
+    });
+  });
+
+  // ─── cleanupOldMetrics ────────────────────────────────────────────────────
+
+  describe('cleanupOldMetrics', () => {
+    it('runs cleanup without errors when no metrics exist', async () => {
+      mockRedis.hgetall.mockResolvedValue({});
+
+      await expect(service.cleanupOldMetrics()).resolves.toBeUndefined();
+    });
+
+    it('keeps old metrics that have high sample count', async () => {
+      const oldDate = new Date(Date.now() - 8 * 24 * 60 * 60 * 1000);
+      const oldMetrics: CacheMetrics = {
+        ...freshMetrics(), key: 'popular-old', lastAccessed: oldDate, hits: 200, misses: 50,
+      };
+
+      mockRedis.hgetall.mockResolvedValue({ 'popular-old': JSON.stringify(oldMetrics) });
+
+      await service.cleanupOldMetrics();
+
+      expect(mockRedis.hdel).not.toHaveBeenCalled();
+    });
+
+    it('does nothing when there are no metrics', async () => {
+      mockRedis.hgetall.mockResolvedValue({});
+
+      await service.cleanupOldMetrics();
+
+      expect(mockRedis.hdel).not.toHaveBeenCalled();
+    });
+  });
+
+  // ─── handleCacheGet ───────────────────────────────────────────────────────
+
+  describe('handleCacheGet', () => {
+    it('delegates to recordHit when hit is true', async () => {
+      await service.handleCacheGet({ key: 'k', hit: true, ttl: 120 });
+
+      expect(mockRedis.hset).toHaveBeenCalled();
+      const stored = JSON.parse(mockRedis.hset.mock.calls[0][2]) as CacheMetrics;
+      expect(stored.hits).toBe(1);
+      expect(stored.avgTtl).toBe(120);
+    });
+
+    it('delegates to recordMiss when hit is false', async () => {
+      await service.handleCacheGet({ key: 'k', hit: false });
+
+      const stored = JSON.parse(mockRedis.hset.mock.calls[0][2]) as CacheMetrics;
+      expect(stored.misses).toBe(1);
+    });
+  });
+
+  // ─── handleCacheSet ───────────────────────────────────────────────────────
+
+  describe('handleCacheSet', () => {
+    it('delegates to recordSet', async () => {
+      await service.handleCacheSet({ key: 'k', ttl: 600, size: 4096 });
+
+      const stored = JSON.parse(mockRedis.hset.mock.calls[0][2]) as CacheMetrics;
+      expect(stored.avgTtl).toBe(600);
+      expect(stored.dataSize).toBe(4096);
+    });
+  });
+
+  // ─── cost score calculations (via recordHit + report) ─────────────────────
+
+  describe('cost score', () => {
+    it('ranks keys by costScore with high hit-rate and frequency scoring higher', async () => {
+      const smallHot: CacheMetrics = {
+        ...freshMetrics(), key: 'hot-small', hits: 200, misses: 10,
+        hitRate: 200 / 210, accessFrequency: 15, dataSize: 100, avgTtl: 300, costScore: 0.3,
+      };
+      const largeCold: CacheMetrics = {
+        ...freshMetrics(), key: 'cold-large', hits: 20, misses: 80,
+        hitRate: 0.2, accessFrequency: 0.5, dataSize: 5 * 1024 * 1024, avgTtl: 60, costScore: 0.1,
+      };
+      mockRedis.hgetall.mockResolvedValue({
+        'hot-small': JSON.stringify(smallHot),
+        'cold-large': JSON.stringify(largeCold),
+      });
+      mockRedis.info.mockResolvedValue('used_memory:1000');
+      mockRedis.get.mockResolvedValue('0');
+
+      const report = await service.generateAnalyticsReport();
+
+      expect(report.topPerformers[0].key).toBe('hot-small');
+      expect(report.topPerformers[0].costScore).toBeGreaterThan(
+        report.topPerformers.find((p) => p.key === 'cold-large')!.costScore,
+      );
+    });
+  });
+
+  // ─── TTL recommendation edge cases ────────────────────────────────────────
+
+  describe('TTL recommendations', () => {
+    const makeMetrics = (overrides: Partial<CacheMetrics> = {}): CacheMetrics => ({
+      ...freshMetrics(),
+      key: 'rec-key',
+      hits: 200,
+      misses: 10,
+      hitRate: 200 / 210,
+      avgTtl: 300,
+      accessFrequency: 10,
+      dataSize: 1024,
+      costScore: 0.8,
+      ...overrides,
+    });
+
+    it('recommends decreased TTL for low hit rate', async () => {
+      const metrics = makeMetrics({
+        hitRate: 0.2,
+        accessFrequency: 10,
+        avgTtl: 600,
+        dataSize: 512,
+      });
+      mockRedis.hgetall.mockResolvedValue({ [metrics.key]: JSON.stringify(metrics) });
+      mockRedis.info.mockResolvedValue('used_memory:100');
+      mockRedis.get.mockResolvedValue('0');
+
+      const report = await service.generateAnalyticsReport();
+
+      const rec = report.ttlRecommendations.find((r) => r.key === 'rec-key');
+      expect(rec).toBeDefined();
+      expect(rec!.recommendedTtl).toBeLessThan(600);
+    });
+
+    it('returns no recommendation when TTL change is less than 20%', async () => {
+      // high hit rate but accessFrequency is between 1 and 5, and dataSize is small
+      // → no rule triggers a significant change
+      const metrics = makeMetrics({
+        hitRate: 0.7,
+        accessFrequency: 3,
+        avgTtl: 300,
+        dataSize: 500,
+      });
+      mockRedis.hgetall.mockResolvedValue({ [metrics.key]: JSON.stringify(metrics) });
+      mockRedis.info.mockResolvedValue('used_memory:100');
+      mockRedis.get.mockResolvedValue('0');
+
+      const report = await service.generateAnalyticsReport();
+
+      expect(report.ttlRecommendations).toEqual([]);
+    });
+
+    it('does not recommend a TTL change for large objects when the change is exactly 20%', async () => {
+      // large-object branch sets recommendedTtl = max(avgTtl*0.8, 120)
+      // When avgTtl*0.8 > 120 the change is exactly 20%, which fails the >0.2 check
+      const metrics = makeMetrics({
+        hitRate: 0.5,
+        accessFrequency: 3,
+        avgTtl: 1200,
+        dataSize: 2 * 1024 * 1024, // 2MB
+      });
+      mockRedis.hgetall.mockResolvedValue({ [metrics.key]: JSON.stringify(metrics) });
+      mockRedis.info.mockResolvedValue('used_memory:100');
+      mockRedis.get.mockResolvedValue('0');
+
+      const report = await service.generateAnalyticsReport();
+
+      // 0.8*1200=960, |960-1200|/1200 = 0.2 exactly → not > 0.2, so no rec
+      const rec = report.ttlRecommendations.find((r) => r.key === 'rec-key');
+      expect(rec).toBeUndefined();
+    });
+
+    it('recommends decreased TTL for a large object when avgTtl is very low', async () => {
+      // When avgTtl is low enough that max(avgTtl*0.8, 120) = 120
+      // the change can exceed 20%
+      const metrics = makeMetrics({
+        hitRate: 0.5,
+        accessFrequency: 3,
+        avgTtl: 50,
+        dataSize: 2 * 1024 * 1024, // 2MB
+      });
+      mockRedis.hgetall.mockResolvedValue({ [metrics.key]: JSON.stringify(metrics) });
+      mockRedis.info.mockResolvedValue('used_memory:100');
+      mockRedis.get.mockResolvedValue('0');
+
+      const report = await service.generateAnalyticsReport();
+
+      const rec = report.ttlRecommendations.find((r) => r.key === 'rec-key');
+      expect(rec).toBeDefined();
+      expect(rec!.recommendedTtl).toBe(120); // Math.max(40, 120)
+      expect(rec!.reason).toContain('Large object');
+    });
+
+    it('sorts recommendations by potentialSavings descending', async () => {
+      const m1: CacheMetrics = makeMetrics({
+        key: 'key-a', hitRate: 0.1, accessFrequency: 10, avgTtl: 600, dataSize: 500,
+      });
+      const m2: CacheMetrics = makeMetrics({
+        key: 'key-b', hitRate: 0.1, accessFrequency: 10, avgTtl: 600, dataSize: 5000,
+      });
+      mockRedis.hgetall.mockResolvedValue({
+        'key-a': JSON.stringify(m1),
+        'key-b': JSON.stringify(m2),
+      });
+      mockRedis.info.mockResolvedValue('used_memory:100');
+      mockRedis.get.mockResolvedValue('0');
+
+      const report = await service.generateAnalyticsReport();
+
+      expect(report.ttlRecommendations.length).toBeGreaterThanOrEqual(2);
+      expect(report.ttlRecommendations[0].potentialSavings).toBeGreaterThanOrEqual(
+        report.ttlRecommendations[1].potentialSavings,
+      );
+    });
+  });
+});

--- a/src/caching/cache-analytics.service.spec.ts
+++ b/src/caching/cache-analytics.service.spec.ts
@@ -283,8 +283,20 @@ describe('CacheAnalyticsService', () => {
     });
 
     it('calculates overall hit rate from multiple keys', async () => {
-      const m1: CacheMetrics = { ...freshMetrics(), key: 'a', hits: 80, misses: 20, costScore: 0.5 };
-      const m2: CacheMetrics = { ...freshMetrics(), key: 'b', hits: 10, misses: 90, costScore: 0.2 };
+      const m1: CacheMetrics = {
+        ...freshMetrics(),
+        key: 'a',
+        hits: 80,
+        misses: 20,
+        costScore: 0.5,
+      };
+      const m2: CacheMetrics = {
+        ...freshMetrics(),
+        key: 'b',
+        hits: 10,
+        misses: 90,
+        costScore: 0.2,
+      };
       mockRedis.hgetall.mockResolvedValue({
         a: JSON.stringify(m1),
         b: JSON.stringify(m2),
@@ -323,7 +335,13 @@ describe('CacheAnalyticsService', () => {
 
     it('skips corrupt metrics entries gracefully', async () => {
       mockRedis.hgetall.mockResolvedValue({
-        good: JSON.stringify({ ...freshMetrics(), key: 'good', hits: 10, misses: 5, costScore: 0.5 }),
+        good: JSON.stringify({
+          ...freshMetrics(),
+          key: 'good',
+          hits: 10,
+          misses: 5,
+          costScore: 0.5,
+        }),
         bad: 'not-json',
         empty: JSON.stringify({ key: 'empty' }),
       });
@@ -532,7 +550,11 @@ describe('CacheAnalyticsService', () => {
     it('keeps old metrics that have high sample count', async () => {
       const oldDate = new Date(Date.now() - 8 * 24 * 60 * 60 * 1000);
       const oldMetrics: CacheMetrics = {
-        ...freshMetrics(), key: 'popular-old', lastAccessed: oldDate, hits: 200, misses: 50,
+        ...freshMetrics(),
+        key: 'popular-old',
+        lastAccessed: oldDate,
+        hits: 200,
+        misses: 50,
       };
 
       mockRedis.hgetall.mockResolvedValue({ 'popular-old': JSON.stringify(oldMetrics) });
@@ -588,12 +610,26 @@ describe('CacheAnalyticsService', () => {
   describe('cost score', () => {
     it('ranks keys by costScore with high hit-rate and frequency scoring higher', async () => {
       const smallHot: CacheMetrics = {
-        ...freshMetrics(), key: 'hot-small', hits: 200, misses: 10,
-        hitRate: 200 / 210, accessFrequency: 15, dataSize: 100, avgTtl: 300, costScore: 0.3,
+        ...freshMetrics(),
+        key: 'hot-small',
+        hits: 200,
+        misses: 10,
+        hitRate: 200 / 210,
+        accessFrequency: 15,
+        dataSize: 100,
+        avgTtl: 300,
+        costScore: 0.3,
       };
       const largeCold: CacheMetrics = {
-        ...freshMetrics(), key: 'cold-large', hits: 20, misses: 80,
-        hitRate: 0.2, accessFrequency: 0.5, dataSize: 5 * 1024 * 1024, avgTtl: 60, costScore: 0.1,
+        ...freshMetrics(),
+        key: 'cold-large',
+        hits: 20,
+        misses: 80,
+        hitRate: 0.2,
+        accessFrequency: 0.5,
+        dataSize: 5 * 1024 * 1024,
+        avgTtl: 60,
+        costScore: 0.1,
       };
       mockRedis.hgetall.mockResolvedValue({
         'hot-small': JSON.stringify(smallHot),
@@ -706,10 +742,18 @@ describe('CacheAnalyticsService', () => {
 
     it('sorts recommendations by potentialSavings descending', async () => {
       const m1: CacheMetrics = makeMetrics({
-        key: 'key-a', hitRate: 0.1, accessFrequency: 10, avgTtl: 600, dataSize: 500,
+        key: 'key-a',
+        hitRate: 0.1,
+        accessFrequency: 10,
+        avgTtl: 600,
+        dataSize: 500,
       });
       const m2: CacheMetrics = makeMetrics({
-        key: 'key-b', hitRate: 0.1, accessFrequency: 10, avgTtl: 600, dataSize: 5000,
+        key: 'key-b',
+        hitRate: 0.1,
+        accessFrequency: 10,
+        avgTtl: 600,
+        dataSize: 5000,
       });
       mockRedis.hgetall.mockResolvedValue({
         'key-a': JSON.stringify(m1),

--- a/src/caching/cache-optimization.service.spec.ts
+++ b/src/caching/cache-optimization.service.spec.ts
@@ -1,0 +1,483 @@
+import { EventEmitter2 } from '@nestjs/event-emitter';
+import { CacheOptimizationService } from './cache-optimization.service';
+import { CacheAnalyticsReport, CacheAnalyticsService, TTLRecommendation } from './cache-analytics.service';
+
+jest.mock('../config/cache.config', () => ({
+  getSharedRedisClient: jest.fn(() => ({
+    get: jest.fn().mockResolvedValue(null),
+    set: jest.fn().mockResolvedValue('OK'),
+    del: jest.fn().mockResolvedValue(1),
+  })),
+}));
+
+function makeConfigService(overrides: Record<string, unknown> = {}) {
+  const defaults: Record<string, unknown> = {
+    CACHE_ADAPTIVE_TTL_ENABLED: true,
+    CACHE_HIT_RATE_OPTIMIZATION_ENABLED: true,
+    CACHE_MEMORY_OPTIMIZATION_ENABLED: true,
+    CACHE_MIN_HIT_RATE_THRESHOLD: 0.6,
+    CACHE_MAX_MEMORY_THRESHOLD: 0.8,
+    CACHE_OPTIMIZATION_INTERVAL_MINUTES: 60,
+  };
+  return {
+    get: jest.fn((key: string, fallback?: unknown) => {
+      const val = { ...defaults, ...overrides }[key];
+      return val ?? fallback;
+    }),
+  };
+}
+
+function makeReport(overrides: Partial<CacheAnalyticsReport> = {}): CacheAnalyticsReport {
+  return {
+    totalKeys: 0,
+    overallHitRate: 0,
+    memoryUsage: 0,
+    topPerformers: [],
+    underPerformers: [],
+    ttlRecommendations: [],
+    adaptiveTtlAdjustments: 0,
+    generatedAt: new Date(),
+    ...overrides,
+  };
+}
+
+describe('CacheOptimizationService', () => {
+  let service: CacheOptimizationService;
+  let cacheManager: { get: jest.Mock; set: jest.Mock; del: jest.Mock };
+  let eventEmitter: { emit: jest.Mock };
+  let analyticsService: { getRecommendedTTL: jest.Mock; generateAnalyticsReport: jest.Mock };
+
+  beforeEach(() => {
+    cacheManager = {
+      get: jest.fn().mockResolvedValue(undefined),
+      set: jest.fn().mockResolvedValue(undefined),
+      del: jest.fn().mockResolvedValue(undefined),
+    };
+    eventEmitter = { emit: jest.fn() };
+    analyticsService = {
+      getRecommendedTTL: jest.fn().mockResolvedValue(300),
+      generateAnalyticsReport: jest.fn().mockResolvedValue(makeReport()),
+    };
+    service = new CacheOptimizationService(
+      cacheManager as never,
+      makeConfigService() as never,
+      eventEmitter as unknown as EventEmitter2,
+      analyticsService as unknown as CacheAnalyticsService,
+    );
+  });
+
+  afterEach(() => jest.restoreAllMocks());
+
+  // ─── get ──────────────────────────────────────────────────────────────────
+
+  describe('get', () => {
+    it('returns cached value on hit and emits events', async () => {
+      cacheManager.get.mockResolvedValueOnce('cached-data');
+
+      const result = await service.get<string>('my-key');
+
+      expect(result).toBe('cached-data');
+      expect(eventEmitter.emit).toHaveBeenCalledWith(
+        'cache.get',
+        expect.objectContaining({ key: 'my-key', hit: true }),
+      );
+      expect(eventEmitter.emit).toHaveBeenCalledWith(
+        'cache.performance',
+        expect.objectContaining({ operation: 'get', key: 'my-key', hit: true }),
+      );
+    });
+
+    it('returns undefined on cache miss', async () => {
+      cacheManager.get.mockResolvedValueOnce(undefined);
+
+      const result = await service.get<string>('missing-key');
+
+      expect(result).toBeUndefined();
+      expect(eventEmitter.emit).toHaveBeenCalledWith(
+        'cache.get',
+        expect.objectContaining({ key: 'missing-key', hit: false }),
+      );
+    });
+
+    it('returns undefined on error and emits cache.error', async () => {
+      cacheManager.get.mockRejectedValueOnce(new Error('redis down'));
+
+      const result = await service.get<string>('fail-key');
+
+      expect(result).toBeUndefined();
+      expect(eventEmitter.emit).toHaveBeenCalledWith(
+        'cache.error',
+        expect.objectContaining({ operation: 'get', key: 'fail-key' }),
+      );
+    });
+  });
+
+  // ─── set ──────────────────────────────────────────────────────────────────
+
+  describe('set', () => {
+    it('sets value with default TTL when no ttl supplied', async () => {
+      await service.set('cache:course:1', { name: 'Course 1' });
+
+      expect(cacheManager.set).toHaveBeenCalledWith(
+        'cache:course:1',
+        { name: 'Course 1' },
+        expect.any(Number),
+      );
+      expect(eventEmitter.emit).toHaveBeenCalledWith(
+        'cache.set',
+        expect.objectContaining({ key: 'cache:course:1', size: expect.any(Number) }),
+      );
+    });
+
+    it('uses adaptive TTL when enabled and ttl is supplied', async () => {
+      analyticsService.getRecommendedTTL.mockResolvedValueOnce(600);
+
+      await service.set('my-key', 'value', 300);
+
+      expect(analyticsService.getRecommendedTTL).toHaveBeenCalledWith('my-key', 300);
+      // finalTtl=600, so cacheManager.set gets 600*1000 ms
+      expect(cacheManager.set).toHaveBeenCalledWith('my-key', 'value', 600_000);
+    });
+
+    it('uses provided TTL directly when adaptive TTL is disabled', async () => {
+      service = new CacheOptimizationService(
+        cacheManager as never,
+        makeConfigService({ CACHE_ADAPTIVE_TTL_ENABLED: false }) as never,
+        eventEmitter as unknown as EventEmitter2,
+        analyticsService as unknown as CacheAnalyticsService,
+      );
+
+      await service.set('my-key', 'value', 120);
+
+      expect(analyticsService.getRecommendedTTL).not.toHaveBeenCalled();
+      expect(cacheManager.set).toHaveBeenCalledWith('my-key', 'value', 120_000);
+    });
+
+    it('uses default TTL for unknown prefix when no ttl supplied', async () => {
+      await service.set('unknown-prefix:key', 'data');
+
+      // Falls back to CACHE_TTL.COURSE_DETAILS = 300
+      expect(cacheManager.set).toHaveBeenCalledWith('unknown-prefix:key', 'data', 300_000);
+    });
+
+    it('emits cache.error on cache-manager failure', async () => {
+      cacheManager.set.mockRejectedValueOnce(new Error('set failed'));
+
+      await service.set('bad-key', 'value');
+
+      expect(eventEmitter.emit).toHaveBeenCalledWith(
+        'cache.error',
+        expect.objectContaining({ operation: 'set', key: 'bad-key' }),
+      );
+    });
+  });
+
+  // ─── del ──────────────────────────────────────────────────────────────────
+
+  describe('del', () => {
+    it('deletes key and emits cache.delete event', async () => {
+      await service.del('my-key');
+
+      expect(cacheManager.del).toHaveBeenCalledWith('my-key');
+      expect(eventEmitter.emit).toHaveBeenCalledWith('cache.delete', { key: 'my-key' });
+      expect(eventEmitter.emit).toHaveBeenCalledWith(
+        'cache.performance',
+        expect.objectContaining({ operation: 'delete', key: 'my-key' }),
+      );
+    });
+
+    it('emits cache.error on failure', async () => {
+      cacheManager.del.mockRejectedValueOnce(new Error('del failed'));
+
+      await service.del('bad-key');
+
+      expect(eventEmitter.emit).toHaveBeenCalledWith(
+        'cache.error',
+        expect.objectContaining({ operation: 'delete', key: 'bad-key' }),
+      );
+    });
+  });
+
+  // ─── optimizeCache ────────────────────────────────────────────────────────
+
+  describe('optimizeCache', () => {
+    it('applies TTL optimizations from high-confidence recommendations', async () => {
+      const recommendations: TTLRecommendation[] = [
+        {
+          key: 'hot-key',
+          currentTtl: 300,
+          recommendedTtl: 450,
+          reason: 'increase',
+          confidence: 0.9,
+          potentialSavings: 1024,
+        },
+        {
+          key: 'low-conf-key',
+          currentTtl: 300,
+          recommendedTtl: 150,
+          reason: 'decrease',
+          confidence: 0.5,
+          potentialSavings: 512,
+        },
+      ];
+      analyticsService.generateAnalyticsReport.mockResolvedValueOnce(
+        makeReport({ ttlRecommendations: recommendations }),
+      );
+
+      const result = await service.optimizeCache();
+
+      // Only the high-confidence one (0.9 > 0.7) should be applied
+      expect(result.optimizationsApplied).toBe(1);
+      expect(result.memoryFreed).toBe(1024);
+      expect(result.recommendations).toEqual(recommendations);
+      expect(result.timestamp).toBeInstanceOf(Date);
+      expect(eventEmitter.emit).toHaveBeenCalledWith(
+        'cache.ttl.updated',
+        { key: 'hot-key', ttl: 450 },
+      );
+      expect(eventEmitter.emit).toHaveBeenCalledWith(
+        'cache.optimization.completed',
+        expect.any(Object),
+      );
+    });
+
+    it('applies hit rate optimizations for low-hit-rate underperformers', async () => {
+      const underPerformers = [
+        {
+          key: 'low-hit',
+          hits: 5,
+          misses: 95,
+          hitRate: 0.05,
+          avgTtl: 600,
+          accessFrequency: 2,
+          dataSize: 500,
+          costScore: 0.1,
+          lastAccessed: new Date(),
+        },
+        {
+          key: 'mid-hit',
+          hits: 40,
+          misses: 60,
+          hitRate: 0.4,
+          avgTtl: 600,
+          accessFrequency: 2,
+          dataSize: 500,
+          costScore: 0.3,
+          lastAccessed: new Date(),
+        },
+      ];
+      analyticsService.generateAnalyticsReport.mockResolvedValueOnce(
+        makeReport({ underPerformers }),
+      );
+
+      const result = await service.optimizeCache();
+
+      // mid-hit: avgTtl 600 > 300 → TTL reduced
+      // low-hit: avgTtl 600 > 300 → TTL reduced, AND hitRate < 0.1 + freq < 0.5 → scheduled for removal
+      expect(result.optimizationsApplied).toBeGreaterThanOrEqual(2);
+      expect(eventEmitter.emit).toHaveBeenCalledWith(
+        'cache.ttl.updated',
+        expect.objectContaining({ key: 'mid-hit' }),
+      );
+    });
+
+    it('applies memory optimizations for large low-performing keys', async () => {
+      const underPerformers = [
+        {
+          key: 'big-slow',
+          hits: 2,
+          misses: 98,
+          hitRate: 0.02,
+          avgTtl: 300,
+          accessFrequency: 1,
+          dataSize: 2 * 1024 * 1024, // 2MB
+          costScore: 0.05,
+          lastAccessed: new Date(),
+        },
+      ];
+      analyticsService.generateAnalyticsReport.mockResolvedValueOnce(
+        makeReport({ underPerformers }),
+      );
+
+      const result = await service.optimizeCache();
+
+      expect(result.memoryFreed).toBeGreaterThanOrEqual(2 * 1024 * 1024);
+      expect(cacheManager.del).toHaveBeenCalledWith('big-slow');
+    });
+
+    it('respects disabled feature flags', async () => {
+      service = new CacheOptimizationService(
+        cacheManager as never,
+        makeConfigService({
+          CACHE_ADAPTIVE_TTL_ENABLED: false,
+          CACHE_HIT_RATE_OPTIMIZATION_ENABLED: false,
+          CACHE_MEMORY_OPTIMIZATION_ENABLED: false,
+        }) as never,
+        eventEmitter as unknown as EventEmitter2,
+        analyticsService as unknown as CacheAnalyticsService,
+      );
+      analyticsService.generateAnalyticsReport.mockResolvedValueOnce(
+        makeReport({
+          ttlRecommendations: [
+            {
+              key: 'k',
+              currentTtl: 100,
+              recommendedTtl: 200,
+              reason: 'r',
+              confidence: 0.9,
+              potentialSavings: 100,
+            },
+          ],
+          underPerformers: [
+            {
+              key: 'low',
+              hits: 1,
+              misses: 99,
+              hitRate: 0.01,
+              avgTtl: 600,
+              accessFrequency: 0.1,
+              dataSize: 3 * 1024 * 1024,
+              costScore: 0.01,
+              lastAccessed: new Date(),
+            },
+          ],
+        }),
+      );
+
+      const result = await service.optimizeCache();
+
+      expect(result.optimizationsApplied).toBe(0);
+      expect(result.memoryFreed).toBe(0);
+      // No TTL updates or deletes when everything is disabled
+      expect(eventEmitter.emit).not.toHaveBeenCalledWith(
+        'cache.ttl.updated',
+        expect.anything(),
+      );
+    });
+
+    it('returns zero optimizations when no recommendations exist', async () => {
+      const result = await service.optimizeCache();
+
+      expect(result.optimizationsApplied).toBe(0);
+      expect(result.memoryFreed).toBe(0);
+      expect(result.hitRateImprovement).toBe(0);
+      expect(result.recommendations).toEqual([]);
+    });
+  });
+
+  // ─── getOptimizationConfig ────────────────────────────────────────────────
+
+  describe('getOptimizationConfig', () => {
+    it('returns a copy of the current config', () => {
+      const config = service.getOptimizationConfig();
+
+      expect(config.enableAdaptiveTtl).toBe(true);
+      expect(config.enableHitRateOptimization).toBe(true);
+      expect(config.enableMemoryOptimization).toBe(true);
+      expect(config.minHitRateThreshold).toBe(0.6);
+      expect(config.maxMemoryUsageThreshold).toBe(0.8);
+      expect(config.optimizationInterval).toBe(60);
+    });
+
+    it('returns a copy, not a reference', () => {
+      const config1 = service.getOptimizationConfig();
+      const config2 = service.getOptimizationConfig();
+
+      expect(config1).not.toBe(config2);
+      expect(config1).toEqual(config2);
+    });
+
+    it('reflects custom config overrides', () => {
+      service = new CacheOptimizationService(
+        cacheManager as never,
+        makeConfigService({
+          CACHE_ADAPTIVE_TTL_ENABLED: false,
+          CACHE_MIN_HIT_RATE_THRESHOLD: 0.9,
+        }) as never,
+        eventEmitter as unknown as EventEmitter2,
+        analyticsService as unknown as CacheAnalyticsService,
+      );
+
+      const config = service.getOptimizationConfig();
+      expect(config.enableAdaptiveTtl).toBe(false);
+      expect(config.minHitRateThreshold).toBe(0.9);
+    });
+  });
+
+  // ─── updateOptimizationConfig ─────────────────────────────────────────────
+
+  describe('updateOptimizationConfig', () => {
+    it('updates config and emits cache.config.updated event', () => {
+      service.updateOptimizationConfig({ enableAdaptiveTtl: false, optimizationInterval: 30 });
+
+      const config = service.getOptimizationConfig();
+      expect(config.enableAdaptiveTtl).toBe(false);
+      expect(config.optimizationInterval).toBe(30);
+      // Other values unchanged
+      expect(config.enableHitRateOptimization).toBe(true);
+
+      expect(eventEmitter.emit).toHaveBeenCalledWith(
+        'cache.config.updated',
+        expect.objectContaining({ enableAdaptiveTtl: false, optimizationInterval: 30 }),
+      );
+    });
+
+    it('preserves other config values when partial update', () => {
+      service.updateOptimizationConfig({ minHitRateThreshold: 0.9 });
+
+      const config = service.getOptimizationConfig();
+      expect(config.minHitRateThreshold).toBe(0.9);
+      expect(config.enableAdaptiveTtl).toBe(true);
+      expect(config.maxMemoryUsageThreshold).toBe(0.8);
+    });
+  });
+
+  // ─── getDefaultTTL (via set without ttl) ──────────────────────────────────
+
+  describe('default TTL selection (via set)', () => {
+    it('uses USER_PROFILE TTL for user profile keys', async () => {
+      await service.set('cache:user:profile:123', { name: 'User' });
+      expect(cacheManager.set).toHaveBeenCalledWith(
+        'cache:user:profile:123',
+        { name: 'User' },
+        600_000, // CACHE_TTL.USER_PROFILE = 600
+      );
+    });
+
+    it('uses SEARCH_RESULTS TTL for search keys', async () => {
+      await service.set('cache:search:query', { results: [] });
+      expect(cacheManager.set).toHaveBeenCalledWith(
+        'cache:search:query',
+        { results: [] },
+        120_000, // CACHE_TTL.SEARCH_RESULTS = 120
+      );
+    });
+
+    it('uses POPULAR_COURSES TTL for popular keys', async () => {
+      await service.set('cache:popular:list', []);
+      expect(cacheManager.set).toHaveBeenCalledWith(
+        'cache:popular:list',
+        [],
+        1800_000, // CACHE_TTL.POPULAR_COURSES = 1800
+      );
+    });
+
+    it('uses ENROLLMENT_DATA TTL for enrollment keys', async () => {
+      await service.set('cache:enrollment:123', { enrolled: true });
+      expect(cacheManager.set).toHaveBeenCalledWith(
+        'cache:enrollment:123',
+        { enrolled: true },
+        300_000, // CACHE_TTL.ENROLLMENT_DATA = 300
+      );
+    });
+
+    it('uses COURSE_DETAILS TTL for course keys', async () => {
+      await service.set('cache:course:42', { title: 'Course' });
+      expect(cacheManager.set).toHaveBeenCalledWith(
+        'cache:course:42',
+        { title: 'Course' },
+        300_000, // CACHE_TTL.COURSE_DETAILS = 300
+      );
+    });
+  });
+});

--- a/src/caching/cache-optimization.service.spec.ts
+++ b/src/caching/cache-optimization.service.spec.ts
@@ -1,6 +1,10 @@
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import { CacheOptimizationService } from './cache-optimization.service';
-import { CacheAnalyticsReport, CacheAnalyticsService, TTLRecommendation } from './cache-analytics.service';
+import {
+  CacheAnalyticsReport,
+  CacheAnalyticsService,
+  TTLRecommendation,
+} from './cache-analytics.service';
 
 jest.mock('../config/cache.config', () => ({
   getSharedRedisClient: jest.fn(() => ({
@@ -231,10 +235,10 @@ describe('CacheOptimizationService', () => {
       expect(result.memoryFreed).toBe(1024);
       expect(result.recommendations).toEqual(recommendations);
       expect(result.timestamp).toBeInstanceOf(Date);
-      expect(eventEmitter.emit).toHaveBeenCalledWith(
-        'cache.ttl.updated',
-        { key: 'hot-key', ttl: 450 },
-      );
+      expect(eventEmitter.emit).toHaveBeenCalledWith('cache.ttl.updated', {
+        key: 'hot-key',
+        ttl: 450,
+      });
       expect(eventEmitter.emit).toHaveBeenCalledWith(
         'cache.optimization.completed',
         expect.any(Object),
@@ -349,10 +353,7 @@ describe('CacheOptimizationService', () => {
       expect(result.optimizationsApplied).toBe(0);
       expect(result.memoryFreed).toBe(0);
       // No TTL updates or deletes when everything is disabled
-      expect(eventEmitter.emit).not.toHaveBeenCalledWith(
-        'cache.ttl.updated',
-        expect.anything(),
-      );
+      expect(eventEmitter.emit).not.toHaveBeenCalledWith('cache.ttl.updated', expect.anything());
     });
 
     it('returns zero optimizations when no recommendations exist', async () => {

--- a/src/common/database/transaction-helper.service.spec.ts
+++ b/src/common/database/transaction-helper.service.spec.ts
@@ -80,10 +80,7 @@ describe('TransactionHelperService', () => {
       const op1 = jest.fn().mockResolvedValue('a');
       const op2 = jest.fn().mockResolvedValue('b');
 
-      const results = await service.executeWithRollback([
-        { operation: op1 },
-        { operation: op2 },
-      ]);
+      const results = await service.executeWithRollback([{ operation: op1 }, { operation: op2 }]);
 
       expect(results).toEqual(['a', 'b']);
       expect(queryRunner.commitTransaction).toHaveBeenCalledTimes(1);
@@ -114,9 +111,7 @@ describe('TransactionHelperService', () => {
     it('rolls back and rethrows on operation failure', async () => {
       const op = jest.fn().mockRejectedValue(new Error('fail'));
 
-      await expect(
-        service.executeWithRollback([{ operation: op }]),
-      ).rejects.toThrow('fail');
+      await expect(service.executeWithRollback([{ operation: op }])).rejects.toThrow('fail');
       expect(queryRunner.rollbackTransaction).toHaveBeenCalledTimes(1);
       expect(queryRunner.release).toHaveBeenCalledTimes(1);
     });
@@ -125,9 +120,9 @@ describe('TransactionHelperService', () => {
       const rollback = jest.fn().mockResolvedValue(undefined);
       const op = jest.fn().mockRejectedValue(new Error('fail'));
 
-      await expect(
-        service.executeWithRollback([{ operation: op, rollback }]),
-      ).rejects.toThrow('fail');
+      await expect(service.executeWithRollback([{ operation: op, rollback }])).rejects.toThrow(
+        'fail',
+      );
       expect(rollback).toHaveBeenCalledWith(queryRunner.manager);
     });
 
@@ -135,9 +130,9 @@ describe('TransactionHelperService', () => {
       const rollback = jest.fn().mockRejectedValue(new Error('rollback failed'));
       const op = jest.fn().mockRejectedValue(new Error('original fail'));
 
-      await expect(
-        service.executeWithRollback([{ operation: op, rollback }]),
-      ).rejects.toThrow('original fail');
+      await expect(service.executeWithRollback([{ operation: op, rollback }])).rejects.toThrow(
+        'original fail',
+      );
       // rollback error is caught and logged, original error is rethrown
     });
 
@@ -171,9 +166,7 @@ describe('TransactionHelperService', () => {
       await expect(service.createSavepoint(manager, 'has space')).rejects.toThrow(
         'Invalid savepoint name',
       );
-      await expect(service.createSavepoint(manager, '')).rejects.toThrow(
-        'Invalid savepoint name',
-      );
+      await expect(service.createSavepoint(manager, '')).rejects.toThrow('Invalid savepoint name');
     });
 
     it('accepts underscore-prefixed names', async () => {

--- a/src/common/database/transaction-helper.service.spec.ts
+++ b/src/common/database/transaction-helper.service.spec.ts
@@ -1,0 +1,363 @@
+import { DataSource, QueryRunner, EntityManager } from 'typeorm';
+import { TransactionHelperService } from './transaction-helper.service';
+
+describe('TransactionHelperService', () => {
+  let service: TransactionHelperService;
+  let dataSource: { createQueryRunner: jest.Mock };
+  let queryRunner: {
+    connect: jest.Mock;
+    startTransaction: jest.Mock;
+    commitTransaction: jest.Mock;
+    rollbackTransaction: jest.Mock;
+    release: jest.Mock;
+    manager: EntityManager;
+  };
+
+  beforeEach(() => {
+    queryRunner = {
+      connect: jest.fn().mockResolvedValue(undefined),
+      startTransaction: jest.fn().mockResolvedValue(undefined),
+      commitTransaction: jest.fn().mockResolvedValue(undefined),
+      rollbackTransaction: jest.fn().mockResolvedValue(undefined),
+      release: jest.fn().mockResolvedValue(undefined),
+      manager: {} as EntityManager,
+    };
+    dataSource = {
+      createQueryRunner: jest.fn().mockReturnValue(queryRunner),
+    };
+    service = new TransactionHelperService(dataSource as unknown as DataSource);
+  });
+
+  afterEach(() => jest.restoreAllMocks());
+
+  // ─── executeInTransaction ─────────────────────────────────────────────────
+
+  describe('executeInTransaction', () => {
+    it('runs all operations and returns results', async () => {
+      const op1 = jest.fn().mockResolvedValue('result-1');
+      const op2 = jest.fn().mockResolvedValue('result-2');
+
+      const results = await service.executeInTransaction([op1, op2]);
+
+      expect(results).toEqual(['result-1', 'result-2']);
+      expect(op1).toHaveBeenCalledWith(queryRunner.manager);
+      expect(op2).toHaveBeenCalledWith(queryRunner.manager);
+      expect(queryRunner.connect).toHaveBeenCalledTimes(1);
+      expect(queryRunner.startTransaction).toHaveBeenCalledTimes(1);
+      expect(queryRunner.commitTransaction).toHaveBeenCalledTimes(1);
+      expect(queryRunner.release).toHaveBeenCalledTimes(1);
+    });
+
+    it('rolls back and rethrows on operation failure', async () => {
+      const failingOp = jest.fn().mockRejectedValue(new Error('db error'));
+
+      await expect(service.executeInTransaction([failingOp])).rejects.toThrow('db error');
+      expect(queryRunner.rollbackTransaction).toHaveBeenCalledTimes(1);
+      expect(queryRunner.commitTransaction).not.toHaveBeenCalled();
+      expect(queryRunner.release).toHaveBeenCalledTimes(1);
+    });
+
+    it('releases query runner even when commit fails', async () => {
+      queryRunner.commitTransaction.mockRejectedValue(new Error('commit failed'));
+
+      await expect(
+        service.executeInTransaction([jest.fn().mockResolvedValue('ok')]),
+      ).rejects.toThrow('commit failed');
+      expect(queryRunner.release).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns empty array for zero operations', async () => {
+      const results = await service.executeInTransaction([]);
+      expect(results).toEqual([]);
+      expect(queryRunner.commitTransaction).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // ─── executeWithRollback ──────────────────────────────────────────────────
+
+  describe('executeWithRollback', () => {
+    it('runs operations sequentially and returns results', async () => {
+      const op1 = jest.fn().mockResolvedValue('a');
+      const op2 = jest.fn().mockResolvedValue('b');
+
+      const results = await service.executeWithRollback([
+        { operation: op1 },
+        { operation: op2 },
+      ]);
+
+      expect(results).toEqual(['a', 'b']);
+      expect(queryRunner.commitTransaction).toHaveBeenCalledTimes(1);
+    });
+
+    it('skips operations when condition returns false', async () => {
+      const op1 = jest.fn().mockResolvedValue('a');
+      const op2 = jest.fn().mockResolvedValue('b');
+
+      const results = await service.executeWithRollback([
+        { operation: op1, condition: () => true },
+        { operation: op2, condition: () => false },
+      ]);
+
+      expect(results).toEqual(['a']);
+      expect(op1).toHaveBeenCalledTimes(1);
+      expect(op2).not.toHaveBeenCalled();
+    });
+
+    it('runs operations without condition', async () => {
+      const op = jest.fn().mockResolvedValue('x');
+
+      const results = await service.executeWithRollback([{ operation: op }]);
+
+      expect(results).toEqual(['x']);
+    });
+
+    it('rolls back and rethrows on operation failure', async () => {
+      const op = jest.fn().mockRejectedValue(new Error('fail'));
+
+      await expect(
+        service.executeWithRollback([{ operation: op }]),
+      ).rejects.toThrow('fail');
+      expect(queryRunner.rollbackTransaction).toHaveBeenCalledTimes(1);
+      expect(queryRunner.release).toHaveBeenCalledTimes(1);
+    });
+
+    it('executes rollback functions on failure', async () => {
+      const rollback = jest.fn().mockResolvedValue(undefined);
+      const op = jest.fn().mockRejectedValue(new Error('fail'));
+
+      await expect(
+        service.executeWithRollback([{ operation: op, rollback }]),
+      ).rejects.toThrow('fail');
+      expect(rollback).toHaveBeenCalledWith(queryRunner.manager);
+    });
+
+    it('handles rollback function failure gracefully', async () => {
+      const rollback = jest.fn().mockRejectedValue(new Error('rollback failed'));
+      const op = jest.fn().mockRejectedValue(new Error('original fail'));
+
+      await expect(
+        service.executeWithRollback([{ operation: op, rollback }]),
+      ).rejects.toThrow('original fail');
+      // rollback error is caught and logged, original error is rethrown
+    });
+
+    it('does not call rollback functions on success', async () => {
+      const rollback = jest.fn();
+      const op = jest.fn().mockResolvedValue('ok');
+
+      await service.executeWithRollback([{ operation: op, rollback }]);
+
+      expect(rollback).not.toHaveBeenCalled();
+    });
+  });
+
+  // ─── createSavepoint ──────────────────────────────────────────────────────
+
+  describe('createSavepoint', () => {
+    it('creates a savepoint with valid name', async () => {
+      const manager = { query: jest.fn().mockResolvedValue(undefined) } as unknown as EntityManager;
+
+      await service.createSavepoint(manager, 'sp1');
+
+      expect(manager.query).toHaveBeenCalledWith('SAVEPOINT sp1');
+    });
+
+    it('rejects invalid savepoint names', async () => {
+      const manager = { query: jest.fn() } as unknown as EntityManager;
+
+      await expect(service.createSavepoint(manager, '123bad')).rejects.toThrow(
+        'Invalid savepoint name',
+      );
+      await expect(service.createSavepoint(manager, 'has space')).rejects.toThrow(
+        'Invalid savepoint name',
+      );
+      await expect(service.createSavepoint(manager, '')).rejects.toThrow(
+        'Invalid savepoint name',
+      );
+    });
+
+    it('accepts underscore-prefixed names', async () => {
+      const manager = { query: jest.fn().mockResolvedValue(undefined) } as unknown as EntityManager;
+
+      await service.createSavepoint(manager, '_savepoint');
+
+      expect(manager.query).toHaveBeenCalledWith('SAVEPOINT _savepoint');
+    });
+  });
+
+  // ─── rollbackToSavepoint ──────────────────────────────────────────────────
+
+  describe('rollbackToSavepoint', () => {
+    it('rolls back to a savepoint with valid name', async () => {
+      const manager = { query: jest.fn().mockResolvedValue(undefined) } as unknown as EntityManager;
+
+      await service.rollbackToSavepoint(manager, 'sp1');
+
+      expect(manager.query).toHaveBeenCalledWith('ROLLBACK TO SAVEPOINT sp1');
+    });
+
+    it('rejects invalid savepoint names', async () => {
+      const manager = { query: jest.fn() } as unknown as EntityManager;
+
+      await expect(service.rollbackToSavepoint(manager, 'bad-name!')).rejects.toThrow(
+        'Invalid savepoint name',
+      );
+    });
+  });
+
+  // ─── releaseSavepoint ─────────────────────────────────────────────────────
+
+  describe('releaseSavepoint', () => {
+    it('releases a savepoint with valid name', async () => {
+      const manager = { query: jest.fn().mockResolvedValue(undefined) } as unknown as EntityManager;
+
+      await service.releaseSavepoint(manager, 'sp1');
+
+      expect(manager.query).toHaveBeenCalledWith('RELEASE SAVEPOINT sp1');
+    });
+
+    it('rejects invalid savepoint names', async () => {
+      const manager = { query: jest.fn() } as unknown as EntityManager;
+
+      await expect(service.releaseSavepoint(manager, 'no spaces')).rejects.toThrow(
+        'Invalid savepoint name',
+      );
+    });
+  });
+
+  // ─── isInTransaction ──────────────────────────────────────────────────────
+
+  describe('isInTransaction', () => {
+    it('returns true when transaction is active', () => {
+      const manager = {
+        queryRunner: { isTransactionActive: true },
+      } as unknown as EntityManager;
+
+      expect(service.isInTransaction(manager)).toBe(true);
+    });
+
+    it('returns false when transaction is not active', () => {
+      const manager = {
+        queryRunner: { isTransactionActive: false },
+      } as unknown as EntityManager;
+
+      expect(service.isInTransaction(manager)).toBe(false);
+    });
+
+    it('returns false when queryRunner is undefined', () => {
+      const manager = { queryRunner: undefined } as unknown as EntityManager;
+
+      expect(service.isInTransaction(manager)).toBe(false);
+    });
+  });
+
+  // ─── getIsolationLevel ────────────────────────────────────────────────────
+
+  describe('getIsolationLevel', () => {
+    it('returns the isolation level from the database', async () => {
+      const manager = {
+        query: jest.fn().mockResolvedValue([{ level: 'REPEATABLE READ' }]),
+      } as unknown as EntityManager;
+
+      const level = await service.getIsolationLevel(manager);
+
+      expect(level).toBe('REPEATABLE READ');
+      expect(manager.query).toHaveBeenCalledWith('SHOW TRANSACTION ISOLATION LEVEL');
+    });
+
+    it('returns READ COMMITTED as fallback on error', async () => {
+      const manager = {
+        query: jest.fn().mockRejectedValue(new Error('not supported')),
+      } as unknown as EntityManager;
+
+      const level = await service.getIsolationLevel(manager);
+
+      expect(level).toBe('READ COMMITTED');
+    });
+
+    it('returns READ COMMITTED when query returns empty result', async () => {
+      const manager = {
+        query: jest.fn().mockResolvedValue([]),
+      } as unknown as EntityManager;
+
+      const level = await service.getIsolationLevel(manager);
+
+      expect(level).toBe('READ COMMITTED');
+    });
+  });
+
+  // ─── setTransactionTimeout ────────────────────────────────────────────────
+
+  describe('setTransactionTimeout', () => {
+    it('sets lock timeout for valid integer', async () => {
+      const manager = { query: jest.fn().mockResolvedValue(undefined) } as unknown as EntityManager;
+
+      await service.setTransactionTimeout(manager, 5000);
+
+      expect(manager.query).toHaveBeenCalledWith('SET lock_timeout = $1', ['5000']);
+    });
+
+    it('sets timeout for zero', async () => {
+      const manager = { query: jest.fn().mockResolvedValue(undefined) } as unknown as EntityManager;
+
+      await service.setTransactionTimeout(manager, 0);
+
+      expect(manager.query).toHaveBeenCalledWith('SET lock_timeout = $1', ['0']);
+    });
+
+    it('rejects negative timeout', async () => {
+      const manager = { query: jest.fn() } as unknown as EntityManager;
+
+      await expect(service.setTransactionTimeout(manager, -1)).rejects.toThrow(
+        'Invalid timeout value',
+      );
+    });
+
+    it('rejects non-integer timeout', async () => {
+      const manager = { query: jest.fn() } as unknown as EntityManager;
+
+      await expect(service.setTransactionTimeout(manager, 1.5)).rejects.toThrow(
+        'Invalid timeout value',
+      );
+      await expect(service.setTransactionTimeout(manager, NaN)).rejects.toThrow(
+        'Invalid timeout value',
+      );
+    });
+  });
+
+  // ─── setStatementTimeout ──────────────────────────────────────────────────
+
+  describe('setStatementTimeout', () => {
+    it('sets statement timeout for valid integer', async () => {
+      const manager = { query: jest.fn().mockResolvedValue(undefined) } as unknown as EntityManager;
+
+      await service.setStatementTimeout(manager, 10000);
+
+      expect(manager.query).toHaveBeenCalledWith('SET statement_timeout = $1', ['10000']);
+    });
+
+    it('sets timeout for zero', async () => {
+      const manager = { query: jest.fn().mockResolvedValue(undefined) } as unknown as EntityManager;
+
+      await service.setStatementTimeout(manager, 0);
+
+      expect(manager.query).toHaveBeenCalledWith('SET statement_timeout = $1', ['0']);
+    });
+
+    it('rejects negative timeout', async () => {
+      const manager = { query: jest.fn() } as unknown as EntityManager;
+
+      await expect(service.setStatementTimeout(manager, -1)).rejects.toThrow(
+        'Invalid timeout value',
+      );
+    });
+
+    it('rejects non-integer timeout', async () => {
+      const manager = { query: jest.fn() } as unknown as EntityManager;
+
+      await expect(service.setStatementTimeout(manager, 2.5)).rejects.toThrow(
+        'Invalid timeout value',
+      );
+    });
+  });
+});


### PR DESCRIPTION
Closes #1270


### Summary

Adds focused unit tests for three services that previously had no test coverage, verifying their public APIs with both happy-path and edge-case scenarios.
Closes #1271
### What changed

| File | Tests | Covers |
|---|---|---|
| `src/caching/cache-analytics.service.spec.ts` | 43 | `recordHit`, `recordMiss`, `recordSet`, `getRecommendedTTL`, `generateAnalyticsReport`, `applyAdaptiveTTLAdjustments`, `cleanupOldMetrics`, event handlers, TTL recommendations, cost scoring |
| `src/caching/cache-optimization.service.spec.ts` | 25 | `get`, `set`, `del`, `optimizeCache`, config get/update, default TTL selection per prefix, adaptive TTL, error handling |
| `src/common/database/transaction-helper.service.spec.ts` | 32 | `executeInTransaction`, `executeWithRollback`, savepoint CRUD, `isInTransaction`, `getIsolationLevel`, timeout setters, input validation |

**Total: 100 tests across 3 files, all passing.**
Closes #1273
### Edge cases tested

- Corrupt/unparseable Redis metrics data
- Redis connection failures (graceful fallback)
- Transaction rollback on operation failure (including commit failure)
- Savepoint name validation
- Conditional operation skipping in `executeWithRollback`
- Rollback function failure handling
- Disabled feature flags (adaptive TTL, hit rate optimization, memory optimization)
- Cache-manager error handling across `get`/`set`/`del`

### Validation
Closes #1274
```
npx jest src/caching/cache-analytics.service.spec.ts --forceExit          # 43/43 passed
npx jest src/caching/cache-optimization.service.spec.ts --forceExit       # 25/25 passed
npx jest src/common/database/transaction-helper.service.spec.ts --forceExit  # 32/32 passed
```