### PR TITLE
feat(email-marketing): add indexes to segment_rules table

### DIFF
--- a/src/email-marketing/entities/segment-rule.entity.ts
+++ b/src/email-marketing/entities/segment-rule.entity.ts
@@ -6,6 +6,7 @@ import {
   JoinColumn,
   DeleteDateColumn,
   VersionColumn,
+  Index,
 } from 'typeorm';
 import { ApiProperty } from '@nestjs/swagger';
 import { Segment } from './segment.entity';
@@ -14,7 +15,21 @@ import { SegmentRuleField } from '../enums/segment-rule-field.enum';
 
 /**
  * Represents the segment Rule entity.
+ *
+ * Index strategy:
+ *  - IDX_segment_rules_segmentId          — covers the FK lookup and all
+ *    "load rules for a segment" queries.
+ *  - IDX_segment_rules_segmentId_order    — composite index that satisfies
+ *    the common "load rules for segment ordered by position" path without a
+ *    separate sort step.
+ *  - IDX_segment_rules_deletedAt          — partial index (WHERE deletedAt IS NULL)
+ *    so soft-delete filtering stays efficient as the table grows.
  */
+@Index('IDX_segment_rules_segmentId', ['segmentId'])
+@Index('IDX_segment_rules_segmentId_order', ['segmentId', 'order'])
+@Index('IDX_segment_rules_deletedAt', ['deletedAt'], {
+  where: '"deletedAt" IS NULL',
+})
 @Entity('segment_rules')
 export class SegmentRule {
   @ApiProperty()

--- a/src/migrations/1803000000000-add-segment-rule-indexes.ts
+++ b/src/migrations/1803000000000-add-segment-rule-indexes.ts
@@ -1,0 +1,43 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Adds indexes to the `segment_rules` table to cover the common query paths:
+ *
+ *  - "load all rules for a segment"
+ *      → WHERE "segmentId" = $1
+ *  - "load rules for a segment ordered by position"
+ *      → WHERE "segmentId" = $1 ORDER BY "order"
+ *  - soft-delete filtering
+ *      → WHERE "deletedAt" IS NULL  (combined with any other predicate)
+ *
+ * The enum columns `field` and `operator` are low-cardinality and are always
+ * fetched as part of a segmentId lookup, so standalone indexes on them would
+ * be redundant and add unnecessary write overhead.
+ */
+export class AddSegmentRuleIndexes1803000000000 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // Single-column FK index — satisfies all plain "rules for segment" lookups
+    // and supports the ON DELETE CASCADE on segmentId.
+    await queryRunner.query(
+      `CREATE INDEX IF NOT EXISTS "IDX_segment_rules_segmentId" ON "segment_rules" ("segmentId")`,
+    );
+
+    // Composite index — satisfies "rules for segment ordered by position" in a
+    // single index scan with no extra sort step.
+    await queryRunner.query(
+      `CREATE INDEX IF NOT EXISTS "IDX_segment_rules_segmentId_order" ON "segment_rules" ("segmentId", "order")`,
+    );
+
+    // Partial index on deletedAt — keeps soft-delete filtering cheap as the
+    // table grows; only rows that have NOT been soft-deleted are indexed.
+    await queryRunner.query(
+      `CREATE INDEX IF NOT EXISTS "IDX_segment_rules_deletedAt" ON "segment_rules" ("deletedAt") WHERE "deletedAt" IS NULL`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX IF EXISTS "IDX_segment_rules_deletedAt"`);
+    await queryRunner.query(`DROP INDEX IF EXISTS "IDX_segment_rules_segmentId_order"`);
+    await queryRunner.query(`DROP INDEX IF EXISTS "IDX_segment_rules_segmentId"`);
+  }
+}

--- a/src/migrations/1803000000000-add-segment-rule-indexes.ts
+++ b/src/migrations/1803000000000-add-segment-rule-indexes.ts
@@ -19,25 +19,25 @@ export class AddSegmentRuleIndexes1803000000000 implements MigrationInterface {
     // Single-column FK index — satisfies all plain "rules for segment" lookups
     // and supports the ON DELETE CASCADE on segmentId.
     await queryRunner.query(
-      `CREATE INDEX IF NOT EXISTS "IDX_segment_rules_segmentId" ON "segment_rules" ("segmentId")`,
+      'CREATE INDEX IF NOT EXISTS "IDX_segment_rules_segmentId" ON "segment_rules" ("segmentId")',
     );
 
     // Composite index — satisfies "rules for segment ordered by position" in a
     // single index scan with no extra sort step.
     await queryRunner.query(
-      `CREATE INDEX IF NOT EXISTS "IDX_segment_rules_segmentId_order" ON "segment_rules" ("segmentId", "order")`,
+      'CREATE INDEX IF NOT EXISTS "IDX_segment_rules_segmentId_order" ON "segment_rules" ("segmentId", "order")',
     );
 
     // Partial index on deletedAt — keeps soft-delete filtering cheap as the
     // table grows; only rows that have NOT been soft-deleted are indexed.
     await queryRunner.query(
-      `CREATE INDEX IF NOT EXISTS "IDX_segment_rules_deletedAt" ON "segment_rules" ("deletedAt") WHERE "deletedAt" IS NULL`,
+      'CREATE INDEX IF NOT EXISTS "IDX_segment_rules_deletedAt" ON "segment_rules" ("deletedAt") WHERE "deletedAt" IS NULL',
     );
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {
-    await queryRunner.query(`DROP INDEX IF EXISTS "IDX_segment_rules_deletedAt"`);
-    await queryRunner.query(`DROP INDEX IF EXISTS "IDX_segment_rules_segmentId_order"`);
-    await queryRunner.query(`DROP INDEX IF EXISTS "IDX_segment_rules_segmentId"`);
+    await queryRunner.query('DROP INDEX IF EXISTS "IDX_segment_rules_deletedAt"');
+    await queryRunner.query('DROP INDEX IF EXISTS "IDX_segment_rules_segmentId_order"');
+    await queryRunner.query('DROP INDEX IF EXISTS "IDX_segment_rules_segmentId"');
   }
 }


### PR DESCRIPTION
Summary
  
  segment_rules had no indexes beyond the primary key, forcing sequential scans on every query as the table grows. This adds targeted indexes covering the
  table's actual query paths and creates a migration to apply them to existing databases.
  
  Changes
  
  src/email-marketing/entities/segment-rule.entity.ts
  
  - Added @Index import from typeorm
  - Added three class-level @Index decorators (see index strategy below)
  
  src/migrations/1803000000000-add-segment-rule-indexes.ts
  
  - New migration using CREATE INDEX IF NOT EXISTS — safe to run on databases that already have partial indexes from a previous deploy
  - down() drops all three indexes via DROP INDEX IF EXISTS
  
  Index strategy
  
  ┌───────────────────────────────────┬──────────────────┬───────────────────────────────────┬────────────────────────────────────────────────────────────────┐
  │ Index                             │ Columns          │ Type                              │ Query path covered                                             │
  ├───────────────────────────────────┼──────────────────┼───────────────────────────────────┼────────────────────────────────────────────────────────────────┤
  │ IDX_segment_rules_segmentId       │ segmentId        │ Single                            │ FK lookup; all "load rules for segment" queries; ON DELETE     │
  │                                   │                  │                                   │ CASCADE resolution                                             │
  ├───────────────────────────────────┼──────────────────┼───────────────────────────────────┼────────────────────────────────────────────────────────────────┤
  │ IDX_segment_rules_segmentId_order │ segmentId, order │ Composite                         │ WHERE segmentId = $1 ORDER BY order — resolved in a single     │
  │                                   │                  │                                   │ index scan, no sort step                                       │
  ├───────────────────────────────────┼──────────────────┼───────────────────────────────────┼────────────────────────────────────────────────────────────────┤
  │ IDX_segment_rules_deletedAt       │ deletedAt        │ Partial (WHERE deletedAt IS NULL) │ Soft-delete filter; only indexes active rows, keeping the      │
  │                                   │                  │                                   │ index small                                                    │
  └───────────────────────────────────┴──────────────────┴───────────────────────────────────┴────────────────────────────────────────────────────────────────┘
  
  field and operator were intentionally left without standalone indexes — they are low-cardinality enum columns always fetched as part of a segmentId lookup, so
  standalone indexes would add write overhead with no meaningful read benefit.
  
  Testing
  
  - TypeScript type-check passes (tsc --noEmit)
  - Migration timestamp 1803000000000 is unique across all existing migrations
  - No pre-existing IDX_segment_rules_* names in any other migration or the baseline schema



closes #1236 