### PR TITLE
feat(email-marketing): add indexes to AutomationWorkflow entity

### DIFF
--- a/src/email-marketing/entities/automation-workflow.entity.ts
+++ b/src/email-marketing/entities/automation-workflow.entity.ts
@@ -7,6 +7,7 @@ import {
   DeleteDateColumn,
   OneToMany,
   VersionColumn,
+  Index,
 } from 'typeorm';
 import { ApiProperty } from '@nestjs/swagger';
 import { AutomationTrigger } from './automation-trigger.entity';
@@ -15,8 +16,16 @@ import { WorkflowStatus } from '../enums/workflow-status.enum';
 
 /**
  * Represents the automation Workflow entity.
+ *
+ * Indexes:
+ *  - IDX_automation_workflows_status           – filters active/inactive workflows
+ *  - IDX_automation_workflows_createdAt        – default descending sort in findAll
+ *  - IDX_automation_workflows_status_createdAt – covers the combined filter+sort path
  */
 @Entity('automation_workflows')
+@Index('IDX_automation_workflows_status', ['status'])
+@Index('IDX_automation_workflows_createdAt', ['createdAt'])
+@Index('IDX_automation_workflows_status_createdAt', ['status', 'createdAt'])
 export class AutomationWorkflow {
   @ApiProperty()
   @PrimaryGeneratedColumn('uuid')

--- a/src/migrations/1804000000000-add-automation-workflow-indexes.ts
+++ b/src/migrations/1804000000000-add-automation-workflow-indexes.ts
@@ -1,0 +1,36 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Add database indexes to the automation_workflows table.
+ *
+ * Indexes added:
+ *  - IDX_automation_workflows_status           – WHERE status = '...' (active-workflow
+ *                                                lookups, activate/deactivate guards)
+ *  - IDX_automation_workflows_createdAt        – ORDER BY createdAt DESC (paginated listing)
+ *  - IDX_automation_workflows_status_createdAt – composite covering the combined
+ *                                                filter-by-status + sort-by-createdAt path
+ */
+export class AddAutomationWorkflowIndexes1804000000000 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE INDEX IF NOT EXISTS "IDX_automation_workflows_status"
+       ON "automation_workflows" ("status")`,
+    );
+
+    await queryRunner.query(
+      `CREATE INDEX IF NOT EXISTS "IDX_automation_workflows_createdAt"
+       ON "automation_workflows" ("createdAt")`,
+    );
+
+    await queryRunner.query(
+      `CREATE INDEX IF NOT EXISTS "IDX_automation_workflows_status_createdAt"
+       ON "automation_workflows" ("status", "createdAt")`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query('DROP INDEX IF EXISTS "IDX_automation_workflows_status_createdAt"');
+    await queryRunner.query('DROP INDEX IF EXISTS "IDX_automation_workflows_createdAt"');
+    await queryRunner.query('DROP INDEX IF EXISTS "IDX_automation_workflows_status"');
+  }
+}


### PR DESCRIPTION
Summary
  
  automation_workflows had no indexes on any column, causing full sequential scans as the table grows. This PR adds indexes covering the three common query paths
  identified in AutomationService and creates a migration so existing databases are updated without schema synchronization.
  
  Changes
  
  src/email-marketing/entities/automation-workflow.entity.ts
  
  - Added @Index('IDX_automation_workflows_status', ['status']) — covers WHERE status = 'ACTIVE' used in the activate/deactivate guards and event-driven trigger
  dispatch
  - Added @Index('IDX_automation_workflows_createdAt', ['createdAt']) — covers ORDER BY createdAt DESC used in every paginated findAll call
  - Added @Index('IDX_automation_workflows_status_createdAt', ['status', 'createdAt']) — composite index covering the combined filter + sort path (e.g. list
  active workflows, newest first)
  
  src/migrations/1804000000000-add-automation-workflow-indexes.ts (new)
  
  - Creates the same three indexes via CREATE INDEX IF NOT EXISTS (idempotent, safe to run on any existing database)
  - down() drops them in reverse order
  
  No redundant indexes
  
  The entity has no FK columns (foreign keys live on automation_triggers and automation_actions). The single-column indexes on status and createdAt still serve
  single-predicate queries; the composite covers the combined case. No existing indexes were duplicated.
  
  Testing
  
  - pnpm typecheck — passes (exit 0)
  - pnpm lint on changed files — 0 errors, 0 warnings
  - Migration timestamp 1804000000000 is unique across all files in src/migrations/


closes #1234 