### PR TITLE
feat(database): add database indexes to schema_version entity and mig…

### DIFF
--- a/src/entities/schema_version.entity.ts
+++ b/src/entities/schema_version.entity.ts
@@ -5,10 +5,15 @@ import {
   CreateDateColumn,
   UpdateDateColumn,
   OneToMany,
+  Index,
 } from 'typeorm';
 import { SchemaChange } from './schema_change.entity';
 
 @Entity('schema_version')
+@Index('IDX_schema_version_schemaName', ['schemaName'])
+@Index('IDX_schema_version_checksum', ['checksum'])
+@Index('IDX_schema_version_createdAt', ['createdAt'])
+@Index('IDX_schema_version_schemaName_createdAt', ['schemaName', 'createdAt'])
 export class SchemaVersion {
   @PrimaryGeneratedColumn('uuid')
   id: string;

--- a/src/migrations/1804000000000-add-schema-version-indexes.ts
+++ b/src/migrations/1804000000000-add-schema-version-indexes.ts
@@ -1,0 +1,34 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Issue #1239 - Add database indexes to the schema_version entity.
+ *
+ * Indexes added:
+ *  - IDX_schema_version_schemaName - lookups and filtering by schema name
+ *  - IDX_schema_version_checksum - lookups and verification by content checksum
+ *  - IDX_schema_version_createdAt - chronological ordering and range queries
+ *  - IDX_schema_version_schemaName_createdAt - composite index for schema version history queries
+ */
+export class AddSchemaVersionIndexes1804000000000 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      'CREATE INDEX IF NOT EXISTS "IDX_schema_version_schemaName" ON "schema_version" ("schemaName")',
+    );
+    await queryRunner.query(
+      'CREATE INDEX IF NOT EXISTS "IDX_schema_version_checksum" ON "schema_version" ("checksum")',
+    );
+    await queryRunner.query(
+      'CREATE INDEX IF NOT EXISTS "IDX_schema_version_createdAt" ON "schema_version" ("createdAt")',
+    );
+    await queryRunner.query(
+      'CREATE INDEX IF NOT EXISTS "IDX_schema_version_schemaName_createdAt" ON "schema_version" ("schemaName", "createdAt")',
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query('DROP INDEX IF EXISTS "IDX_schema_version_schemaName_createdAt"');
+    await queryRunner.query('DROP INDEX IF EXISTS "IDX_schema_version_createdAt"');
+    await queryRunner.query('DROP INDEX IF EXISTS "IDX_schema_version_checksum"');
+    await queryRunner.query('DROP INDEX IF EXISTS "IDX_schema_version_schemaName"');
+  }
+}


### PR DESCRIPTION
## Summary
- Added `@Index` decorators to `src/entities/schema_version.entity.ts` covering `schemaName`, `checksum`, `createdAt`, and composite `("schemaName", "createdAt")`.
- Added migration `src/migrations/1804000000000-add-schema-version-indexes.ts` to create these indexes on existing databases with idempotent `IF NOT EXISTS` clauses and reversible `down()` method.

## Why
The `schema_version` table lacked indexes on its primary lookup, filtering, and sorting columns (`schemaName`, `checksum`, `createdAt`). As the table grows, lookups by schema name and chronological history ordering force sequential scans. Adding targeted B-tree indexes ensures high-performance lookups and prevents schema drift between the TypeORM entity and the database.

## Implementation
- `src/entities/schema_version.entity.ts`:
  - Imported `Index` from `typeorm`.
  - Added `@Index('IDX_schema_version_schemaName', ['schemaName'])`.
  - Added `@Index('IDX_schema_version_checksum', ['checksum'])`.
  - Added `@Index('IDX_schema_version_createdAt', ['createdAt'])`.
  - Added composite `@Index('IDX_schema_version_schemaName_createdAt', ['schemaName', 'createdAt'])`.
- `src/migrations/1804000000000-add-schema-version-indexes.ts`:
  - Implemented `AddSchemaVersionIndexes1804000000000` with `up()` creating all 4 indexes and `down()` dropping them.

## Testing
- Verified syntax, entity decorator definitions, and TypeORM migration interface compliance.
- Verified timestamp ordering and uniqueness adherence with `src/migrations/migration-timestamps.spec.ts`.

## Scope / Risk
- Scope is strictly confined to `schema_version` entity and the new migration file.
- Non-breaking change; uses `IF NOT EXISTS` to safely run across all environments.

## Issue
Closes #1239
