### PR TITLE
Add database indexes for automation trigger lookups and workflow foreign keys

### DIFF
--- a/src/email-marketing/entities/automation-trigger.entity.spec.ts
+++ b/src/email-marketing/entities/automation-trigger.entity.spec.ts
@@ -1,0 +1,15 @@
+import { getMetadataArgsStorage } from 'typeorm';
+import { AutomationTrigger } from './automation-trigger.entity';
+
+describe('AutomationTrigger entity - index metadata', () => {
+  it('declares indexes for the trigger lookup and workflow foreign key paths', () => {
+    const indices = getMetadataArgsStorage().filterIndices(AutomationTrigger);
+    const indexedProperties = indices.flatMap((index) =>
+      Array.isArray(index.columns)
+        ? (index.columns as any[]).map((column) => column.propertyName ?? column)
+        : [],
+    );
+
+    expect(indexedProperties).toEqual(expect.arrayContaining(['workflowId', 'type']));
+  });
+});

--- a/src/email-marketing/entities/automation-trigger.entity.ts
+++ b/src/email-marketing/entities/automation-trigger.entity.ts
@@ -6,6 +6,7 @@ import {
   JoinColumn,
   DeleteDateColumn,
   VersionColumn,
+  Index,
 } from 'typeorm';
 import { ApiProperty } from '@nestjs/swagger';
 import { AutomationWorkflow } from './automation-workflow.entity';
@@ -15,6 +16,8 @@ import { TriggerType } from '../enums/trigger-type.enum';
  * Represents the automation Trigger entity.
  */
 @Entity('automation_triggers')
+@Index('IDX_automation_triggers_workflowId', ['workflowId'])
+@Index('IDX_automation_triggers_type', ['type'])
 export class AutomationTrigger {
   @ApiProperty()
   @PrimaryGeneratedColumn('uuid')

--- a/src/migrations/1804000000000-add-automation-trigger-indexes.ts
+++ b/src/migrations/1804000000000-add-automation-trigger-indexes.ts
@@ -1,0 +1,28 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Issue #XXXX — Add database indexes to the automation-trigger entity.
+ *
+ * Query patterns observed in the automation workflow service:
+ *  - `find({ where: { type: triggerType }})` for active trigger matching
+ *  - `softDelete({ workflowId: id })` and joins against workflow rows
+ *
+ * Indexes added:
+ *  - IDX_automation_triggers_workflowId — foreign-key lookup for workflow joins
+ *  - IDX_automation_triggers_type       — trigger-type filters during execution
+ */
+export class AddAutomationTriggerIndexes1804000000000 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      'CREATE INDEX IF NOT EXISTS "IDX_automation_triggers_workflowId" ON "automation_triggers" ("workflowId")',
+    );
+    await queryRunner.query(
+      'CREATE INDEX IF NOT EXISTS "IDX_automation_triggers_type" ON "automation_triggers" ("type")',
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query('DROP INDEX IF EXISTS "IDX_automation_triggers_type"');
+    await queryRunner.query('DROP INDEX IF EXISTS "IDX_automation_triggers_workflowId"');
+  }
+}


### PR DESCRIPTION


## Description
Close #1233

### Summary
This PR adds the missing database indexes for the automation trigger entity to improve query performance for the main lookup and join paths used by the email-marketing automation flow.

### What changed
- Added TypeORM `@Index` decorators to the `AutomationTrigger` entity for:
  - `workflowId` — used in workflow association lookups and delete operations
  - `type` — used in trigger execution queries that filter active triggers by event type
- Added a migration to create the same indexes in database-backed environments:
  - `1804000000000-add-automation-trigger-indexes.ts`

### Why
The automation service frequently queries triggers by:
- `type` to find workflows matching an event
- `workflowId` during workflow updates/removals and joins

Without indexes, these lookups can degrade as the table grows and force table scans.

### Files changed
- `automation-trigger.entity.ts`
- `1804000000000-add-automation-trigger-indexes.ts`
- `automation-trigger.entity.spec.ts`

### Verification
- Ran the focused regression test for the entity metadata:
  - `pnpm exec jest `automation-trigger.entity.spec.ts` --runInBand --watch=false`
- Result: passed

### Notes
This is a safe, additive performance fix and does not alter application logic or trigger behavior beyond database indexing.