### PR TITLE
feat: add indexes for schema_change entity

### DIFF
--- a/src/entities/schema_change.entity.ts
+++ b/src/entities/schema_change.entity.ts
@@ -1,4 +1,11 @@
-import { Entity, PrimaryGeneratedColumn, Column, ManyToOne, CreateDateColumn } from 'typeorm';
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  ManyToOne,
+  CreateDateColumn,
+  Index,
+} from 'typeorm';
 import { SchemaVersion } from './schema_version.entity';
 
 export enum ChangeType {
@@ -14,6 +21,9 @@ export enum ChangeType {
 }
 
 @Entity('schema_change')
+@Index('IDX_schema_change_schema_name_created_at', ['schemaName', 'createdAt'])
+@Index('IDX_schema_change_schema_version_created_at', ['schemaVersion', 'createdAt'])
+@Index('IDX_schema_change_change_type', ['changeType'])
 export class SchemaChange {
   @PrimaryGeneratedColumn('uuid')
   id: string;

--- a/src/migrations/1804000000000-add-schema-change-indexes.ts
+++ b/src/migrations/1804000000000-add-schema-change-indexes.ts
@@ -1,0 +1,29 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Issue #1238 — Add database indexes to the schema_change entity.
+ *
+ * Common access patterns for this table are:
+ *  - filtering by schema name and ordering by recent change time
+ *  - joining on the owning schema_version record
+ *  - filtering by changeType
+ */
+export class AddSchemaChangeIndexes1804000000000 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      'CREATE INDEX IF NOT EXISTS "IDX_schema_change_schema_name_created_at" ON "schema_change" ("schemaName", "createdAt")',
+    );
+    await queryRunner.query(
+      'CREATE INDEX IF NOT EXISTS "IDX_schema_change_schema_version_created_at" ON "schema_change" ("schemaVersionId", "createdAt")',
+    );
+    await queryRunner.query(
+      'CREATE INDEX IF NOT EXISTS "IDX_schema_change_change_type" ON "schema_change" ("changeType")',
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query('DROP INDEX IF EXISTS "IDX_schema_change_change_type"');
+    await queryRunner.query('DROP INDEX IF EXISTS "IDX_schema_change_schema_version_created_at"');
+    await queryRunner.query('DROP INDEX IF EXISTS "IDX_schema_change_schema_name_created_at"');
+  }
+}


### PR DESCRIPTION

### Summary
Adds database indexes to the `schema_change` entity to improve query performance, along with the corresponding migration.

### Changes
- Added indexes via decorators on `src/entities/schema_change.entity.ts`
- Added migration `1804000000000-add-schema-change-indexes.ts`

### Verification
- ✅ TypeScript compilation passes (`exit code 0`)
- ✅ Migration timestamp `1804000000000` confirmed unique, no collisions with existing migrations
- ⚠️ Migration test suite fails, but due to a **pre-existing issue unrelated to this change**: two other migrations share duplicate timestamps (`1800000000000` and `1802000000000`). This was verified independently of my changes and should be tracked/fixed separately.

### Notes
The migration test failure predates this PR and isn't caused by the new migration. happy to open a follow-up issue for the duplicate-timestamp cleanup if that's useful.

---
closes #1238 