### PR TITLE
fix(caching): bound and prioritise cache warming repository reads

### DIFF
--- a/src/caching/cache-warming.scheduler.spec.ts
+++ b/src/caching/cache-warming.scheduler.spec.ts
@@ -38,8 +38,17 @@ describe('CacheWarmingScheduler', () => {
     );
   });
 
-  it('runs full warm-up on module init', async () => {
-    await scheduler.onModuleInit();
+  it('defers full warm-up to after bootstrap without blocking readiness', async () => {
+    scheduler.onApplicationBootstrap();
+
+    // Warming is dispatched via setImmediate, so it must not run synchronously
+    // during bootstrap.
+    expect(warming.warmAll).not.toHaveBeenCalled();
+
+    await new Promise((resolve) => setImmediate(resolve));
+    // Allow the swallowed promise chain inside runWarmUp to settle.
+    await Promise.resolve();
+
     expect(warming.warmAll).toHaveBeenCalledTimes(1);
   });
 

--- a/src/caching/cache-warming.scheduler.ts
+++ b/src/caching/cache-warming.scheduler.ts
@@ -1,4 +1,4 @@
-import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
+import { Injectable, Logger, OnApplicationBootstrap } from '@nestjs/common';
 import { Cron } from '@nestjs/schedule';
 import { CacheWarmingService } from './cache-warming.service';
 import { CachingService } from './caching.service';
@@ -7,7 +7,7 @@ import { CachingService } from './caching.service';
  * Schedules background cache warming for high-traffic query patterns.
  */
 @Injectable()
-export class CacheWarmingScheduler implements OnModuleInit {
+export class CacheWarmingScheduler implements OnApplicationBootstrap {
   private readonly logger = new Logger(CacheWarmingScheduler.name);
 
   constructor(
@@ -15,9 +15,16 @@ export class CacheWarmingScheduler implements OnModuleInit {
     private readonly caching: CachingService,
   ) {}
 
-  async onModuleInit(): Promise<void> {
-    this.logger.log('Running initial cache warm-up on startup');
-    await this.runWarmUp('startup');
+  /**
+   * Startup warming is deferred to `onApplicationBootstrap` and dispatched on the
+   * next tick without being awaited, so it runs once the app is up and accepting
+   * traffic rather than blocking bootstrap/readiness. Failures are swallowed by
+   * `runWarmUp`, so a cold cache never prevents the server from starting.
+   */
+  onApplicationBootstrap(): void {
+    setImmediate(() => {
+      void this.runWarmUp('startup');
+    });
   }
 
   /** Search results — TTL 2 min */

--- a/src/caching/cache-warming.service.spec.ts
+++ b/src/caching/cache-warming.service.spec.ts
@@ -1,14 +1,16 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { Course, CourseStatus } from '../courses/entities/course.entity';
 import { Enrollment } from '../courses/entities/enrollment.entity';
 import { User } from '../users/entities/user.entity';
 import { ProfileCompletenessService } from '../profile-completeness/profile-completeness.service';
 import { SearchService } from '../search/search.service';
+import { MetricsCollectionService } from '../monitoring/metrics/metrics-collection.service';
 import { IsolationService } from '../tenancy/isolation/isolation.service';
 import { CachingService } from './caching.service';
 import { CacheWarmingService } from './cache-warming.service';
-import { CACHE_TTL } from './caching.constants';
+import { CACHE_TTL, CACHE_WARMING } from './caching.constants';
 import {
   buildCourseListKey,
   buildPopularCoursesKey,
@@ -19,18 +21,34 @@ import {
 describe('CacheWarmingService', () => {
   let service: CacheWarmingService;
   let caching: jest.Mocked<Pick<CachingService, 'set'>>;
-  let courseRepo: { find: jest.Mock };
+  let courseRepo: { find: jest.Mock; createQueryBuilder: jest.Mock };
   let enrollmentRepo: { createQueryBuilder: jest.Mock };
   let userRepo: { find: jest.Mock };
   let searchService: { search: jest.Mock };
   let profileCompleteness: { getScore: jest.Mock };
+  let metrics: { recordCacheWarming: jest.Mock };
+  let configStore: Record<string, unknown>;
+
+  const makeCourseQb = (courses: unknown[]) => {
+    const qb = {
+      leftJoin: jest.fn().mockReturnThis(),
+      where: jest.fn().mockReturnThis(),
+      groupBy: jest.fn().mockReturnThis(),
+      orderBy: jest.fn().mockReturnThis(),
+      addOrderBy: jest.fn().mockReturnThis(),
+      limit: jest.fn().mockReturnThis(),
+      getMany: jest.fn().mockResolvedValue(courses),
+    };
+    return qb;
+  };
 
   beforeEach(async () => {
+    configStore = {};
     caching = {
       set: jest.fn().mockResolvedValue(undefined),
       getCurrentTenantId: jest.fn().mockReturnValue('tenant-a'),
     } as any;
-    courseRepo = { find: jest.fn() };
+    courseRepo = { find: jest.fn(), createQueryBuilder: jest.fn() };
     enrollmentRepo = { createQueryBuilder: jest.fn() };
     userRepo = { find: jest.fn() };
     searchService = {
@@ -39,6 +57,7 @@ describe('CacheWarmingService', () => {
     profileCompleteness = {
       getScore: jest.fn().mockResolvedValue({ score: 80, percentage: 80 }),
     };
+    metrics = { recordCacheWarming: jest.fn() };
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -53,6 +72,15 @@ describe('CacheWarmingService', () => {
           provide: IsolationService,
           useValue: { getTenantId: jest.fn().mockReturnValue('tenant-a') },
         },
+        {
+          provide: ConfigService,
+          useValue: {
+            get: jest.fn((key: string, fallback?: unknown) =>
+              key in configStore ? configStore[key] : fallback,
+            ),
+          },
+        },
+        { provide: MetricsCollectionService, useValue: metrics },
         { provide: getRepositoryToken(Course), useValue: courseRepo },
         { provide: getRepositoryToken(Enrollment), useValue: enrollmentRepo },
         { provide: getRepositoryToken(User), useValue: userRepo },
@@ -62,18 +90,33 @@ describe('CacheWarmingService', () => {
     service = module.get(CacheWarmingService);
   });
 
-  it('warms published course listings', async () => {
+  it('warms published course listings ranked by enrollment count', async () => {
     const courses = [{ id: 'c1', status: CourseStatus.PUBLISHED }];
-    courseRepo.find.mockResolvedValue(courses);
+    const qb = makeCourseQb(courses);
+    courseRepo.createQueryBuilder.mockReturnValue(qb);
 
     const result = await service.warmCoursesList();
 
     expect(result.target).toBe('COURSES_LIST');
+    expect(qb.orderBy).toHaveBeenCalledWith('COUNT(enrollment.id)', 'DESC');
+    // Bounded by the default max-entries cap.
+    expect(qb.limit).toHaveBeenCalledWith(CACHE_WARMING.MAX_ENTRIES_DEFAULT);
     expect(caching.set).toHaveBeenCalledWith(
       buildCourseListKey('tenant-a', 'published'),
       courses,
       CACHE_TTL.COURSE_METADATA,
     );
+    expect(metrics.recordCacheWarming).toHaveBeenCalledWith('COURSES_LIST', 1, expect.any(Number));
+  });
+
+  it('honours CACHE_WARM_MAX_ENTRIES when bounding the course listing read', async () => {
+    configStore.CACHE_WARM_MAX_ENTRIES = 5;
+    const qb = makeCourseQb([]);
+    courseRepo.createQueryBuilder.mockReturnValue(qb);
+
+    await service.warmCoursesList();
+
+    expect(qb.limit).toHaveBeenCalledWith(5);
   });
 
   it('warms popular courses using enrollment counts', async () => {
@@ -92,6 +135,11 @@ describe('CacheWarmingService', () => {
     const result = await service.warmPopularCourses();
 
     expect(result.target).toBe('POPULAR_COURSES');
+    // Popular list keeps its tighter product limit even under a larger global cap.
+    expect(qb.limit).toHaveBeenCalledWith(CACHE_WARMING.POPULAR_COURSES_LIMIT);
+    expect(courseRepo.find).toHaveBeenCalledWith(
+      expect.objectContaining({ take: CACHE_WARMING.POPULAR_COURSES_LIMIT }),
+    );
     expect(caching.set).toHaveBeenCalledWith(
       buildPopularCoursesKey('tenant-a'),
       [{ id: 'c1' }],
@@ -112,17 +160,41 @@ describe('CacheWarmingService', () => {
     );
   });
 
-  it('warms user profile scores for recently active users', async () => {
+  it('warms user profile scores for recently active users, bounded and in batches', async () => {
     userRepo.find.mockResolvedValue([{ id: 'u1' }]);
 
     const result = await service.warmUserProfiles();
 
     expect(result.target).toBe('USER_PROFILE');
+    expect(userRepo.find).toHaveBeenCalledWith(
+      expect.objectContaining({
+        order: { lastLoginAt: 'DESC' },
+        take: CACHE_WARMING.USER_PROFILE_WARM_LIMIT,
+      }),
+    );
     expect(profileCompleteness.getScore).toHaveBeenCalledWith('u1');
     expect(caching.set).toHaveBeenCalledWith(
       buildUserProfileKey('tenant-a', 'u1'),
       expect.objectContaining({ score: 80 }),
       CACHE_TTL.USER_PROFILE,
     );
+    expect(metrics.recordCacheWarming).toHaveBeenCalledWith('USER_PROFILE', 1, expect.any(Number));
+  });
+
+  it('processes user profiles in bounded batches with a delay between them', async () => {
+    configStore.CACHE_WARM_BATCH_SIZE = 2;
+    configStore.CACHE_WARM_BATCH_DELAY_MS = 5;
+    const users = Array.from({ length: 5 }, (_, i) => ({ id: `u${i}` }));
+    userRepo.find.mockResolvedValue(users);
+    const sleepSpy = jest
+      .spyOn(service as unknown as { sleep: (ms: number) => Promise<void> }, 'sleep')
+      .mockResolvedValue(undefined);
+
+    await service.warmUserProfiles();
+
+    expect(profileCompleteness.getScore).toHaveBeenCalledTimes(5);
+    // 5 items / batch size 2 => 3 batches => 2 inter-batch delays.
+    expect(sleepSpy).toHaveBeenCalledTimes(2);
+    expect(sleepSpy).toHaveBeenCalledWith(5);
   });
 });

--- a/src/caching/cache-warming.service.ts
+++ b/src/caching/cache-warming.service.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable, Logger, Optional } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 import { InjectRepository } from '@nestjs/typeorm';
 import { In, IsNull, Not, Repository } from 'typeorm';
 import { Course, CourseStatus } from '../courses/entities/course.entity';
@@ -6,8 +7,15 @@ import { Enrollment } from '../courses/entities/enrollment.entity';
 import { User } from '../users/entities/user.entity';
 import { ProfileCompletenessService } from '../profile-completeness/profile-completeness.service';
 import { SearchService } from '../search/search.service';
+import { MetricsCollectionService } from '../monitoring/metrics/metrics-collection.service';
 import { CachingService } from './caching.service';
-import { CACHE_TTL, CACHE_WARMING } from './caching.constants';
+import {
+  CACHE_TTL,
+  CACHE_WARMING,
+  CACHE_WARM_BATCH_DELAY_MS_ENV,
+  CACHE_WARM_BATCH_SIZE_ENV,
+  CACHE_WARM_MAX_ENTRIES_ENV,
+} from './caching.constants';
 import { IsolationService } from '../tenancy/isolation/isolation.service';
 import {
   buildCourseListKey,
@@ -24,6 +32,13 @@ export interface WarmResult {
 
 /**
  * Preloads high-traffic cache entries before they are requested.
+ *
+ * All repository reads are bounded by `CACHE_WARM_MAX_ENTRIES` (env/ConfigService,
+ * default {@link CACHE_WARMING.MAX_ENTRIES_DEFAULT}) so warming never loads whole
+ * courses/users tables into memory. The warmed set is prioritised by a real
+ * signal — courses by enrollment count, users by recent activity — and processed
+ * in batches with a short delay between them to bound DB/memory pressure. Every
+ * pass exports its entry count and duration as Prometheus metrics.
  */
 @Injectable()
 export class CacheWarmingService {
@@ -40,6 +55,8 @@ export class CacheWarmingService {
     private readonly enrollmentRepo: Repository<Enrollment>,
     @InjectRepository(User)
     private readonly userRepo: Repository<User>,
+    @Optional() private readonly configService?: ConfigService,
+    @Optional() private readonly metrics?: MetricsCollectionService,
   ) {}
 
   async warmAll(): Promise<WarmResult[]> {
@@ -58,17 +75,19 @@ export class CacheWarmingService {
       throw new Error('Tenant context is required for tenant-scoped cache warmup');
     }
     const key = buildCourseListKey(tenantId, 'published');
-    const courses = await this.courseRepo.find({
-      where: { status: CourseStatus.PUBLISHED },
-      order: { createdAt: 'DESC' },
-    });
+    // Priority signal: most-enrolled published courses first (createdAt as a
+    // stable tie-breaker), bounded so we never scan the whole courses table.
+    const courses = await this.courseRepo
+      .createQueryBuilder('course')
+      .leftJoin('course.enrollments', 'enrollment')
+      .where('course.status = :status', { status: CourseStatus.PUBLISHED })
+      .groupBy('course.id')
+      .orderBy('COUNT(enrollment.id)', 'DESC')
+      .addOrderBy('course.createdAt', 'DESC')
+      .limit(this.resolveMaxEntries())
+      .getMany();
     await this.caching.set(key, courses, CACHE_TTL.COURSE_METADATA);
-    this.logger.log(`Warmed courses list (${courses.length} courses)`);
-    return {
-      target: 'COURSES_LIST',
-      keysWarmed: 1,
-      durationMs: Date.now() - started,
-    };
+    return this.report('COURSES_LIST', 1, started, `${courses.length} courses`);
   }
 
   async warmPopularCourses(): Promise<WarmResult> {
@@ -77,6 +96,7 @@ export class CacheWarmingService {
     if (!tenantId) {
       throw new Error('Tenant context is required for tenant-scoped cache warmup');
     }
+    const maxEntries = this.resolveMaxEntries(CACHE_WARMING.POPULAR_COURSES_LIMIT);
     const key = buildPopularCoursesKey(tenantId);
     const popular = await this.enrollmentRepo
       .createQueryBuilder('enrollment')
@@ -87,7 +107,7 @@ export class CacheWarmingService {
       })
       .groupBy('enrollment.courseId')
       .orderBy('COUNT(enrollment.id)', 'DESC')
-      .limit(CACHE_WARMING.POPULAR_COURSES_LIMIT)
+      .limit(maxEntries)
       .getRawMany<{ courseId: string; enrollmentCount: string }>();
 
     let courses: Course[];
@@ -95,22 +115,20 @@ export class CacheWarmingService {
       courses = await this.courseRepo.find({
         where: { status: CourseStatus.PUBLISHED },
         order: { createdAt: 'DESC' },
-        take: CACHE_WARMING.POPULAR_COURSES_LIMIT,
+        take: maxEntries,
       });
     } else {
       const courseIds = popular.map((row) => row.courseId);
-      const fetched = await this.courseRepo.find({ where: { id: In(courseIds) } });
+      const fetched = await this.courseRepo.find({
+        where: { id: In(courseIds) },
+        take: maxEntries,
+      });
       const rank = new Map(courseIds.map((id, index) => [id, index]));
       courses = fetched.sort((a, b) => (rank.get(a.id) ?? 0) - (rank.get(b.id) ?? 0));
     }
 
     await this.caching.set(key, courses, CACHE_TTL.POPULAR_COURSES);
-    this.logger.log(`Warmed popular courses (${courses.length} courses)`);
-    return {
-      target: 'POPULAR_COURSES',
-      keysWarmed: 1,
-      durationMs: Date.now() - started,
-    };
+    return this.report('POPULAR_COURSES', 1, started, `${courses.length} courses`);
   }
 
   async warmSearchResults(): Promise<WarmResult> {
@@ -134,26 +152,23 @@ export class CacheWarmingService {
     await this.caching.set(filtersKey, filteredResult, CACHE_TTL.SEARCH_RESULTS);
     keysWarmed += 1;
 
-    this.logger.log(`Warmed search results (${keysWarmed} keys)`);
-    return {
-      target: 'SEARCH_RESULTS',
-      keysWarmed,
-      durationMs: Date.now() - started,
-    };
+    return this.report('SEARCH_RESULTS', keysWarmed, started, `${keysWarmed} keys`);
   }
 
   async warmUserProfiles(): Promise<WarmResult> {
     const started = Date.now();
+    const maxEntries = this.resolveMaxEntries(CACHE_WARMING.USER_PROFILE_WARM_LIMIT);
+    // Priority signal: most-recently active users first.
     let users = await this.userRepo.find({
       where: { lastLoginAt: Not(IsNull()) },
       order: { lastLoginAt: 'DESC' },
-      take: CACHE_WARMING.USER_PROFILE_WARM_LIMIT,
+      take: maxEntries,
     });
 
     if (users.length === 0) {
       users = await this.userRepo.find({
         order: { updatedAt: 'DESC' },
-        take: CACHE_WARMING.USER_PROFILE_WARM_LIMIT,
+        take: maxEntries,
       });
     }
 
@@ -162,19 +177,78 @@ export class CacheWarmingService {
       throw new Error('Tenant context is required for tenant-scoped cache warmup');
     }
 
-    await Promise.all(
-      users.map(async (user) => {
-        const profile = await this.profileCompleteness.getScore(user.id);
-        const key = buildUserProfileKey(tenantId, user.id);
-        await this.caching.set(key, profile, CACHE_TTL.USER_PROFILE);
-      }),
-    );
+    // Batch the per-user score computation so we don't fan out one query per
+    // user simultaneously; a short delay between batches bounds DB/memory load.
+    await this.processInBatches(users, async (user) => {
+      const profile = await this.profileCompleteness.getScore(user.id);
+      const key = buildUserProfileKey(tenantId, user.id);
+      await this.caching.set(key, profile, CACHE_TTL.USER_PROFILE);
+    });
 
-    this.logger.log(`Warmed user profiles (${users.length} users)`);
-    return {
-      target: 'USER_PROFILE',
-      keysWarmed: users.length,
-      durationMs: Date.now() - started,
-    };
+    return this.report('USER_PROFILE', users.length, started, `${users.length} users`);
+  }
+
+  /**
+   * Resolves the per-query warming cap from config/env, clamped to a positive
+   * integer. A caller-supplied `fallback` (e.g. a target-specific limit) is used
+   * when it is smaller than the global cap so existing tighter limits are kept.
+   */
+  private resolveMaxEntries(fallback?: number): number {
+    const configured = this.readPositiveInt(
+      CACHE_WARM_MAX_ENTRIES_ENV,
+      CACHE_WARMING.MAX_ENTRIES_DEFAULT,
+    );
+    if (fallback !== undefined && fallback > 0) {
+      return Math.min(configured, fallback);
+    }
+    return configured;
+  }
+
+  private resolveBatchSize(): number {
+    return this.readPositiveInt(CACHE_WARM_BATCH_SIZE_ENV, CACHE_WARMING.BATCH_SIZE_DEFAULT);
+  }
+
+  private resolveBatchDelayMs(): number {
+    const value = this.configService?.get<number | string>(CACHE_WARM_BATCH_DELAY_MS_ENV);
+    const parsed = typeof value === 'string' ? parseInt(value, 10) : value;
+    if (typeof parsed === 'number' && Number.isFinite(parsed) && parsed >= 0) {
+      return parsed;
+    }
+    return CACHE_WARMING.BATCH_DELAY_MS_DEFAULT;
+  }
+
+  private readPositiveInt(envKey: string, fallback: number): number {
+    const value = this.configService?.get<number | string>(envKey);
+    const parsed = typeof value === 'string' ? parseInt(value, 10) : value;
+    if (typeof parsed === 'number' && Number.isFinite(parsed) && parsed > 0) {
+      return Math.floor(parsed);
+    }
+    return fallback;
+  }
+
+  private async processInBatches<T>(
+    items: T[],
+    handler: (item: T) => Promise<void>,
+  ): Promise<void> {
+    const batchSize = this.resolveBatchSize();
+    const delayMs = this.resolveBatchDelayMs();
+    for (let start = 0; start < items.length; start += batchSize) {
+      const batch = items.slice(start, start + batchSize);
+      await Promise.all(batch.map(handler));
+      if (delayMs > 0 && start + batchSize < items.length) {
+        await this.sleep(delayMs);
+      }
+    }
+  }
+
+  private sleep(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+  }
+
+  private report(target: string, keysWarmed: number, started: number, detail: string): WarmResult {
+    const durationMs = Date.now() - started;
+    this.metrics?.recordCacheWarming(target, keysWarmed, durationMs / 1000);
+    this.logger.log(`Warmed ${target.toLowerCase()} (${detail}) in ${durationMs}ms`);
+    return { target, keysWarmed, durationMs };
   }
 }

--- a/src/caching/caching.constants.ts
+++ b/src/caching/caching.constants.ts
@@ -62,7 +62,23 @@ export const CACHE_WARMING = {
   POPULAR_COURSES_LIMIT: 20,
   USER_PROFILE_WARM_LIMIT: 50,
   SEARCH_WARM_QUERIES: ['', 'programming', 'math', 'science'],
+  /**
+   * Upper bound on how many rows any single warming query may load. Overridable
+   * via the `CACHE_WARM_MAX_ENTRIES` env var (read through ConfigService). This
+   * keeps startup/scheduled warming from loading full courses/users tables into
+   * memory; the warmed set is prioritised by a real signal (see service).
+   */
+  MAX_ENTRIES_DEFAULT: 100,
+  /** How many entries are processed per batch before yielding to the event loop. */
+  BATCH_SIZE_DEFAULT: 25,
+  /** Delay (ms) inserted between batches to bound DB/memory pressure. */
+  BATCH_DELAY_MS_DEFAULT: 50,
 } as const;
+
+/** ConfigService/env key controlling the per-query warming cap. */
+export const CACHE_WARM_MAX_ENTRIES_ENV = 'CACHE_WARM_MAX_ENTRIES';
+export const CACHE_WARM_BATCH_SIZE_ENV = 'CACHE_WARM_BATCH_SIZE';
+export const CACHE_WARM_BATCH_DELAY_MS_ENV = 'CACHE_WARM_BATCH_DELAY_MS';
 
 export const CACHE_EVENTS = {
   COURSE_CREATED: 'cache.course.created',

--- a/src/monitoring/metrics/metrics-collection.service.ts
+++ b/src/monitoring/metrics/metrics-collection.service.ts
@@ -86,6 +86,15 @@ export class MetricsCollectionService implements OnModuleInit {
   /** Cache hit rate percentage, labelled by cache_type */
   public cacheHitRate: Gauge;
 
+  /** Duration of a cache warming pass in seconds, labelled by warm target */
+  public cacheWarmDuration: Histogram;
+
+  /** Total cache entries warmed, labelled by warm target */
+  public cacheWarmEntries: Counter;
+
+  /** Number of entries warmed on the most recent pass, labelled by warm target */
+  public cacheWarmLastEntries: Gauge;
+
   // ── Business Metrics – Queues ──────────────────────────────────────────────
 
   /** Queue job processing duration, labelled by queue_name and job_type */
@@ -222,6 +231,19 @@ export class MetricsCollectionService implements OnModuleInit {
 
   updateCacheHitRate(cacheType: string, hitRate: number): void {
     this.cacheHitRate.set({ cache_type: cacheType }, hitRate);
+  }
+
+  /**
+   * Records the outcome of a cache warming pass.
+   *
+   * @param target           Warm target (e.g. COURSES_LIST, USER_PROFILE)
+   * @param entries          Number of entries warmed on this pass
+   * @param durationSeconds  Wall-clock duration of the pass in **seconds**
+   */
+  recordCacheWarming(target: string, entries: number, durationSeconds: number): void {
+    this.cacheWarmDuration.observe({ target }, durationSeconds);
+    this.cacheWarmEntries.inc({ target }, entries);
+    this.cacheWarmLastEntries.set({ target }, entries);
   }
 
   // ── Recording helpers – Queues ────────────────────────────────────────────
@@ -431,6 +453,28 @@ export class MetricsCollectionService implements OnModuleInit {
       name: 'cache_hit_rate_percentage',
       help: 'Cache hit rate percentage',
       labelNames: ['cache_type'],
+      registers: [this.registry],
+    });
+
+    this.cacheWarmDuration = new Histogram({
+      name: 'cache_warm_duration_seconds',
+      help: 'Duration of cache warming passes in seconds',
+      labelNames: ['target'],
+      buckets: [0.01, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30],
+      registers: [this.registry],
+    });
+
+    this.cacheWarmEntries = new Counter({
+      name: 'cache_warm_entries_total',
+      help: 'Total number of cache entries warmed',
+      labelNames: ['target'],
+      registers: [this.registry],
+    });
+
+    this.cacheWarmLastEntries = new Gauge({
+      name: 'cache_warm_last_entries',
+      help: 'Number of cache entries warmed on the most recent pass',
+      labelNames: ['target'],
       registers: [this.registry],
     });
 


### PR DESCRIPTION
Bounds all cache-warming repository reads and prevents startup warming from delaying readiness.

- Cap every warming query with an explicit `take` sized from a configurable `CACHE_WARM_MAX_ENTRIES` (ConfigService/env, default 100); replaces the unbounded published-courses find that loaded the whole table into memory.
- Select the warmed set by a real priority signal: published courses ranked by enrollment count (`createdAt` tie-breaker), users by most-recent activity (`lastLoginAt DESC`).
- Process the working set in bounded batches (`CACHE_WARM_BATCH_SIZE`, default 25) with a short delay between batches (`CACHE_WARM_BATCH_DELAY_MS`, default 50ms) to bound DB/memory pressure.
- Export warming metrics: `cache_warm_entries_total`, `cache_warm_last_entries`, and `cache_warm_duration_seconds`.
- Defer startup warming from a blocking `OnModuleInit` to `OnApplicationBootstrap` dispatched via `setImmediate` (not awaited), so warming runs after the server is accepting traffic and never delays readiness.

## Testing
- `npx tsc --noEmit` — clean
- `npm run lint` — clean
- `npx jest src/caching/cache-warming` — 2 suites, 10 tests pass (bounding cap, enrollment ordering, batching/delay, metrics, deferred non-blocking bootstrap). Pre-existing unrelated caching spec failures are unchanged.

Closes #1053
