### PR TITLE
fix(achievements): correct batch notification date filter and bound processing

### DIFF
--- a/src/achievements/achievements-notifications.service.spec.ts
+++ b/src/achievements/achievements-notifications.service.spec.ts
@@ -1,5 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
+import { MoreThanOrEqual } from 'typeorm';
 import { AchievementsNotificationsService } from './achievements-notifications.service';
 import { UserAchievement } from './entities/user-achievement.entity';
 import { Achievement } from './entities/achievement.entity';
@@ -81,6 +82,41 @@ describe('AchievementsNotificationsService', () => {
       const count = await service.sendBatchNotifications();
 
       expect(count).toBe(2);
+    });
+
+    it('selects achievements unlocked since midnight today with notificationSent=false', async () => {
+      const achievement = makeUserAchievement();
+      mockRepo.find.mockResolvedValue([achievement]);
+      mockRepo.update.mockResolvedValue({ affected: 1 });
+
+      const today = new Date();
+      today.setHours(0, 0, 0, 0);
+
+      const count = await service.sendBatchNotifications();
+
+      expect(count).toBe(1);
+      expect(mockRepo.find).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: {
+            unlockedAt: MoreThanOrEqual(today),
+            notificationSent: false,
+          },
+        }),
+      );
+    });
+
+    it('processes a large backlog in bounded chunks', async () => {
+      const batchA = Array.from({ length: 100 }, () => makeUserAchievement());
+      const batchB = Array.from({ length: 3 }, () => makeUserAchievement());
+      // First call returns a full batch, second returns a short batch (loop ends).
+      mockRepo.find.mockResolvedValueOnce(batchA).mockResolvedValueOnce(batchB);
+      mockRepo.update.mockResolvedValue({ affected: 1 });
+
+      const count = await service.sendBatchNotifications();
+
+      expect(count).toBe(103);
+      expect(mockRepo.find).toHaveBeenCalledWith(expect.objectContaining({ take: 100 }));
+      expect(mockRepo.update).toHaveBeenCalledTimes(103);
     });
 
     it('returns 0 when find throws', async () => {

--- a/src/achievements/achievements-notifications.service.ts
+++ b/src/achievements/achievements-notifications.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { MoreThanOrEqual, Repository } from 'typeorm';
 import { UserAchievement } from './entities/user-achievement.entity';
 
 /**
@@ -62,25 +62,45 @@ export class AchievementsNotificationsService {
 
   /**
    * Send batch notifications for achievements unlocked today
+   * Processes achievements in bounded chunks so a large backlog is not
+   * loaded or sent in a single tight loop.
    */
   async sendBatchNotifications(): Promise<number> {
+    const BATCH_SIZE = 100;
+
     try {
       const today = new Date();
       today.setHours(0, 0, 0, 0);
 
-      const achievements = await this.userAchievementRepository.find({
-        where: {
-          unlockedAt: new Date(),
-          notificationSent: false,
-        },
-        relations: ['user', 'achievement'],
-      });
-
       let sentCount = 0;
+      let skip = 0;
+      let keepProcessing = true;
 
-      for (const userAchievement of achievements) {
-        await this.sendAchievementUnlockedNotification(userAchievement);
-        sentCount++;
+      while (keepProcessing) {
+        const achievements = await this.userAchievementRepository.find({
+          where: {
+            unlockedAt: MoreThanOrEqual(today),
+            notificationSent: false,
+          },
+          relations: ['user', 'achievement'],
+          take: BATCH_SIZE,
+          skip,
+        });
+
+        if (achievements.length === 0) {
+          keepProcessing = false;
+          continue;
+        }
+
+        for (const userAchievement of achievements) {
+          await this.sendAchievementUnlockedNotification(userAchievement);
+          sentCount++;
+        }
+
+        skip += achievements.length;
+
+        // Stop when a chunk returns fewer than the batch size (no more pending).
+        keepProcessing = achievements.length === BATCH_SIZE;
       }
 
       this.logger.log(`Sent ${sentCount} achievement notifications`);


### PR DESCRIPTION
## Summary

Closes #1391

`AchievementsNotificationsService.sendBatchNotifications()` was silently **never sending** scheduled batch notifications for achievements unlocked today. The query filtered on `unlockedAt: new Date()`, which compares against the exact current instant with millisecond precision and essentially never matches any stored row — the computed midnight boundary (`today.setHours(0, 0, 0, 0)`) was calculated but never used. The query was also unbounded: unlike `resendFailedNotifications()`, it had no `take` limit, so a fixed query would load an unbounded number of rows and send them all in a single tight loop.

## Changes

### `src/achievements/achievements-notifications.service.ts`
- **Fixed the date filter:** replaced `unlockedAt: new Date()` with `unlockedAt: MoreThanOrEqual(today)`, selecting achievements unlocked since midnight today that have not yet been notified (`notificationSent: false`). The intended "unlocked today" window is now actually applied.
- **Bounded the batch:** added `BATCH_SIZE = 100` and process the backlog in bounded chunks using `take`/`skip` pagination, so large backlogs are handled chunk-by-chunk instead of in one unbounded query — consistent with the existing `resendFailedNotifications()` behavior.
- **Loop hygiene:** the pagination loop terminates when a chunk comes back empty or smaller than the batch size, and is lint-compliant (`while (keepProcessing)` rather than a literal constant condition).

### `src/achievements/achievements-notifications.service.spec.ts`
- **Regression test for the corrected date filter:** asserts the query is issued with `unlockedAt: MoreThanOrEqual(today)` and `notificationSent: false`, and that an achievement unlocked earlier today is selected and notified.
- **Bounded batching test:** verifies a 103-record backlog is processed in chunks (100 + 3) and that all 103 records are marked as sent.

## Verification

All relevant checks run locally:

| Check | Result |
| --- | --- |
| `pnpm lint:ci` | ✅ 0 errors (only pre-existing warnings in unrelated files) |
| `pnpm format:check` | ✅ pass |
| `pnpm typecheck` | ✅ pass |
| `pnpm test src/achievements/achievements-notifications.service.spec.ts` | ✅ 10/10 pass |

Note: `src/achievements/achievements.service.spec.ts` has failing tests, but they fail identically on `main` (unmodified baseline) and are unrelated to this change.
