### PR TITLE
feat(moderation): add database indexes to ReviewItem entity

### DIFF
--- a/src/migrations/1807000000000-add-review-item-indexes.ts
+++ b/src/migrations/1807000000000-add-review-item-indexes.ts
@@ -1,0 +1,43 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Add indexes to the `review_item` table for common query paths:
+ *
+ *  - `status` for filtering by pending/reviewed state (getQueue WHERE clause)
+ *  - `safetyScore, createdAt` composite for prioritised queue ordering
+ *  - `sourceType`, `sourceId`, `reportId` for source-lookup joins and filters
+ *
+ * These cover the primary query paths without introducing redundant
+ * single-column indexes that are already covered by the composite index.
+ */
+export class AddReviewItemIndexes1807000000000 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      'CREATE INDEX IF NOT EXISTS "IDX_review_items_status" ON "review_item" ("status")',
+    );
+
+    await queryRunner.query(
+      'CREATE INDEX IF NOT EXISTS "IDX_review_items_safetyScore_createdAt" ON "review_item" ("safetyScore", "createdAt")',
+    );
+
+    await queryRunner.query(
+      'CREATE INDEX IF NOT EXISTS "IDX_review_items_sourceType" ON "review_item" ("sourceType")',
+    );
+
+    await queryRunner.query(
+      'CREATE INDEX IF NOT EXISTS "IDX_review_items_sourceId" ON "review_item" ("sourceId")',
+    );
+
+    await queryRunner.query(
+      'CREATE INDEX IF NOT EXISTS "IDX_review_items_reportId" ON "review_item" ("reportId")',
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query('DROP INDEX IF EXISTS "IDX_review_items_reportId"');
+    await queryRunner.query('DROP INDEX IF EXISTS "IDX_review_items_sourceId"');
+    await queryRunner.query('DROP INDEX IF EXISTS "IDX_review_items_sourceType"');
+    await queryRunner.query('DROP INDEX IF EXISTS "IDX_review_items_safetyScore_createdAt"');
+    await queryRunner.query('DROP INDEX IF EXISTS "IDX_review_items_status"');
+  }
+}

--- a/src/moderation/manual/review-item.entity.ts
+++ b/src/moderation/manual/review-item.entity.ts
@@ -1,4 +1,11 @@
-import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn, VersionColumn, Index } from 'typeorm';
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  VersionColumn,
+  Index,
+} from 'typeorm';
 
 /**
  * Represents the review Item entity.

--- a/src/moderation/manual/review-item.entity.ts
+++ b/src/moderation/manual/review-item.entity.ts
@@ -1,9 +1,14 @@
-import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn, VersionColumn } from 'typeorm';
+import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn, VersionColumn, Index } from 'typeorm';
 
 /**
  * Represents the review Item entity.
  */
 @Entity()
+@Index('IDX_review_items_status', ['status'])
+@Index('IDX_review_items_safetyScore_createdAt', ['safetyScore', 'createdAt'])
+@Index('IDX_review_items_sourceType', ['sourceType'])
+@Index('IDX_review_items_sourceId', ['sourceId'])
+@Index('IDX_review_items_reportId', ['reportId'])
 export class ReviewItem {
   @PrimaryGeneratedColumn()
   id: number;


### PR DESCRIPTION
Closes #1243 
Add @Index decorators and a migration for commonly queried columns on the ReviewItem entity to avoid sequential scans as the table grows.

## Indexes added

1. `IDX_review_items_status` on `status` — covers the `WHERE status = 'pending'` filter used by `ManualReviewService.getQueue()`.

2. `IDX_review_items_safetyScore_createdAt` composite on `(safetyScore, createdAt)` — covers the `ORDER BY safetyScore DESC, createdAt ASC` sort used by `getQueue()` to prioritise high-risk items, then oldest-first.

3. `IDX_review_items_sourceType` on `sourceType` — supports lookups by source type for content-report linkage.

4. `IDX_review_items_sourceId` on `sourceId` — supports joins / filters by source identifier.

5. `IDX_review_items_reportId` on `reportId` — supports joins / filters by report identifier.

## Migration

New migration `1807000000000-add-review-item-indexes.ts` creates the indexes with `CREATE INDEX IF NOT EXISTS` and drops them in reverse order in `down()`. The migration uses only the passed QueryRunner (no separate connections) and passes the `validate-migrations.js` CI check.

Closes #1243

🤖 Generated with Codebuff