### PR TITLE
fix(courses): add currency column to Course entity to match migration

### DIFF
--- a/src/courses/entities/course.entity.ts
+++ b/src/courses/entities/course.entity.ts
@@ -50,6 +50,11 @@ export class Course {
   @Column({ type: 'decimal', precision: 10, scale: 2, default: 0 })
   price: number;
 
+  /** ISO 4217 currency code for the course price (e.g. 'USD', 'EUR'). */
+  @Index('IDX_course_currency')
+  @Column({ type: 'varchar', length: 3, nullable: true, default: 'USD' })
+  currency?: string;
+
   @Column({
     type: 'enum',
     enum: CourseStatus,


### PR DESCRIPTION
Here's a PR description you can use:
  
  ───────────────────────────────────────────────────────────────────────────────────────────────
  
  fix(courses): declare currency column on Course entity (#1194)
  
  Problem
  
  Migration 1685000001001-add-currency-field-to-courses adds a currency varchar(3) DEFAULT 'USD'
   column and IDX_course_currency index to the course table, but the Course entity had no
  corresponding @Column declaration. This caused two issues:
  
  - Multi-currency pricing was unusable via TypeORM — the field existed in the DB but was
  invisible to the ORM
  - The schema drift checker flagged the column as unknown and wanted to drop it (reported in
  #1194)
  
  Fix
  
  Added the missing currency field to src/courses/entities/course.entity.ts:
  
  /** ISO 4217 currency code for the course price (e.g. 'USD', 'EUR'). */
  @Index('IDX_course_currency')
  @Column({ type: 'varchar', length: 3, nullable: true, default: 'USD' })
  currency?: string;
  
  The declaration matches the migration exactly:
  
  - varchar(3) length
  - nullable with DEFAULT 'USD'
  - Explicit @Index('IDX_course_currency') name so TypeORM recognises the existing index rather
  than creating a duplicate or dropping it
  
  No migration needed — the column already exists in the database. This is an entity-only fix to
  bring the ORM in sync with the schema.
  
  Testing
  
  - TypeScript compilation passes
  - Drift checker will no longer flag currency for removal
  - Course objects returned from TypeORM queries will now include the currency field
  
  Closes #1205 
  Closes #1204 